### PR TITLE
haze ryanpr resolution + simulator-as-default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+# RYANPR: use `gitignore macos,windows,linux,vim,visualstudiocode,emacs,cmake,c,c++,python` and merge the results with this. Make sure not to change anything in the fenced gitignore result and then remove duplicate entries.
 # Build directories
 build/
 build-*/
@@ -18,6 +19,10 @@ Makefile
 !CMakeLists.txt
 install_manifest.txt
 _deps/
+
+# Re-include the top-level standalone Makefile (CMake-generated Makefiles
+# in build/ subdirs are still ignored via the build/ rules above).
+!/Makefile
 
 # Ninja
 build.ninja
@@ -92,4 +97,3 @@ Thumbs.db
 
 # HAZE runtime artefacts (compiler recordings written during tests)
 /haze/
-/my-program/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/niobium-compiler"]
-	path = vendor/niobium-compiler
-	url = git@github.com:NiobiumInc/niobium-compiler.git
 [submodule "vendor/niobium-fhetch"]
 	path = vendor/niobium-fhetch
 	url = git@github.com:NiobiumInc/niobium-fhetch.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# haze — Claude Code working notes
+
+## Hermetic toolchain
+
+All build, test, and lint work for haze must run inside the haze flake's
+`devShells.default`:
+
+```sh
+cd /path/to/niobium-haze
+nix develop
+```
+
+The shell provides clang 19, cmake, clang-tools (clang-format, clang-tidy,
+clangd), catch2_3, and jujutsu, with `MACOSX_DEPLOYMENT_TARGET=14.0` and a
+nix-pinned `SDKROOT`. Do not install build/lint tools globally; if the
+shell is missing something, add it to `devShells.default.nativeBuildInputs`
+in `flake.nix`.
+
+To run a one-shot command without entering an interactive shell:
+
+```sh
+nix develop --command bash -c '<command>'
+```
+
+## SDK / ABI mismatch trap on macOS
+
+Symptom: a clean release build links and links cleanly with warnings like
+`object file ... was built for newer macOS version (26.0) than being
+linked (14.0)`, then `make test-unit-release` segfaults non-deterministically
+at code that should be a no-op (e.g. `hazeSetRingDimension(4096)`,
+`hazeMalloc`). Probes shift the crash site or mask it; tests pass in
+isolation that fail in suite, or vice-versa.
+
+Root cause: OpenFHE (or libnbfhetch built against it) was previously
+compiled outside `nix develop` against the host SDK (e.g. macOS 26.0)
+while haze itself is compiled inside the devshell against the pinned SDK
+(macOS 14.0). The two libc++ ABI versions collide in the same process.
+Memory-layout-sensitive heisenbugs follow.
+
+Fix: rebuild OpenFHE and the niobium-fhetch chain inside the devshell so
+every artifact in the link graph has the same `LC_BUILD_VERSION minos`.
+The cheap path:
+
+```sh
+# Wipe haze-side build dirs (preserves the existing OpenFHE install in
+# vendor/niobium-fhetch/vendor/lib/openfhe).
+rm -rf build dbuild
+nix develop --command bash -c 'EXTERNAL_OPENFHE=1 make build-release'
+```
+
+If the warnings persist, also wipe and rebuild OpenFHE itself:
+
+```sh
+rm -rf vendor/niobium-fhetch/vendor/openfhe/build \
+       vendor/niobium-fhetch/vendor/openfhe/dbuild \
+       vendor/niobium-fhetch/vendor/lib/openfhe
+nix develop --command bash -c 'make build-openfhe-release && make build-release'
+```
+
+Verify the fix with `otool -l <dylib> | grep -A3 LC_BUILD_VERSION` —
+`minos` should be `14.0` for libhaze.dylib, libnbfhetch.dylib, and every
+libOPENFHE*.dylib under `vendor/niobium-fhetch/vendor/lib/openfhe/lib`.
+
+Recognize the symptom early: any non-trivial test segfault accompanied
+by `built for newer macOS version` linker warnings is this trap until
+proven otherwise. Do not waste cycles on probe-based bisection before
+checking the SDK/ABI alignment.
+
+## Baselines (post-fix)
+
+- `make test-unit-release` → **53/53 pass**, ~1s.
+- `make test-integration-release NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler`
+  → **18/27 pass**. The 9 failures in `test_basis_convert.cpp` at lines
+  117/245/291/331/381/443/757(x3) are multi-residue (`hazeModUp` /
+  `hazeModDown`) cases blocked on bridge MRP support; pre-existing,
+  out of scope for the haze RYANPR plan. A passing integration run still
+  exits non-zero (Catch2 reports the failures as test failures).
+
+## Out of scope
+
+Nothing under `vendor/` is editable in the RYANPR resolution work — the
+companion `niobium-fhetch` review is a separate PR. Reading public
+headers via the `Niobium::fhetch` CMake target is fine; modifying source
+under `vendor/` is not.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,12 +247,6 @@ target_compile_definitions(haze_tests PRIVATE
 # ctest entries
 # ---------------------------------------------------------------------------
 
-# HAZE_TARGET value selecting libnbfhetch's in-process simulator. Exposed
-# as a cache var so the symbolic name lives in one place; haze's
-# kFhetchSimTarget constant in src/core/config.hpp must agree.
-set(HAZE_FHETCH_SIM_TARGET "fhetch_sim" CACHE STRING
-    "HAZE_TARGET string that dispatches replay through fhetch_sim in-process")
-
 option(NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS
        "Register haze_transport_tests (transport round-trip via nbcc_fhetch_replay). Default OFF so config-client-release works without NIOBIUM_COMPILER_ROOT. Turn ON to add the ctest entry; the Makefile's test-transport target invokes scripts/test_haze_integration_standalone.sh directly without needing this flag."
        OFF)
@@ -270,10 +264,13 @@ set_tests_properties(haze_unit_tests PROPERTIES
 # Sim suite: in-process fhetch_sim. No transport setup needed; always
 # registered so `ctest` (or the Makefile's `make test`) exercises real
 # FHE math without external dependencies.
+#
+# Target literal must match haze::kFhetchSimTarget in src/core/config.hpp
+# AND the test-sim recipe in Makefile.
 add_test(NAME haze_sim_tests
          COMMAND haze_tests "[integration]")
 set_tests_properties(haze_sim_tests PROPERTIES
-    ENVIRONMENT "HAZE_TARGET=${HAZE_FHETCH_SIM_TARGET}")
+    ENVIRONMENT "HAZE_TARGET=fhetch_sim")
 
 if(NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS)
   set(NIOBIUM_COMPILER_ROOT "" CACHE PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,11 +182,13 @@ add_subdirectory(replay_bridge)
 # ---------------------------------------------------------------------------
 # One executable, three ctest entries split by Catch2 tag + HAZE_TARGET:
 #   - haze_unit_tests       : runs everything not tagged [integration]
-#                             with HAZE_TARGET=local (no FHE math).
+#                             with HAZE_TARGET=local. Unit tests do not
+#                             trigger replay so the target value is
+#                             effectively a recording-only setting.
 #   - haze_sim_tests        : runs [integration]-tagged cases through
-#                             libnbfhetch's in-process fhetch_sim
-#                             simulator. No external binary required;
-#                             default test target.
+#                             libnbfhetch's in-process FHETCH simulator
+#                             (HAZE_TARGET=local). No external binary
+#                             required; default test target.
 #   - haze_transport_tests  : runs [integration]-tagged cases via the
 #                             FHETCH transport (forwarder + server) so
 #                             the niobium-compiler-built nbcc_fhetch_replay
@@ -252,25 +254,25 @@ option(NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS
        OFF)
 
 # Unit suite: in-process, no server, no compiler-side binary.
-# HAZE_TARGET=local pins the compiler target so haze never tries to
-# dispatch to nbcc_fhetch_replay or run the in-process simulator during
-# unit tests. Unit tests observe state-machine and recording behaviour
-# only -- they do not validate FHE math results.
+# HAZE_TARGET=local pins the compiler target so haze never attempts to
+# dispatch to nbcc_fhetch_replay during unit tests. Unit tests observe
+# state-machine and recording behaviour only -- they do not call
+# hazeReplay() and do not validate FHE math results.
 add_test(NAME haze_unit_tests
          COMMAND haze_tests "~[integration]")
 set_tests_properties(haze_unit_tests PROPERTIES
     ENVIRONMENT "HAZE_TARGET=local")
 
-# Sim suite: in-process fhetch_sim. No transport setup needed; always
-# registered so `ctest` (or the Makefile's `make test`) exercises real
-# FHE math without external dependencies.
+# Sim suite: in-process FHETCH simulator. No transport setup needed;
+# always registered so `ctest` (or the Makefile's `make test`) exercises
+# real FHE math without external dependencies.
 #
-# Target literal must match haze::kFhetchSimTarget in src/core/config.hpp
+# Target literal must match haze::kLocalTarget in src/core/config.hpp
 # AND the test-sim recipe in Makefile.
 add_test(NAME haze_sim_tests
          COMMAND haze_tests "[integration]")
 set_tests_properties(haze_sim_tests PROPERTIES
-    ENVIRONMENT "HAZE_TARGET=fhetch_sim")
+    ENVIRONMENT "HAZE_TARGET=local")
 
 if(NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS)
   set(NIOBIUM_COMPILER_ROOT "" CACHE PATH

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,41 +4,30 @@ project(haze LANGUAGES C CXX VERSION 0.1.0)
 # ---------------------------------------------------------------------------
 # niobium-fhetch resolution
 # ---------------------------------------------------------------------------
-# Three-tier lookup, mirroring niobium-client's NIOBIUM_CLIENT_FHETCH_DIR
-# pattern:
-#
-# RYANPR: I don't think we need this first method; niobium-client should specify the NIOBIUM_HAZE_FHETCH_DIR instead.
-#   1. If a parent (e.g. niobium-client) has already added niobium-fhetch
-#      and defined Niobium::fhetch, reuse it. This is the path consumers
-#      who don't recursively sync haze's submodules take.
-#
-#   2. Else, if NIOBIUM_HAZE_FHETCH_DIR is set, add_subdirectory() that
-#      external source tree. Used by parents that want to inject their
-#      own niobium-fhetch checkout without populating haze's submodule.
-#
-#   3. Else, fall back to vendor/niobium-fhetch — haze's own submodule.
+# Two-tier lookup:
+#   1. If NIOBIUM_HAZE_FHETCH_DIR is set, add_subdirectory() that external
+#      source tree. Parents (e.g. niobium-client) that already own a
+#      niobium-fhetch checkout point haze at it via this cache var.
+#   2. Else, fall back to vendor/niobium-fhetch — haze's own submodule.
 #      Used for standalone builds (run `make sync` from this directory
 #      to populate it).
 #
 # OPENFHE_INSTALL_DIR is honored by niobium-fhetch's own CMakeLists when
-# we add it via path #2 or #3, so injecting it here covers transitive
-# OpenFHE discovery for every resolution branch.
+# we add it via either path, so injecting it here covers transitive
+# OpenFHE discovery for both branches.
 
-if(NOT TARGET Niobium::fhetch)
-  set(NIOBIUM_HAZE_FHETCH_DIR "" CACHE PATH
-      "External niobium-fhetch source tree to use instead of haze's vendor/niobium-fhetch (empty = use the vendored submodule)")
-  if(NIOBIUM_HAZE_FHETCH_DIR)
-    add_subdirectory(${NIOBIUM_HAZE_FHETCH_DIR}
-                     ${CMAKE_BINARY_DIR}/_deps/niobium-fhetch-build)
-  elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/niobium-fhetch/CMakeLists.txt)
-    add_subdirectory(vendor/niobium-fhetch)
-  else()
-    message(FATAL_ERROR
-      "haze cannot find niobium-fhetch. Either:\n"
-      "  - build from a parent that adds niobium-fhetch first (defining Niobium::fhetch),\n"
-      "  - pass -DNIOBIUM_HAZE_FHETCH_DIR=<path/to/niobium-fhetch>,\n"
-      "  - or run `make sync` from this directory to init vendor/niobium-fhetch.")
-  endif()
+set(NIOBIUM_HAZE_FHETCH_DIR "" CACHE PATH
+    "External niobium-fhetch source tree to use instead of haze's vendor/niobium-fhetch (empty = use the vendored submodule)")
+if(NIOBIUM_HAZE_FHETCH_DIR)
+  add_subdirectory(${NIOBIUM_HAZE_FHETCH_DIR}
+                   ${CMAKE_BINARY_DIR}/_deps/niobium-fhetch-build)
+elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/niobium-fhetch/CMakeLists.txt)
+  add_subdirectory(vendor/niobium-fhetch)
+else()
+  message(FATAL_ERROR
+    "haze cannot find niobium-fhetch. Either pass "
+    "-DNIOBIUM_HAZE_FHETCH_DIR=<path/to/niobium-fhetch>, or run "
+    "`make sync` from this directory to init vendor/niobium-fhetch.")
 endif()
 
 # OPENFHE_INSTALL_DIR may be set by:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,78 @@
 cmake_minimum_required(VERSION 3.22)
 project(haze LANGUAGES C CXX VERSION 0.1.0)
 
+# ---------------------------------------------------------------------------
+# niobium-fhetch resolution
+# ---------------------------------------------------------------------------
+# Three-tier lookup, mirroring niobium-client's NIOBIUM_CLIENT_FHETCH_DIR
+# pattern:
+#
+# RYANPR: I don't think we need this first method; niobium-client should specify the NIOBIUM_HAZE_FHETCH_DIR instead.
+#   1. If a parent (e.g. niobium-client) has already added niobium-fhetch
+#      and defined Niobium::fhetch, reuse it. This is the path consumers
+#      who don't recursively sync haze's submodules take.
+#
+#   2. Else, if NIOBIUM_HAZE_FHETCH_DIR is set, add_subdirectory() that
+#      external source tree. Used by parents that want to inject their
+#      own niobium-fhetch checkout without populating haze's submodule.
+#
+#   3. Else, fall back to vendor/niobium-fhetch — haze's own submodule.
+#      Used for standalone builds (run `make sync` from this directory
+#      to populate it).
+#
+# OPENFHE_INSTALL_DIR is honored by niobium-fhetch's own CMakeLists when
+# we add it via path #2 or #3, so injecting it here covers transitive
+# OpenFHE discovery for every resolution branch.
+
+if(NOT TARGET Niobium::fhetch)
+  set(NIOBIUM_HAZE_FHETCH_DIR "" CACHE PATH
+      "External niobium-fhetch source tree to use instead of haze's vendor/niobium-fhetch (empty = use the vendored submodule)")
+  if(NIOBIUM_HAZE_FHETCH_DIR)
+    add_subdirectory(${NIOBIUM_HAZE_FHETCH_DIR}
+                     ${CMAKE_BINARY_DIR}/_deps/niobium-fhetch-build)
+  elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/niobium-fhetch/CMakeLists.txt)
+    add_subdirectory(vendor/niobium-fhetch)
+  else()
+    message(FATAL_ERROR
+      "haze cannot find niobium-fhetch. Either:\n"
+      "  - build from a parent that adds niobium-fhetch first (defining Niobium::fhetch),\n"
+      "  - pass -DNIOBIUM_HAZE_FHETCH_DIR=<path/to/niobium-fhetch>,\n"
+      "  - or run `make sync` from this directory to init vendor/niobium-fhetch.")
+  endif()
+endif()
+
+# OPENFHE_INSTALL_DIR may be set by:
+#   - the parent build (niobium-client passes it explicitly)
+#   - haze's own Makefile (standalone build)
+#   - the user via -D
+# When unset, niobium-fhetch's CMakeLists defaults to its own
+# vendor/lib/openfhe install. The test executable below also reads it
+# for the OpenFHE BigInteger reference oracle.
+if(NOT DEFINED OPENFHE_INSTALL_DIR)
+  message(FATAL_ERROR
+    "OPENFHE_INSTALL_DIR is not set. Pass -DOPENFHE_INSTALL_DIR=<path> or "
+    "use haze's Makefile, which derives it from niobium-fhetch's install tree.")
+endif()
+
+# OPENFHE_LIBRARY_PATH locates libOPENFHEcore for the haze_tests reference
+# oracle (test_basis_convert.cpp). Most callers already supply it:
+#   - niobium-client sets it at the parent CMake level, pointing at
+#     OpenFHE's *build* output dir to dodge an extra install copy.
+#   - niobium-fhetch's CMakeLists sets it to ${OPENFHE_INSTALL_DIR}/lib
+#     when haze pulls fhetch in via add_subdirectory.
+# This fallback only fires when haze is built against an externally-resolved
+# Niobium::fhetch target whose enclosing project did not also provide
+# OPENFHE_LIBRARY_PATH (a partial-parent scenario).
+if(NOT DEFINED OPENFHE_LIBRARY_PATH)
+  set(OPENFHE_LIBRARY_PATH "${OPENFHE_INSTALL_DIR}/lib")
+endif()
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Emit compile_commands.json for clangd / IDE integration.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
-if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug CACHE STRING
-    "Build type: Debug, Release, RelWithDebInfo, or MinSizeRel" FORCE)
-endif()
 
 # ---------------------------------------------------------------------------
 # Compiler diagnostics
@@ -64,42 +124,14 @@ if(HAZE_TSAN)
 endif()
 
 # ---------------------------------------------------------------------------
-# Dependency: libnbcc (Niobium FHE compiler)
-# Set CMAKE_PREFIX_PATH to the niobium-compiler install tree, e.g.:
-#   cmake -B build -DCMAKE_PREFIX_PATH=/path/to/niobium-compiler/vendor/lib/niobium-compiler
-# ---------------------------------------------------------------------------
-
-find_package(niobium REQUIRED)
-
-# niobium's cmake config does not propagate its openfhe transitive includes.
-# Derive the path from the niobium install prefix.
-get_target_property(_nb_includes NiobiumInc::niobium INTERFACE_INCLUDE_DIRECTORIES)
-list(GET _nb_includes 0 _nb_include_dir)
-get_filename_component(_nb_prefix "${_nb_include_dir}" DIRECTORY)
-set(NIOBIUM_OPENFHE_INCLUDE
-    "${_nb_prefix}/../openfhe/include/openfhe"
-    CACHE PATH "OpenFHE include root bundled with the niobium compiler")
-set(NIOBIUM_OPENFHE_LIB
-    "${_nb_prefix}/../openfhe/lib"
-    CACHE PATH "OpenFHE shared-library dir bundled with the niobium compiler")
-set(NIOBIUM_JSON_INCLUDE
-    "${_nb_prefix}/../../../vendor/json/single_include"
-    CACHE PATH "nlohmann/json include dir bundled with the niobium compiler")
-
-if(NOT EXISTS "${NIOBIUM_OPENFHE_INCLUDE}")
-  message(FATAL_ERROR
-    "OpenFHE include dir not found at '${NIOBIUM_OPENFHE_INCLUDE}'. "
-    "Set NIOBIUM_OPENFHE_INCLUDE manually or reinstall libnbcc.")
-endif()
-if(NOT EXISTS "${NIOBIUM_JSON_INCLUDE}")
-  message(FATAL_ERROR
-    "nlohmann/json include dir not found at '${NIOBIUM_JSON_INCLUDE}'. "
-    "Set NIOBIUM_JSON_INCLUDE manually or reinstall libnbcc.")
-endif()
-
-# ---------------------------------------------------------------------------
 # libhaze shared library
 # ---------------------------------------------------------------------------
+# Niobium::fhetch (libnbfhetch) supplies:
+#   - the niobium::compiler() singleton (recording + replay dispatch)
+#   - the fhetch::* recording API used by haze's compute / epoch paths
+#   - public include dirs for <niobium/...> and OpenFHE headers (via
+#     BUILD_INTERFACE on the niobium-fhetch target)
+# So haze itself needs no other niobium-side dep.
 
 add_library(haze SHARED
   # extern "C" boundary — one cpp per public-header section.
@@ -122,6 +154,7 @@ add_library(haze SHARED
   src/core/stream.cpp
   # Shared leaf utilities.
   src/common/errors.cpp
+  src/common/log.cpp
 )
 
 target_include_directories(haze
@@ -130,16 +163,15 @@ target_include_directories(haze
     $<INSTALL_INTERFACE:include>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
-    ${NIOBIUM_OPENFHE_INCLUDE}
-    ${NIOBIUM_OPENFHE_INCLUDE}/binfhe
-    ${NIOBIUM_OPENFHE_INCLUDE}/core
-    ${NIOBIUM_OPENFHE_INCLUDE}/pke
-    ${NIOBIUM_JSON_INCLUDE}
+    # niobium-fhetch's JSON_INCLUDE_DIR cache var is PRIVATE on its
+    # target, so haze (a downstream consumer) doesn't inherit it.
+    # polynomial_io.cpp uses nlohmann/json — same vendored copy.
+    ${JSON_INCLUDE_DIR}
 )
 
 target_compile_definitions(haze PRIVATE HAZE_BUILDING_LIBRARY)
 
-target_link_libraries(haze PRIVATE NiobiumInc::niobium)
+target_link_libraries(haze PRIVATE Niobium::fhetch)
 
 set_target_properties(haze PROPERTIES
   CXX_VISIBILITY_PRESET     hidden
@@ -148,22 +180,43 @@ set_target_properties(haze PROPERTIES
 )
 
 # ---------------------------------------------------------------------------
-# Installation
+# Replay bridge — OpenFHE-using helper for synthesizing the CryptoContext +
+# ciphertext templates the compiler-side replay needs. Lives in its own
+# subdirectory and target so libhaze stays FHETCH-only; only haze_tests
+# (and any other replay-aware harness) link it in.
 # ---------------------------------------------------------------------------
 
-install(TARGETS haze
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-install(DIRECTORY include/ DESTINATION include)
+add_subdirectory(replay_bridge)
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+# One executable, two ctest entries split by Catch2 tag:
+#   - haze_unit_tests        : runs everything not tagged [integration].
+#   - haze_integration_tests : runs [integration]-tagged cases via the
+#                              FHETCH transport (forwarder + server) so
+#                              the niobium-compiler-built nbcc_fhetch_replay
+#                              executes the recorded project against the
+#                              OpenFHE simulator.
 
 enable_testing()
 find_package(Catch2 3 REQUIRED)
+
+# Test reference oracle (in test_basis_convert.cpp) calls into OpenFHE
+# BigInteger primitives directly. These come from the parent project's
+# OpenFHE install tree.
+set(_openfhe_include "${OPENFHE_INSTALL_DIR}/include/openfhe")
+set(_openfhe_core_lib_so   "${OPENFHE_LIBRARY_PATH}/libOPENFHEcore.so")
+set(_openfhe_core_lib_dylib "${OPENFHE_LIBRARY_PATH}/libOPENFHEcore.dylib")
+if(EXISTS "${_openfhe_core_lib_dylib}")
+  set(_openfhe_core_lib "${_openfhe_core_lib_dylib}")
+elseif(EXISTS "${_openfhe_core_lib_so}")
+  set(_openfhe_core_lib "${_openfhe_core_lib_so}")
+else()
+  message(FATAL_ERROR
+    "libOPENFHEcore not found under ${OPENFHE_LIBRARY_PATH}. The haze test "
+    "oracle links it directly; ensure niobium-client built OpenFHE first.")
+endif()
 
 add_executable(haze_tests
   test/test_build.cpp
@@ -176,26 +229,58 @@ add_executable(haze_tests
 
 target_include_directories(haze_tests PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/test
 )
 # OpenFHE BigInteger headers — used by test_basis_convert.cpp's reference
-# oracle. Marked SYSTEM so OpenFHE's internal -Wunused-parameter etc.
-# warnings don't trip our -Werror.
+# oracle. Marked SYSTEM so OpenFHE's internal warnings don't trip our -Werror.
 target_include_directories(haze_tests SYSTEM PRIVATE
-  ${NIOBIUM_OPENFHE_INCLUDE}
-  ${NIOBIUM_OPENFHE_INCLUDE}/core
+  ${_openfhe_include}
+  ${_openfhe_include}/core
 )
 
 target_link_libraries(haze_tests PRIVATE
   haze
+  haze_replay_bridge
   Catch2::Catch2WithMain
-  # OPENFHEcore: BigInteger primitives used by the test reference
-  # oracle (no DCRTPoly path — that's blocked by OpenFHE's WITH_CPROBES
-  # instrumentation polluting libnbcc's recording state).
-  ${NIOBIUM_OPENFHE_LIB}/libOPENFHEcore.so
+  ${_openfhe_core_lib}
 )
 
 # Pass the FBC variant choice through to the test oracle.
 target_compile_definitions(haze_tests PRIVATE
   HAZE_FBC_REDUCED_NOISE=$<BOOL:${HAZE_FBC_REDUCED_NOISE}>)
 
-add_test(NAME haze_tests COMMAND haze_tests)
+# ---------------------------------------------------------------------------
+# ctest entries
+# ---------------------------------------------------------------------------
+
+option(NIOBIUM_CLIENT_HAZE_WITH_INTEGRATION_TESTS
+       "Register the haze_integration_tests ctest entry (transport round-trip). Default OFF so config-client-release works without NIOBIUM_COMPILER_ROOT. Turn ON to add the ctest entry; the Makefile's test-haze-integration-release target invokes scripts/test_haze_integration.sh directly without needing this flag."
+       OFF)
+
+# Unit suite: in-process, no server, no compiler-side binary.
+# HAZE_TARGET=local pins the compiler target so haze never tries to
+# dispatch to nbcc_fhetch_replay during unit tests. With the local-target
+# replay path now a no-op (just produces the .fhetch trace), unit tests
+# observe state-machine and recording behaviour only -- they do not
+# validate FHE math results.
+add_test(NAME haze_unit_tests
+         COMMAND haze_tests "~[integration]")
+set_tests_properties(haze_unit_tests PROPERTIES
+    ENVIRONMENT "HAZE_TARGET=local")
+
+if(NIOBIUM_CLIENT_HAZE_WITH_INTEGRATION_TESTS)
+  set(NIOBIUM_COMPILER_ROOT "" CACHE PATH
+      "Path to a niobium-compiler checkout with build/nbcc_fhetch_replay. Required when NIOBIUM_CLIENT_HAZE_WITH_INTEGRATION_TESTS=ON.")
+  if(NOT NIOBIUM_COMPILER_ROOT)
+    message(FATAL_ERROR
+      "NIOBIUM_CLIENT_HAZE_WITH_INTEGRATION_TESTS=ON requires "
+      "-DNIOBIUM_COMPILER_ROOT=<path/to/niobium-compiler>")
+  endif()
+
+  add_test(NAME haze_integration_tests
+           COMMAND
+             ${CMAKE_CURRENT_SOURCE_DIR}/scripts/test_haze_integration.sh)
+  set_tests_properties(haze_integration_tests PROPERTIES
+    ENVIRONMENT
+      "NIOBIUM_COMPILER_ROOT=${NIOBIUM_COMPILER_ROOT};NIOBIUM_CLIENT_BUILD=${CMAKE_BINARY_DIR};HAZE_TEST_BIN=$<TARGET_FILE:haze_tests>;OPENFHE_LIB=${OPENFHE_LIBRARY_PATH}")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,13 +180,18 @@ add_subdirectory(replay_bridge)
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-# One executable, two ctest entries split by Catch2 tag:
-#   - haze_unit_tests        : runs everything not tagged [integration].
-#   - haze_integration_tests : runs [integration]-tagged cases via the
-#                              FHETCH transport (forwarder + server) so
-#                              the niobium-compiler-built nbcc_fhetch_replay
-#                              executes the recorded project against the
-#                              OpenFHE simulator.
+# One executable, three ctest entries split by Catch2 tag + HAZE_TARGET:
+#   - haze_unit_tests       : runs everything not tagged [integration]
+#                             with HAZE_TARGET=local (no FHE math).
+#   - haze_sim_tests        : runs [integration]-tagged cases through
+#                             libnbfhetch's in-process fhetch_sim
+#                             simulator. No external binary required;
+#                             default test target.
+#   - haze_transport_tests  : runs [integration]-tagged cases via the
+#                             FHETCH transport (forwarder + server) so
+#                             the niobium-compiler-built nbcc_fhetch_replay
+#                             executes the recorded project. Opt-in via
+#                             NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS.
 
 enable_testing()
 find_package(Catch2 3 REQUIRED)
@@ -242,34 +247,47 @@ target_compile_definitions(haze_tests PRIVATE
 # ctest entries
 # ---------------------------------------------------------------------------
 
-option(NIOBIUM_CLIENT_HAZE_WITH_INTEGRATION_TESTS
-       "Register the haze_integration_tests ctest entry (transport round-trip). Default OFF so config-client-release works without NIOBIUM_COMPILER_ROOT. Turn ON to add the ctest entry; the Makefile's test-haze-integration-release target invokes scripts/test_haze_integration.sh directly without needing this flag."
+# HAZE_TARGET value selecting libnbfhetch's in-process simulator. Exposed
+# as a cache var so the symbolic name lives in one place; haze's
+# kFhetchSimTarget constant in src/core/config.hpp must agree.
+set(HAZE_FHETCH_SIM_TARGET "fhetch_sim" CACHE STRING
+    "HAZE_TARGET string that dispatches replay through fhetch_sim in-process")
+
+option(NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS
+       "Register haze_transport_tests (transport round-trip via nbcc_fhetch_replay). Default OFF so config-client-release works without NIOBIUM_COMPILER_ROOT. Turn ON to add the ctest entry; the Makefile's test-transport target invokes scripts/test_haze_integration_standalone.sh directly without needing this flag."
        OFF)
 
 # Unit suite: in-process, no server, no compiler-side binary.
 # HAZE_TARGET=local pins the compiler target so haze never tries to
-# dispatch to nbcc_fhetch_replay during unit tests. With the local-target
-# replay path now a no-op (just produces the .fhetch trace), unit tests
-# observe state-machine and recording behaviour only -- they do not
-# validate FHE math results.
+# dispatch to nbcc_fhetch_replay or run the in-process simulator during
+# unit tests. Unit tests observe state-machine and recording behaviour
+# only -- they do not validate FHE math results.
 add_test(NAME haze_unit_tests
          COMMAND haze_tests "~[integration]")
 set_tests_properties(haze_unit_tests PROPERTIES
     ENVIRONMENT "HAZE_TARGET=local")
 
-if(NIOBIUM_CLIENT_HAZE_WITH_INTEGRATION_TESTS)
+# Sim suite: in-process fhetch_sim. No transport setup needed; always
+# registered so `ctest` (or the Makefile's `make test`) exercises real
+# FHE math without external dependencies.
+add_test(NAME haze_sim_tests
+         COMMAND haze_tests "[integration]")
+set_tests_properties(haze_sim_tests PROPERTIES
+    ENVIRONMENT "HAZE_TARGET=${HAZE_FHETCH_SIM_TARGET}")
+
+if(NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS)
   set(NIOBIUM_COMPILER_ROOT "" CACHE PATH
-      "Path to a niobium-compiler checkout with build/nbcc_fhetch_replay. Required when NIOBIUM_CLIENT_HAZE_WITH_INTEGRATION_TESTS=ON.")
+      "Path to a niobium-compiler checkout with build/nbcc_fhetch_replay. Required when NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS=ON.")
   if(NOT NIOBIUM_COMPILER_ROOT)
     message(FATAL_ERROR
-      "NIOBIUM_CLIENT_HAZE_WITH_INTEGRATION_TESTS=ON requires "
+      "NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS=ON requires "
       "-DNIOBIUM_COMPILER_ROOT=<path/to/niobium-compiler>")
   endif()
 
-  add_test(NAME haze_integration_tests
+  add_test(NAME haze_transport_tests
            COMMAND
              ${CMAKE_CURRENT_SOURCE_DIR}/scripts/test_haze_integration.sh)
-  set_tests_properties(haze_integration_tests PROPERTIES
+  set_tests_properties(haze_transport_tests PROPERTIES
     ENVIRONMENT
-      "NIOBIUM_COMPILER_ROOT=${NIOBIUM_COMPILER_ROOT};NIOBIUM_CLIENT_BUILD=${CMAKE_BINARY_DIR};HAZE_TEST_BIN=$<TARGET_FILE:haze_tests>;OPENFHE_LIB=${OPENFHE_LIBRARY_PATH}")
+      "NIOBIUM_COMPILER_ROOT=${NIOBIUM_COMPILER_ROOT};NIOBIUM_CLIENT_BUILD=${CMAKE_BINARY_DIR};HAZE_TEST_BIN=$<TARGET_FILE:haze_tests>;OPENFHE_LIB=${OPENFHE_LIBRARY_PATH};HAZE_TARGET=FUNC_SIM")
 endif()

--- a/FHETCH_IR_REFERENCE.md
+++ b/FHETCH_IR_REFERENCE.md
@@ -1,0 +1,387 @@
+# FHETCH Polynomial IR Reference
+
+The FHETCH Polynomial IR is a library-independent intermediate representation for Fully Homomorphic Encryption programs, following the [FHETCH specification](https://fhetch.org). It expresses FHE computations as polynomial-level operations that map directly to the Niobium BASALISC hardware accelerator ISA.
+
+This document is a comprehensive reference for the IR's data types, instructions, gadgets, and supporting infrastructure as implemented in the Niobium compiler.
+
+## Source locations
+
+| Component                         | Path                                |
+| --------------------------------- | ----------------------------------- |
+| Public API header                 | `include/niobium/fhetch_api.h`      |
+| Implementation                    | `src/FhetchApi.cpp`                 |
+| Existing documentation            | `docs/fhetch/FHETCH.md`             |
+| FHETCH driver (trace interpreter) | `fhetch_driver/`                    |
+| FHETCH driver documentation       | `docs/fhetch/FHETCH_DRIVER.md`      |
+| FHETCH_SIM device spec            | `devices/fhetch_sim/spec.yaml`      |
+| Simple example                    | `examples/fhetch/simple_fhetch.cpp` |
+| Epoch example                     | `examples/fhetch/epoch_fhetch.cpp`  |
+| Simple example test               | `tests/fhetch/fhetch_test.py`       |
+| Epoch example test                | `tests/fhetch/epoch_fhetch_test.py` |
+| HEIR integration design           | `docs/heir/HEIR_FHETCH.md`          |
+
+All FHETCH symbols live in the `niobium::fhetch` namespace.
+
+## Enumerations
+
+| Enum         | Values                      | Description                                                                          |
+| ------------ | --------------------------- | ------------------------------------------------------------------------------------ |
+| `NumberType` | `Integer`, `NonInteger`     | Whether components are modular integers or fixed-point/floating-point values.        |
+| `Format`     | `Coefficient`, `Evaluation` | Polynomial representation domain: time-domain coefficients vs. NTT/FFT point values. |
+
+## Data types
+
+All types use an opaque pimpl pattern (`shared_ptr` to an internal `*Impl` struct). Each polynomial is assigned a synthetic address from a monotonically increasing allocator, starting at 0.
+
+### Polynomial (SRP -- single-residue polynomial)
+
+A vector of N components under a single modulus.
+
+| Constructor / Factory   | Signature                                                                                                | Description                                |
+| ----------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| Default                 | `Polynomial()`                                                                                           | Empty/invalid polynomial.                  |
+| Zero (integer)          | `Polynomial::zeros(uint64_t ring_dim, Format fmt = Evaluation)`                                          | N zero-valued integer components.          |
+| Zero (non-integer)      | `Polynomial::zeros_ni(uint64_t ring_dim, Format fmt = Evaluation)`                                       | N zero-valued floating-point components.   |
+| From data (integer)     | `Polynomial::from_data(const vector<uint64_t>& components, uint64_t ring_dim, Format fmt = Evaluation)`  | Integer polynomial from raw values.        |
+| From data (non-integer) | `Polynomial::from_data_ni(const vector<double>& components, uint64_t ring_dim, Format fmt = Evaluation)` | Floating-point polynomial from raw values. |
+
+| Accessor           | Return type  | Description                              |
+| ------------------ | ------------ | ---------------------------------------- |
+| `ring_dimension()` | `uint64_t`   | Ring dimension N.                        |
+| `number_type()`    | `NumberType` | Integer or NonInteger.                   |
+| `format()`         | `Format`     | Coefficient or Evaluation.               |
+| `is_valid()`       | `bool`       | True if the polynomial holds valid data. |
+
+### Scalar
+
+A single value, integer or floating-point.
+
+| Factory      | Signature                           | Description         |
+| ------------ | ----------------------------------- | ------------------- |
+| From integer | `Scalar::from_int(uint64_t value)`  | Integer scalar.     |
+| From double  | `Scalar::from_double(double value)` | Non-integer scalar. |
+
+| Accessor        | Return type  | Description                          |
+| --------------- | ------------ | ------------------------------------ |
+| `number_type()` | `NumberType` | Integer or NonInteger.               |
+| `is_valid()`    | `bool`       | True if the scalar holds valid data. |
+
+### MRP (multi-residue polynomial)
+
+A set of polynomials indexed by modulus, representing an RNS decomposition. Keyed by modulus value; cannot hold duplicate moduli.
+
+| Constructor / Factory | Signature                                                          | Description                                   |
+| --------------------- | ------------------------------------------------------------------ | --------------------------------------------- |
+| Default               | `MRP()`                                                            | Empty MRP with empty base.                    |
+| From base             | `MRP(const ModuliBase& base, uint64_t ring_dim = 0)`               | Zero-initialized, one polynomial per modulus. |
+| From pairs            | `MRP::from_pairs(const vector<pair<Polynomial, uint64_t>>& pairs)` | Explicit (polynomial, modulus) pairs.         |
+
+| Accessor                 | Return type         | Description                                               |
+| ------------------------ | ------------------- | --------------------------------------------------------- |
+| `base()`                 | `const ModuliBase&` | Ordered set of prime moduli.                              |
+| `num_residues()`         | `size_t`            | Number of residues (== `base().size()`).                  |
+| `operator[](uint64_t q)` | `Polynomial&`       | Polynomial for modulus q. Throws if q is not in the base. |
+| `is_valid()`             | `bool`              | True if the MRP holds valid data.                         |
+
+### MRS (multi-residue scalar)
+
+A set of scalars indexed by modulus, analogous to MRP.
+
+| Constructor / Factory | Signature                                                      | Description                       |
+| --------------------- | -------------------------------------------------------------- | --------------------------------- |
+| Default               | `MRS()`                                                        | Empty MRS.                        |
+| From base             | `MRS(const ModuliBase& base)`                                  | Zero-initialized scalars.         |
+| From pairs            | `MRS::from_pairs(const vector<pair<Scalar, uint64_t>>& pairs)` | Explicit (scalar, modulus) pairs. |
+
+| Accessor                 | Return type         | Description                       |
+| ------------------------ | ------------------- | --------------------------------- |
+| `base()`                 | `const ModuliBase&` | Ordered set of prime moduli.      |
+| `num_residues()`         | `size_t`            | Number of residues.               |
+| `operator[](uint64_t q)` | `Scalar&`           | Scalar for modulus q.             |
+| `is_valid()`             | `bool`              | True if the MRS holds valid data. |
+
+### SRPArray
+
+Ordered, position-indexed array of single-residue polynomials. Unlike MRP, can hold polynomials with duplicate moduli.
+
+| Constructor      | Signature                                      | Description                        |
+| ---------------- | ---------------------------------------------- | ---------------------------------- |
+| Default          | `SRPArray()`                                   | Empty array (length 0).            |
+| Sized            | `SRPArray(size_t n)`                           | n default-initialized polynomials. |
+| Initializer list | `SRPArray(initializer_list<Polynomial> polys)` | From a list of polynomials.        |
+
+| Method                        | Return type   | Description                                                 |
+| ----------------------------- | ------------- | ----------------------------------------------------------- |
+| `length()`                    | `size_t`      | Number of elements.                                         |
+| `operator[](size_t i)`        | `Polynomial&` | Element at index i. Throws `out_of_range` if i >= length(). |
+| `append(const Polynomial& p)` | `void`        | Append a polynomial.                                        |
+| `is_valid()`                  | `bool`        | True if the array holds valid data.                         |
+
+### MRPArray
+
+Ordered array of MRPs. Each element may have a different base and number of residues.
+
+| Constructor      | Signature                              | Description                 |
+| ---------------- | -------------------------------------- | --------------------------- |
+| Default          | `MRPArray()`                           | Empty array (length 0).     |
+| Sized            | `MRPArray(size_t n)`                   | n default-initialized MRPs. |
+| Initializer list | `MRPArray(initializer_list<MRP> mrps)` | From a list of MRPs.        |
+
+| Method                 | Return type | Description                                                 |
+| ---------------------- | ----------- | ----------------------------------------------------------- |
+| `length()`             | `size_t`    | Number of elements.                                         |
+| `operator[](size_t i)` | `MRP&`      | Element at index i. Throws `out_of_range` if i >= length(). |
+| `append(const MRP& m)` | `void`      | Append an MRP.                                              |
+| `is_valid()`           | `bool`      | True if the array holds valid data.                         |
+
+### Type aliases
+
+| Alias        | Definition              | Description                                          |
+| ------------ | ----------------------- | ---------------------------------------------------- |
+| `ModuliBase` | `std::vector<uint64_t>` | An ordered set of prime moduli defining an RNS base. |
+
+### Structs
+
+| Struct                 | Fields                                                                                                                               | Description                                                   |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| `HardwareCapabilities` | `supported_ring_dimensions`, `max_modulus_bits` (63), `max_modulus_chain_length` (64), `supported_gadgets`, `supported_optional_ops` | Capabilities advertised by a hardware target to the compiler. |
+| `ProgramParameters`    | `ring_dimension`, `rns_primes`, `representation` (Evaluation), `coefficient_precision_bits` (64), `prime_congruence`                 | Parameter choices flowing from the compiler to the hardware.  |
+
+## Baseline instructions
+
+These map directly to the Niobium hardware ISA. Every compliant hardware target must implement them. Integer variants operate modulo a prime q; non-integer variants (in the optional section) use q=0 internally.
+
+| FHETCH function  | Signature                                                                                                 | ISA opcode      | Semantics                                                                                                                                                                     |
+| ---------------- | --------------------------------------------------------------------------------------------------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sr_addp`        | `(const Polynomial& a, const Polynomial& b, uint64_t q) -> Polynomial`                                    | ADD             | f_i = (a_i + b_i) mod q                                                                                                                                                       |
+| `sr_subp`        | `(const Polynomial& a, const Polynomial& b, uint64_t q) -> Polynomial`                                    | SUB             | f_i = (a_i - b_i) mod q                                                                                                                                                       |
+| `sr_mulp`        | `(const Polynomial& a, const Polynomial& b, uint64_t q) -> Polynomial`                                    | MUL             | f_i = (a_i \* b_i) mod q                                                                                                                                                      |
+| `sr_addps`       | `(const Polynomial& a, const Scalar& s, uint64_t q) -> Polynomial`                                        | ADDI            | f_i = (a_i + s) mod q (evaluation mode)                                                                                                                                       |
+| `sr_addps_coeff` | `(const Polynomial& a, const Scalar& s, uint64_t q) -> Polynomial`                                        | ADDI            | f*0 = (a_0 + s) mod q, f*{i>0} = a_i (coefficient mode)                                                                                                                       |
+| `sr_subps`       | `(const Polynomial& a, const Scalar& s, uint64_t q) -> Polynomial`                                        | SUBI            | f_i = (a_i - s) mod q (evaluation mode)                                                                                                                                       |
+| `sr_subps_coeff` | `(const Polynomial& a, const Scalar& s, uint64_t q) -> Polynomial`                                        | SUBI            | f*0 = (a_0 - s) mod q, f*{i>0} = a_i (coefficient mode)                                                                                                                       |
+| `sr_mulps`       | `(const Polynomial& a, const Scalar& s, uint64_t q) -> Polynomial`                                        | MULI            | f_i = (a_i \* s) mod q                                                                                                                                                        |
+| `sr_negp`        | `(const Polynomial& a, uint64_t q) -> Polynomial`                                                         | SUB             | f_i = (-a_i) mod q. Emitted as `sub(result, zero, a, q)`, allocating a zero polynomial first.                                                                                 |
+| `sr_ntt`         | `(const Polynomial& a, uint64_t q) -> Polynomial`                                                         | NTT1 + NTT2     | Forward negacyclic NTT. Computes the primitive 2N-th root of unity (omega) from q and N via NTL; cached per modulus. Converts coefficient -> evaluation format.               |
+| `sr_intt`        | `(const Polynomial& a, uint64_t q) -> Polynomial`                                                         | INTT1 + INTT2   | Inverse negacyclic NTT. Uses the same cached omega. Converts evaluation -> coefficient format.                                                                                |
+| `sr_permute`     | `(const Polynomial& a, const vector<uint64_t>& srcs, const vector<int>& signs, uint64_t q) -> Polynomial` | MORPH1 + MORPH2 | General permutation with sign flips. f_i = signs[i] \* a[srcs[i]] (mod q when negative). Currently emitted as a single morph with rot=0; full srcs/signs encoding is pending. |
+| `halt`           | `() -> void`                                                                                              | STOP            | Signal the hardware to stop and notify the host.                                                                                                                              |
+
+## Optional operations
+
+These are not required by all hardware targets. They extend the IR for scheme-specific needs.
+
+### Non-integer arithmetic
+
+These mirror the baseline instructions but operate on floating-point polynomial components without a modulus. Internally they emit the same generator opcodes (ADD, SUB, MUL, ADDI, SUBI, MULI) with mod=0 to signal non-integer mode.
+
+| FHETCH function     | Signature                                                  | Semantics                    |
+| ------------------- | ---------------------------------------------------------- | ---------------------------- |
+| `sr_addp_ni`        | `(const Polynomial& a, const Polynomial& b) -> Polynomial` | f_i = a_i + b_i              |
+| `sr_subp_ni`        | `(const Polynomial& a, const Polynomial& b) -> Polynomial` | f_i = a_i - b_i              |
+| `sr_mulp_ni`        | `(const Polynomial& a, const Polynomial& b) -> Polynomial` | f_i = a_i \* b_i             |
+| `sr_negp_ni`        | `(const Polynomial& a) -> Polynomial`                      | f_i = -a_i                   |
+| `sr_addps_ni`       | `(const Polynomial& a, const Scalar& s) -> Polynomial`     | f_i = a_i + s                |
+| `sr_addps_coeff_ni` | `(const Polynomial& a, const Scalar& s) -> Polynomial`     | f*0 = a_0 + s, f*{i>0} = a_i |
+| `sr_subps_ni`       | `(const Polynomial& a, const Scalar& s) -> Polynomial`     | f_i = a_i - s                |
+| `sr_subps_coeff_ni` | `(const Polynomial& a, const Scalar& s) -> Polynomial`     | f*0 = a_0 - s, f*{i>0} = a_i |
+| `sr_mulps_ni`       | `(const Polynomial& a, const Scalar& s) -> Polynomial`     | f_i = a_i \* s               |
+
+### Fourier transforms
+
+Alternative to NTT/INTT for hardware supporting FHEW/TFHE schemes. Internally emitted as NTT/INTT with mod=0 and omega=0.
+
+| FHETCH function | Signature                             | Semantics                                                                 |
+| --------------- | ------------------------------------- | ------------------------------------------------------------------------- |
+| `sr_ft`         | `(const Polynomial& a) -> Polynomial` | Negacyclic Fourier Transform (complex-valued). Coefficient -> Evaluation. |
+| `sr_ift`        | `(const Polynomial& a) -> Polynomial` | Inverse Negacyclic Fourier Transform. Evaluation -> Coefficient.          |
+
+### Coefficient access
+
+| FHETCH function    | Signature                                                            | Status              | Semantics                                            |
+| ------------------ | -------------------------------------------------------------------- | ------------------- | ---------------------------------------------------- |
+| `sr_coeff_extract` | `(const Polynomial& p, uint64_t i) -> Scalar`                        | Stub (returns 0)    | Extract the i-th component as a scalar.              |
+| `sr_coeff_assign`  | `(const Polynomial& p, uint64_t i, const Scalar& val) -> Polynomial` | Stub (returns copy) | Return a new polynomial with component i set to val. |
+
+### Torus and sample operations (TFHE/FHEW)
+
+| FHETCH function       | Signature                                                      | Status | Semantics                                                                                       |
+| --------------------- | -------------------------------------------------------------- | ------ | ----------------------------------------------------------------------------------------------- |
+| `sr_torus_mod_reduce` | `(const Polynomial& p, double c) -> Polynomial`                | Stub   | Torus modular reduction: coefficients in [c-0.5, c+0.5) equal to p up to an integer polynomial. |
+| `sr_sample_extract`   | `(const SRPArray& rlwe, uint64_t lwe_dim) -> vector<uint64_t>` | Stub   | Sample extraction from RLWE (length-2 SRPArray) to LWE vector.                                  |
+
+## Gadgets -- polynomial level
+
+Class I gadgets are simple compositions of baseline/optional instructions, verifiable by inspection.
+
+### Automorphisms
+
+All automorphisms emit MORPH instructions.
+
+| FHETCH function          | Signature                                                          | Description                                                                                                                          |
+| ------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `sr_automorph_eval`      | `(const Polynomial& x, uint64_t k) -> Polynomial`                  | Galois automorphism X -> X^k in evaluation representation. k is an odd integer in [1, 2N-1]. Uses COPY_MODULUS (0xFFFFFFFFFFFFFFFF). |
+| `sr_automorph_coeff`     | `(const Polynomial& x, uint64_t k, uint64_t q) -> Polynomial`      | Galois automorphism in coefficient representation.                                                                                   |
+| `sr_rot_automorph_coeff` | `(const Polynomial& x, uint64_t offset, uint64_t q) -> Polynomial` | Negacyclic rotation automorphism in coefficient representation. Offset in [0, N-1].                                                  |
+
+### Batch transforms
+
+| FHETCH function | Signature                         | Description                     |
+| --------------- | --------------------------------- | ------------------------------- |
+| `sr_batch_ft`   | `(const SRPArray& x) -> SRPArray` | Apply `sr_ft` to each element.  |
+| `sr_batch_ift`  | `(const SRPArray& x) -> SRPArray` | Apply `sr_ift` to each element. |
+
+## Gadgets -- multi-residue arithmetic
+
+These expand into per-residue baseline instructions, iterating over every modulus in the shared base.
+
+| FHETCH function | Signature                                                   | Expansion                                                  |
+| --------------- | ----------------------------------------------------------- | ---------------------------------------------------------- |
+| `mr_addp`       | `(const MRP& x, const MRP& y) -> MRP`                       | For each q in base: z[q] = `sr_addp`(x[q], y[q], q)        |
+| `mr_subp`       | `(const MRP& x, const MRP& y) -> MRP`                       | For each q in base: z[q] = `sr_subp`(x[q], y[q], q)        |
+| `mr_mulp`       | `(const MRP& x, const MRP& y) -> MRP`                       | For each q in base: z[q] = `sr_mulp`(x[q], y[q], q)        |
+| `mr_mulps`      | `(const MRP& x, const MRS& s) -> MRP`                       | For each q in base: z[q] = `sr_mulps`(x[q], s[q], q)       |
+| `mr_addps`      | `(const MRP& x, const MRS& s) -> MRP`                       | For each q in base: z[q] = `sr_addps`(x[q], s[q], q)       |
+| `mr_ntt`        | `(const MRP& x) -> MRP`                                     | For each q in base: z[q] = `sr_ntt`(x[q], q)               |
+| `mr_intt`       | `(const MRP& x) -> MRP`                                     | For each q in base: z[q] = `sr_intt`(x[q], q)              |
+| `mr_zeros`      | `(const ModuliBase& target_base, uint64_t ring_dim) -> MRP` | Construct a zero-initialized MRP. No instructions emitted. |
+
+## Gadgets -- MRP residue manipulation
+
+These are structural operations that create new MRP objects by rearranging residues. No hardware instructions are emitted.
+
+| FHETCH function | Signature                                                  | Description                                                                   |
+| --------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `mr_append_srp` | `(const MRP& x, const Polynomial& a, uint64_t q_a) -> MRP` | New MRP with base = x.base() union {q_a}.                                     |
+| `mr_union`      | `(const MRP& x, const MRP& y) -> MRP`                      | Merge two MRPs with mutually exclusive bases. base = x.base() union y.base(). |
+| `mr_subset`     | `(const MRP& x, const ModuliBase& subbase) -> MRP`         | Restrict MRP to a sub-base. subbase must be a subset of x.base().             |
+
+## Gadgets -- base conversion and rescaling
+
+| FHETCH function     | Signature                                               | Description                                                                                                                                                                                               |
+| ------------------- | ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fast_base_convert` | `(const MRP& x, const ModuliBase& target_base) -> MRP`  | CRT-based approximate base conversion from x's current base to target_base. Emits per-residue `sr_mulps` and `sr_addp` instructions. Input must be in coefficient mode.                                   |
+| `rescale_fbc`       | `(const MRP& x, const ModuliBase& rescale_base) -> MRP` | CKKS rescale: removes residues in rescale_base and rescales. Returns MRP in base = x.base() \ rescale_base. Calls `fast_base_convert` internally, then emits `sr_subp` and `sr_mulps` per output residue. |
+
+## Gadgets -- MRP array operations
+
+| FHETCH function   | Signature                                       | Description                                                                                                                           |
+| ----------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `mrpa_dotproduct` | `(const MRPArray& x, const MRPArray& y) -> MRP` | z = sum_i mr_mulp(x[i], y[i]). Both arrays must have the same length and all MRPs must share the same base. Key-switching inner loop. |
+
+## Gadgets -- decomposition
+
+| FHETCH function      | Signature                                                                                     | Description                                                                                                                                                              |
+| -------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `dig_decomp`         | `(const MRP& x, const vector<ModuliBase>& digit_bases, const ModuliBase& p_base) -> MRPArray` | CKKS/BGV/BFV hybrid key-switching digit decomposition. Returns MRPArray of length d where element i is base-extended from digit_bases[i] to (x.base() union p_base).     |
+| `gadget_decomp`      | `(const Polynomial& x, uint64_t base, uint64_t n_levels) -> SRPArray`                         | TFHE gadget decomposition (unsigned integer). Returns SRPArray of length n_levels. Stub -- requires integer division/bit-shift instructions not yet in the baseline ISA. |
+| `gadget_decomp_pow2` | `(const Polynomial& x, uint64_t log_base, uint64_t n_levels) -> SRPArray`                     | TFHE gadget decomposition for power-of-two base. Same status as `gadget_decomp`.                                                                                         |
+
+## Gadgets -- composite operations
+
+| FHETCH function     | Signature                                                                               | Description                                                                                                                                                                                                                  |
+| ------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `gsw_rlwe_ext_prod` | `(const SRPArray& gsw, const SRPArray& rlwe_in, uint64_t l, uint64_t base) -> SRPArray` | GSW/RLWE external product. gsw is a length-4l SRPArray, rlwe_in is length 2. Internally calls `gadget_decomp`, `sr_batch_ft`, non-integer `sr_mulp_ni`/`sr_addp_ni`, and `sr_batch_ift`. Returns a length-2 RLWE ciphertext. |
+| `ckks_bootstrap`    | `(const MRPArray& ct_in, const MRPArray& aux_data) -> MRPArray`                         | CKKS bootstrapping. Stub -- returns input unchanged. Requires scheme-specific parameter flow from hardware capabilities.                                                                                                     |
+
+## Input/output tagging
+
+Polynomials must be tagged as inputs or outputs so the optimizer's observability analysis knows which addresses are live. Without tags, all instructions are eliminated as dead code.
+
+| Function     | Signature                                           | Description                                         |
+| ------------ | --------------------------------------------------- | --------------------------------------------------- |
+| `tag_input`  | `(const string& name, const Polynomial& p) -> void` | Mark a single polynomial as a named input.          |
+| `tag_input`  | `(const string& name, const MRP& m) -> void`        | Mark all residues of an MRP as named inputs.        |
+| `tag_input`  | `(const string& name, const SRPArray& arr) -> void` | Mark all elements of an SRP array as named inputs.  |
+| `tag_input`  | `(const string& name, const MRPArray& arr) -> void` | Mark all elements of an MRP array as named inputs.  |
+| `tag_output` | `(const string& name, const Polynomial& p) -> void` | Mark a single polynomial as a named output (probe). |
+| `tag_output` | `(const string& name, const MRP& m) -> void`        | Mark all residues of an MRP as named outputs.       |
+| `tag_output` | `(const string& name, const SRPArray& arr) -> void` | Mark all elements of an SRP array as named outputs. |
+| `tag_output` | `(const string& name, const MRPArray& arr) -> void` | Mark all elements of an MRP array as named outputs. |
+
+Names are used as keys in the serialized JSON files and for retrieving results after replay.
+
+## Result retrieval
+
+After `compiler().replay()`, computed polynomial values can be read back from `replay_outputs_integer.json`.
+
+| Function | Signature                                     | Description                                                   |
+| -------- | --------------------------------------------- | ------------------------------------------------------------- |
+| `result` | `(const string& name, Polynomial& p) -> bool` | Retrieve a single polynomial result. Returns true on success. |
+| `result` | `(const string& name, MRP& m) -> bool`        | Retrieve a multi-residue polynomial result.                   |
+| `result` | `(const string& name, MRPArray& arr) -> bool` | Retrieve an MRP array result.                                 |
+
+Only outputs with `"status": "computed"` in the replay output file are returned.
+
+## Internal serialization functions
+
+These are called automatically during `compiler().stop()` in FHETCH mode but can also be invoked explicitly.
+
+| Function                   | Signature        | Description                                                                                                                    |
+| -------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `save_input_data`          | `() -> void`     | Write per-input JSON files and a master index to the program directory.                                                        |
+| `save_probe_outputs`       | `() -> void`     | Write output probe definitions to `<prog>.outputs.json`.                                                                       |
+| `reset_for_epoch`          | `() -> void`     | Clear input/output registries, reset the address allocator to 0, invalidate replay cache. Called automatically between epochs. |
+| `get_input_ring_dimension` | `() -> uint64_t` | Ring dimension from the first registered input (0 if none). Used for the synthetic crypto context.                             |
+
+## File I/O
+
+### Binary format (not yet implemented)
+
+| Function                                    | Signature                            | Status |
+| ------------------------------------------- | ------------------------------------ | ------ |
+| `save_polynomial` / `load_polynomial`       | `(Polynomial&, const path&) -> bool` | Stub   |
+| `save_scalar` / `load_scalar`               | `(Scalar&, const path&) -> bool`     | Stub   |
+| `save_mrp` / `load_mrp`                     | `(MRP&, const path&) -> bool`        | Stub   |
+| `save_mrs` / `load_mrs`                     | `(MRS&, const path&) -> bool`        | Stub   |
+| `save_srp_array` / `load_srp_array`         | `(SRPArray&, const path&) -> bool`   | Stub   |
+| `save_mrp_array` / `load_mrp_array`         | `(MRPArray&, const path&) -> bool`   | Stub   |
+| `save_mrp_dir` / `load_mrp_dir`             | `(MRP&, const path&) -> bool`        | Stub   |
+| `save_mrp_array_dir` / `load_mrp_array_dir` | `(MRPArray&, const path&) -> bool`   | Stub   |
+
+### JSON format (implemented)
+
+| Function               | Signature                                         | Description                                                               |
+| ---------------------- | ------------------------------------------------- | ------------------------------------------------------------------------- |
+| `save_polynomial_json` | `(const Polynomial& p, const path& file) -> bool` | Human-readable polynomial export (ring_dim, format, number_type, values). |
+| `load_polynomial_json` | `(Polynomial& p, const path& file) -> bool`       | Load from JSON.                                                           |
+| `save_mrp_json`        | `(const MRP& m, const path& file) -> bool`        | All residues + base metadata.                                             |
+| `load_mrp_json`        | `(MRP& m, const path& file) -> bool`              | Load from JSON.                                                           |
+| `save_mrp_array_json`  | `(const MRPArray& arr, const path& file) -> bool` | Array of MRPs.                                                            |
+| `load_mrp_array_json`  | `(MRPArray& arr, const path& file) -> bool`       | Load from JSON.                                                           |
+
+## Hardware ISA mapping
+
+The Generator (`src/Frontend/llvm/Generator.h`) emits instructions that map to the hardware ISA defined in the device spec (`devices/fhetch_sim/spec.yaml`). The full instruction set supported by FHETCH_SIM:
+
+| ISA opcode      | Generator method                         | FHETCH baseline instruction                              |
+| --------------- | ---------------------------------------- | -------------------------------------------------------- |
+| ADD             | `add(dest, src1, src2, mod)`             | `sr_addp`                                                |
+| SUB             | `sub(dest, src1, src2, mod)`             | `sr_subp`, `sr_negp` (as 0-a)                            |
+| MUL             | `mul(dest, src1, src2, mod)`             | `sr_mulp`                                                |
+| ADDI            | `addi(dest, src, imm, mod)`              | `sr_addps`, `sr_addps_coeff`                             |
+| SUBI            | `subi(dest, src, imm, mod)`              | `sr_subps`, `sr_subps_coeff`                             |
+| MULI            | `muli(dest, src, imm, mod)`              | `sr_mulps`                                               |
+| NTT1 + NTT2     | `ntt(dest, src, mod, omega)`             | `sr_ntt`                                                 |
+| INTT1 + INTT2   | `intt(dest, src, mod, omega)`            | `sr_intt`                                                |
+| MORPH1 + MORPH2 | `morph(dest, src, mod, mask, logn, rot)` | `sr_permute`, `sr_automorph_*`, `sr_rot_automorph_coeff` |
+| COPY            | (internal)                               | Register-to-register copy (optimization pass)            |
+| MOVE            | (internal)                               | Memory move (optimization pass)                          |
+| ALLOCATE        | (internal)                               | Memory allocation marker                                 |
+| COMMENT         | (internal)                               | Annotation in instruction stream                         |
+| IP              | (internal)                               | Instruction pointer                                      |
+| START           | (internal)                               | Start marker                                             |
+| STOP            | `halt()`                                 | Program termination                                      |
+| FENCE           | (internal)                               | Memory fence                                             |
+| NOP             | (internal)                               | No-operation                                             |
+| HALT            | (internal)                               | Hardware halt signal                                     |
+
+Instructions marked (internal) are emitted by the optimization pipeline or runtime infrastructure, not directly by FHETCH API calls.
+
+## Implementation notes
+
+- Non-integer variants emit the same opcodes as integer variants but with mod=0, signaling non-integer mode to the backend.
+- `sr_negp` allocates a zero polynomial and emits `zero()` + `sub()`, rather than having a dedicated negate opcode.
+- NTT omega values are computed via NTL's primitive root finder and cached per modulus in a static map.
+- Synthetic addresses are allocated from a global atomic counter starting at 0, incrementing by 1 per polynomial/scalar. These stay below PHYS_REG_BASE (0x1000000000) so the optimizer's address tracking works correctly.
+- FHETCH mode activates automatically on the first `fhetch::` function call. No explicit mode flag is needed.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,249 @@
+# ==============================================================================
+# Haze — standalone build entry
+# ==============================================================================
+# Convention: dbuild/ for Debug, build/ for Release
+#
+# RYANPR: Instead of this, make a help phony target to describe that is happening. Include example of running the integration test when the nbcc_fhetch_replay is being run from the niobium-client repository (if that makes sense)
+# Standalone build (haze owns its own niobium-fhetch + openfhe checkout):
+#   make sync                      # one-time: init vendor/niobium-fhetch + nested submodules
+#   make build-release             # configure + build everything (Release)
+#   make test-unit-release         # run the unit suite (no compiler dep)
+#   make test-integration-release NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler
+#                                  # run integration suite (requires nbcc_fhetch_replay binary)
+#
+# Parent-driven build (e.g. niobium-client adds_subdirectory(vendor/niobium-haze)):
+#   The parent's CMake build system already handles configuring and building
+#   haze. This Makefile is only used for standalone work.
+#
+# RYANPR: Make sure this is up to date
+# Override knobs (parent or user can supply):
+#   NIOBIUM_HAZE_FHETCH_DIR  External niobium-fhetch source tree to use instead
+#                            of vendor/niobium-fhetch. When set, vendor/niobium-fhetch
+#                            does not need to be initialized.
+#   OPENFHE_INSTALL_DIR      Where OpenFHE is installed (libs + headers).
+#                            Defaults to <fhetch>/vendor/lib/openfhe.
+#   JSON_INCLUDE_DIR         nlohmann/json single_include directory.
+#                            Empty -> use niobium-fhetch's vendored copy.
+#   EXTERNAL_OPENFHE         1 if a parent built OpenFHE and pointed
+#                            OPENFHE_INSTALL_DIR at it; we skip the openfhe
+#                            build target chain.
+#   NIOBIUM_COMPILER_ROOT    Path to a niobium-compiler checkout containing
+#                            build/nbcc_fhetch_replay. Required for integration
+#                            tests; the compiler binary is invoked directly
+#                            (no HTTP transport from haze's standalone path).
+# ==============================================================================
+
+SHELL := /bin/bash
+.SHELLFLAGS := -o pipefail -c
+
+# ==============================================================================
+# Platform / CPU detection
+# ==============================================================================
+
+UNAME_S := $(shell uname -s)
+
+ifndef NUM_CPUS
+  ifeq ($(UNAME_S), Darwin)
+    NUM_CPUS := $(shell sysctl -n hw.ncpu)
+  else
+    NUM_CPUS := $(shell nproc)
+  endif
+endif
+
+# ==============================================================================
+# Paths
+# ==============================================================================
+
+# niobium-fhetch resolution: same precedence as haze's CMakeLists.txt.
+# 1. Caller-provided override
+# 2. haze's own vendor submodule
+NIOBIUM_HAZE_FHETCH_DIR ?=
+ifeq ($(NIOBIUM_HAZE_FHETCH_DIR),)
+  FHETCH_DIR := $(CURDIR)/vendor/niobium-fhetch
+else
+  FHETCH_DIR := $(NIOBIUM_HAZE_FHETCH_DIR)
+endif
+
+# OpenFHE: defaults to niobium-fhetch's vendored install, but a parent
+# (or user) can point us at a pre-built install with EXTERNAL_OPENFHE=1
+# + OPENFHE_INSTALL_DIR=<path>.
+OPENFHE_DIR         ?= $(FHETCH_DIR)/vendor/openfhe
+OPENFHE_INSTALL_DIR ?= $(FHETCH_DIR)/vendor/lib/openfhe
+JSON_INCLUDE_DIR    ?=
+
+EXTERNAL_OPENFHE ?= 0
+ifeq ($(EXTERNAL_OPENFHE),1)
+  OPENFHE_BUILD_DEP_DEBUG   :=
+  OPENFHE_BUILD_DEP_RELEASE :=
+else
+  OPENFHE_BUILD_DEP_DEBUG   := build-openfhe
+  OPENFHE_BUILD_DEP_RELEASE := build-openfhe-release
+endif
+
+# CMake -D flags emitted only when the corresponding override is set.
+CMAKE_FHETCH_DIR_FLAG       := $(if $(NIOBIUM_HAZE_FHETCH_DIR),-DNIOBIUM_HAZE_FHETCH_DIR="$(NIOBIUM_HAZE_FHETCH_DIR)")
+CMAKE_JSON_INCLUDE_DIR_FLAG := $(if $(JSON_INCLUDE_DIR),-DJSON_INCLUDE_DIR="$(JSON_INCLUDE_DIR)")
+
+# Path to a built niobium-compiler checkout (must contain
+# build/nbcc_fhetch_replay). Haze does NOT vendor the compiler — set this
+# explicitly when running integration tests:
+#   make test-integration-release NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler
+# The fallback `vendor/niobium-compiler` lets developers symlink an
+# external checkout in if they prefer that pattern; otherwise the
+# test-integration-release prerequisite check will print a clear error.
+# RYANPR: Only have the variable based root, not some magic symlink path.
+NIOBIUM_COMPILER_ROOT ?= $(CURDIR)/vendor/niobium-compiler
+
+# ==============================================================================
+# Build config helper (mirrors niobium-client/Makefile)
+# ==============================================================================
+
+BUILD_CONFIG = Debug
+BUILD_DIR = dbuild
+
+# RYANPR: What is this for?
+define set-build-config
+$(eval BUILD_CONFIG = $(1))
+$(eval BUILD_DIR = $(2))
+endef
+
+# Per-test artifact runs dir (tests cd here so libnbfhetch's program_dir
+# resolves under build/ and not into the source tree).
+HAZE_RUNS_DIR = $(CURDIR)/$(BUILD_DIR)/runs
+
+# ==============================================================================
+# Phony targets
+# ==============================================================================
+
+.PHONY: help sync \
+        config config-release build build-release release \
+        config-openfhe config-openfhe-release build-openfhe build-openfhe-release \
+        test-unit-release test-integration-release test-release \
+        clean clean-runs
+
+##@ Primary Targets
+
+# RYANPR: What the hell is this. Ideally we just include the help here.
+help: ## Display this help message
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Submodule sync (standalone use only)
+
+sync: ## Init vendor/niobium-fhetch + its nested openfhe / json submodules (recursive)
+	git submodule update --init --recursive vendor/niobium-fhetch
+
+##@ OpenFHE Build (skipped when EXTERNAL_OPENFHE=1)
+
+OPENFHE_CMAKE_FLAGS = \
+	-DBUILD_SHARED=ON \
+	-DBUILD_EXAMPLES=OFF \
+	-DBUILD_UNITTESTS=OFF \
+	-DBUILD_BENCHMARKS=OFF \
+	-DBUILD_EXTRAS=OFF \
+	-DWITH_CPROBES=ON \
+	-DWITH_OPENMP=OFF
+
+# RYANPR: Think about a way to make all these `X` and `X-release` targets modular, since otherwise we are repeating code all the time. Essentially there should be a build directory, a build symbol (Debug/Release), and you can pipe those through the appropriate places. `set-build-config` kinda does parts of this but doesn't seem to use them. Apply to all targets that this works agains (config, config-openfhe, build, build-openfhe, etc) Use a variable that defaults to one mode and override it on the command line. For example:
+#
+#   MODE ?= debug
+#   CFLAGS_debug   := -g -O0
+#   CFLAGS_release := -O2 -DNDEBUG
+#
+#   build:
+#         $(CC) $(CFLAGS_$(MODE)) -o app main.c
+config-openfhe: ## Configure OpenFHE (Debug)
+	@if [ ! -d "$(OPENFHE_DIR)" ]; then \
+		echo "ERROR: $(OPENFHE_DIR) is empty. Run 'make sync' first."; exit 2; \
+	fi
+	cd "$(OPENFHE_DIR)" && cmake -S . -B dbuild \
+		-DCMAKE_BUILD_TYPE=Debug \
+		$(OPENFHE_CMAKE_FLAGS) \
+		-DCMAKE_INSTALL_PREFIX="$(OPENFHE_INSTALL_DIR)"
+
+config-openfhe-release: ## Configure OpenFHE (Release)
+	@if [ ! -d "$(OPENFHE_DIR)" ]; then \
+		echo "ERROR: $(OPENFHE_DIR) is empty. Run 'make sync' first."; exit 2; \
+	fi
+	cd "$(OPENFHE_DIR)" && cmake -S . -B build \
+		-DCMAKE_BUILD_TYPE=Release \
+		$(OPENFHE_CMAKE_FLAGS) \
+		-DCMAKE_INSTALL_PREFIX="$(OPENFHE_INSTALL_DIR)"
+
+build-openfhe: config-openfhe ## Build and install OpenFHE locally (Debug)
+	cd "$(OPENFHE_DIR)" && cmake --build dbuild -j $(NUM_CPUS) --target install --config Debug
+
+build-openfhe-release: config-openfhe-release ## Build and install OpenFHE locally (Release)
+	cd "$(OPENFHE_DIR)" && cmake --build build -j $(NUM_CPUS) --target install --config Release
+
+##@ Haze Build
+
+config: $(OPENFHE_BUILD_DEP_DEBUG) ## Configure haze (Debug)
+	$(call set-build-config,Debug,dbuild)
+	cmake -S "$(CURDIR)" -B "$(CURDIR)/dbuild" \
+		-DCMAKE_BUILD_TYPE=Debug \
+		-DOPENFHE_INSTALL_DIR="$(OPENFHE_INSTALL_DIR)" \
+		$(CMAKE_FHETCH_DIR_FLAG) \
+		$(CMAKE_JSON_INCLUDE_DIR_FLAG)
+
+config-release: $(OPENFHE_BUILD_DEP_RELEASE) ## Configure haze (Release)
+	$(call set-build-config,Release,build)
+	cmake -S "$(CURDIR)" -B "$(CURDIR)/build" \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DOPENFHE_INSTALL_DIR="$(OPENFHE_INSTALL_DIR)" \
+		$(CMAKE_FHETCH_DIR_FLAG) \
+		$(CMAKE_JSON_INCLUDE_DIR_FLAG)
+
+build: config ## Build haze (Debug)
+	$(call set-build-config,Debug,dbuild)
+	cmake --build dbuild -j $(NUM_CPUS) --config Debug
+
+build-release: config-release ## Build haze (Release)
+	$(call set-build-config,Release,build)
+	cmake --build build -j $(NUM_CPUS) --config Release
+
+##@ Haze Tests
+
+# RYANPR: Why do the tests not run against the debug copy?
+test-unit-release: build-release ## Run the haze unit suite (HAZE_TARGET=local; no compiler dep)
+	$(call set-build-config,Release,build)
+	@rm -rf "$(HAZE_RUNS_DIR)/haze"
+	@mkdir -p "$(HAZE_RUNS_DIR)"
+	@cd "$(HAZE_RUNS_DIR)" && \
+	  HAZE_TARGET=local "$(CURDIR)/build/haze_tests" "~[integration]"
+
+test-integration-release: build-release ## End-to-end haze integration tests (direct nbcc_fhetch_replay invocation; no HTTP transport)
+	$(call set-build-config,Release,build)
+	@if [ ! -x "$(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay" ]; then \
+		echo "ERROR: nbcc_fhetch_replay not found at $(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay"; \
+		echo "Build it with: (cd $(NIOBIUM_COMPILER_ROOT) && make release)"; \
+		echo "Or override:   make test-integration-release NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler"; \
+		exit 2; \
+	fi
+	@HAZE_TEST_BIN="$(CURDIR)/build/haze_tests" \
+	 NIOBIUM_COMPILER_ROOT="$(NIOBIUM_COMPILER_ROOT)" \
+	 OPENFHE_LIB="$(OPENFHE_INSTALL_DIR)/lib" \
+	 HAZE_RUNS_DIR="$(HAZE_RUNS_DIR)" \
+	 scripts/test_haze_integration_standalone.sh
+
+test-release: test-unit-release test-integration-release ## Run all haze tests (unit + standalone integration)
+
+##@ Cleanup
+
+clean-runs: ## Remove haze test runs/ artifacts (keeps build outputs intact)
+	-rm -rf "$(CURDIR)/build/runs" "$(CURDIR)/dbuild/runs"
+
+# RYANPR: Should this not use clean-runs as a dependency?
+clean: ## Remove all build artifacts (keeps vendor/ checkouts; refuses to touch external trees pointed at via NIOBIUM_HAZE_FHETCH_DIR or EXTERNAL_OPENFHE)
+	-rm -rf "$(CURDIR)/build" "$(CURDIR)/dbuild"
+	@if [ "$(EXTERNAL_OPENFHE)" != "1" ]; then \
+	  case "$(OPENFHE_DIR)" in \
+	    "$(CURDIR)"/*) rm -rf "$(OPENFHE_DIR)/build" "$(OPENFHE_DIR)/dbuild" ;; \
+	    *) echo "skipping clean of external OPENFHE_DIR=$(OPENFHE_DIR)" ;; \
+	  esac; \
+	  case "$(OPENFHE_INSTALL_DIR)" in \
+	    "$(CURDIR)"/*) rm -rf "$(OPENFHE_INSTALL_DIR)" ;; \
+	    *) echo "skipping clean of external OPENFHE_INSTALL_DIR=$(OPENFHE_INSTALL_DIR)" ;; \
+	  esac; \
+	else \
+	  echo "skipping clean of OpenFHE build/install dirs (EXTERNAL_OPENFHE=1)"; \
+	fi

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,6 @@
 #                            test-transport; the compiler binary is invoked
 #                            directly (no HTTP transport from haze's
 #                            standalone path). No default.
-#   FHETCH_SIM_TARGET        HAZE_TARGET value selecting libnbfhetch's
-#                            in-process simulator. Default: fhetch_sim.
 # ==============================================================================
 
 SHELL := /bin/bash
@@ -100,11 +98,6 @@ CMAKE_JSON_INCLUDE_DIR_FLAG := $(if $(JSON_INCLUDE_DIR),-DJSON_INCLUDE_DIR="$(JS
 # explicitly when running transport-path tests:
 #   make test-transport NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler
 NIOBIUM_COMPILER_ROOT ?=
-
-# HAZE_TARGET value that selects libnbfhetch's in-process simulator.
-# Surfaced as a knob so the discovery work in plan section H1 lands here
-# without scattering string literals across the Makefile / CMake / src.
-FHETCH_SIM_TARGET ?= fhetch_sim
 
 # Per-test artifact runs dir (tests cd here so libnbfhetch's program_dir
 # resolves under build/ and not into the source tree).
@@ -218,8 +211,10 @@ test-unit: build ## Run unit suite (HAZE_TARGET=local; no FHE math)
 test-sim: build ## Run sim suite (in-process fhetch_sim; validates FHE math)
 	@rm -rf "$(HAZE_RUNS_DIR)/haze"
 	@mkdir -p "$(HAZE_RUNS_DIR)"
+	@# Target literal must match haze::kFhetchSimTarget in src/core/config.hpp
+	@# AND the haze_sim_tests ENVIRONMENT entry in CMakeLists.txt.
 	@cd "$(HAZE_RUNS_DIR)" && \
-	  HAZE_TARGET=$(FHETCH_SIM_TARGET) "$(CURDIR)/$(BUILD_DIR)/haze_tests" "[integration]"
+	  HAZE_TARGET=fhetch_sim "$(CURDIR)/$(BUILD_DIR)/haze_tests" "[integration]"
 
 test-transport: build ## Run integration suite via nbcc_fhetch_replay (opt-in)
 	@if [ -z "$(NIOBIUM_COMPILER_ROOT)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,17 @@
 # ==============================================================================
 # Haze — standalone build entry
 # ==============================================================================
-# Convention: dbuild/ for Debug, build/ for Release
+# Build directory convention: dbuild/ for MODE=debug, build/ for MODE=release.
+# All targets honour MODE; defaults to release. See `make help`.
 #
-# RYANPR: Instead of this, make a help phony target to describe that is happening. Include example of running the integration test when the nbcc_fhetch_replay is being run from the niobium-client repository (if that makes sense)
-# Standalone build (haze owns its own niobium-fhetch + openfhe checkout):
-#   make sync                      # one-time: init vendor/niobium-fhetch + nested submodules
-#   make build-release             # configure + build everything (Release)
-#   make test-unit-release         # run the unit suite (no compiler dep)
-#   make test-integration-release NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler
-#                                  # run integration suite (requires nbcc_fhetch_replay binary)
-#
-# Parent-driven build (e.g. niobium-client adds_subdirectory(vendor/niobium-haze)):
-#   The parent's CMake build system already handles configuring and building
-#   haze. This Makefile is only used for standalone work.
-#
-# RYANPR: Make sure this is up to date
 # Override knobs (parent or user can supply):
+#   MODE                     debug | release. Selects build dir (dbuild|build)
+#                            and CMake config (Debug|Release). Default: release.
+#   NUM_CPUS                 Build parallelism. Auto-detected from sysctl/nproc;
+#                            override to throttle.
 #   NIOBIUM_HAZE_FHETCH_DIR  External niobium-fhetch source tree to use instead
 #                            of vendor/niobium-fhetch. When set, vendor/niobium-fhetch
-#                            does not need to be initialized.
+#                            does not need to be initialised.
 #   OPENFHE_INSTALL_DIR      Where OpenFHE is installed (libs + headers).
 #                            Defaults to <fhetch>/vendor/lib/openfhe.
 #   JSON_INCLUDE_DIR         nlohmann/json single_include directory.
@@ -28,9 +20,12 @@
 #                            OPENFHE_INSTALL_DIR at it; we skip the openfhe
 #                            build target chain.
 #   NIOBIUM_COMPILER_ROOT    Path to a niobium-compiler checkout containing
-#                            build/nbcc_fhetch_replay. Required for integration
-#                            tests; the compiler binary is invoked directly
-#                            (no HTTP transport from haze's standalone path).
+#                            build/nbcc_fhetch_replay. Required for
+#                            test-transport; the compiler binary is invoked
+#                            directly (no HTTP transport from haze's
+#                            standalone path). No default.
+#   FHETCH_SIM_TARGET        HAZE_TARGET value selecting libnbfhetch's
+#                            in-process simulator. Default: fhetch_sim.
 # ==============================================================================
 
 SHELL := /bin/bash
@@ -48,6 +43,24 @@ ifndef NUM_CPUS
   else
     NUM_CPUS := $(shell nproc)
   endif
+endif
+
+# ==============================================================================
+# Mode selection (debug vs release)
+# ==============================================================================
+
+MODE ?= release
+
+BUILD_DIR_debug   := dbuild
+BUILD_DIR_release := build
+BUILD_DIR := $(BUILD_DIR_$(MODE))
+
+CMAKE_CONFIG_debug   := Debug
+CMAKE_CONFIG_release := Release
+CMAKE_CONFIG := $(CMAKE_CONFIG_$(MODE))
+
+ifeq ($(BUILD_DIR),)
+  $(error invalid MODE='$(MODE)' (expected 'debug' or 'release'))
 endif
 
 # ==============================================================================
@@ -73,11 +86,9 @@ JSON_INCLUDE_DIR    ?=
 
 EXTERNAL_OPENFHE ?= 0
 ifeq ($(EXTERNAL_OPENFHE),1)
-  OPENFHE_BUILD_DEP_DEBUG   :=
-  OPENFHE_BUILD_DEP_RELEASE :=
+  OPENFHE_BUILD_DEP :=
 else
-  OPENFHE_BUILD_DEP_DEBUG   := build-openfhe
-  OPENFHE_BUILD_DEP_RELEASE := build-openfhe-release
+  OPENFHE_BUILD_DEP := build-openfhe
 endif
 
 # CMake -D flags emitted only when the corresponding override is set.
@@ -86,26 +97,14 @@ CMAKE_JSON_INCLUDE_DIR_FLAG := $(if $(JSON_INCLUDE_DIR),-DJSON_INCLUDE_DIR="$(JS
 
 # Path to a built niobium-compiler checkout (must contain
 # build/nbcc_fhetch_replay). Haze does NOT vendor the compiler — set this
-# explicitly when running integration tests:
-#   make test-integration-release NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler
-# The fallback `vendor/niobium-compiler` lets developers symlink an
-# external checkout in if they prefer that pattern; otherwise the
-# test-integration-release prerequisite check will print a clear error.
-# RYANPR: Only have the variable based root, not some magic symlink path.
-NIOBIUM_COMPILER_ROOT ?= $(CURDIR)/vendor/niobium-compiler
+# explicitly when running transport-path tests:
+#   make test-transport NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler
+NIOBIUM_COMPILER_ROOT ?=
 
-# ==============================================================================
-# Build config helper (mirrors niobium-client/Makefile)
-# ==============================================================================
-
-BUILD_CONFIG = Debug
-BUILD_DIR = dbuild
-
-# RYANPR: What is this for?
-define set-build-config
-$(eval BUILD_CONFIG = $(1))
-$(eval BUILD_DIR = $(2))
-endef
+# HAZE_TARGET value that selects libnbfhetch's in-process simulator.
+# Surfaced as a knob so the discovery work in plan section H1 lands here
+# without scattering string literals across the Makefile / CMake / src.
+FHETCH_SIM_TARGET ?= fhetch_sim
 
 # Per-test artifact runs dir (tests cd here so libnbfhetch's program_dir
 # resolves under build/ and not into the source tree).
@@ -116,23 +115,60 @@ HAZE_RUNS_DIR = $(CURDIR)/$(BUILD_DIR)/runs
 # ==============================================================================
 
 .PHONY: help sync \
-        config config-release build build-release release \
-        config-openfhe config-openfhe-release build-openfhe build-openfhe-release \
-        test-unit-release test-integration-release test-release \
+        config build \
+        config-openfhe build-openfhe \
+        test-unit test-sim test-transport test test-all \
         clean clean-runs
 
-##@ Primary Targets
+# ==============================================================================
+# help
+# ==============================================================================
 
-# RYANPR: What the hell is this. Ideally we just include the help here.
+define HAZE_HELP_TEXT
+
+Usage: make <target> [MODE=debug|release]
+
+  Build:
+    config              Configure haze (uses MODE; default: release)
+    build               Build haze
+    config-openfhe      Configure OpenFHE
+    build-openfhe       Build and install OpenFHE locally
+    sync                Init vendor/niobium-fhetch submodule
+
+  Test:
+    test-unit           Run unit suite (HAZE_TARGET=local; no FHE math)
+    test-sim            Run sim suite (in-process fhetch_sim)
+    test-transport      Run integration suite via nbcc_fhetch_replay
+                        (requires NIOBIUM_COMPILER_ROOT)
+    test                Default: test-unit + test-sim
+    test-all            test-unit + test-sim + test-transport
+
+  Cleanup:
+    clean-runs          Remove test runs/ artifacts
+    clean               Remove all build artifacts
+
+  Examples:
+    make test                                        # default tests
+    make test MODE=debug                             # debug build
+    make test-transport NIOBIUM_COMPILER_ROOT=/path  # transport path
+    cd niobium-client && make test-haze              # parent-driven
+
+endef
+export HAZE_HELP_TEXT
+
 help: ## Display this help message
-	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-28s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+	@echo "$$HAZE_HELP_TEXT"
 
-##@ Submodule sync (standalone use only)
+# ==============================================================================
+# Submodule sync (standalone use only)
+# ==============================================================================
 
 sync: ## Init vendor/niobium-fhetch + its nested openfhe / json submodules (recursive)
 	git submodule update --init --recursive vendor/niobium-fhetch
 
-##@ OpenFHE Build (skipped when EXTERNAL_OPENFHE=1)
+# ==============================================================================
+# OpenFHE Build (skipped when EXTERNAL_OPENFHE=1)
+# ==============================================================================
 
 OPENFHE_CMAKE_FLAGS = \
 	-DBUILD_SHARED=ON \
@@ -143,97 +179,78 @@ OPENFHE_CMAKE_FLAGS = \
 	-DWITH_CPROBES=ON \
 	-DWITH_OPENMP=OFF
 
-# RYANPR: Think about a way to make all these `X` and `X-release` targets modular, since otherwise we are repeating code all the time. Essentially there should be a build directory, a build symbol (Debug/Release), and you can pipe those through the appropriate places. `set-build-config` kinda does parts of this but doesn't seem to use them. Apply to all targets that this works agains (config, config-openfhe, build, build-openfhe, etc) Use a variable that defaults to one mode and override it on the command line. For example:
-#
-#   MODE ?= debug
-#   CFLAGS_debug   := -g -O0
-#   CFLAGS_release := -O2 -DNDEBUG
-#
-#   build:
-#         $(CC) $(CFLAGS_$(MODE)) -o app main.c
-config-openfhe: ## Configure OpenFHE (Debug)
+config-openfhe: ## Configure OpenFHE
 	@if [ ! -d "$(OPENFHE_DIR)" ]; then \
 		echo "ERROR: $(OPENFHE_DIR) is empty. Run 'make sync' first."; exit 2; \
 	fi
-	cd "$(OPENFHE_DIR)" && cmake -S . -B dbuild \
-		-DCMAKE_BUILD_TYPE=Debug \
+	cd "$(OPENFHE_DIR)" && cmake -S . -B "$(BUILD_DIR)" \
+		-DCMAKE_BUILD_TYPE=$(CMAKE_CONFIG) \
 		$(OPENFHE_CMAKE_FLAGS) \
 		-DCMAKE_INSTALL_PREFIX="$(OPENFHE_INSTALL_DIR)"
 
-config-openfhe-release: ## Configure OpenFHE (Release)
-	@if [ ! -d "$(OPENFHE_DIR)" ]; then \
-		echo "ERROR: $(OPENFHE_DIR) is empty. Run 'make sync' first."; exit 2; \
-	fi
-	cd "$(OPENFHE_DIR)" && cmake -S . -B build \
-		-DCMAKE_BUILD_TYPE=Release \
-		$(OPENFHE_CMAKE_FLAGS) \
-		-DCMAKE_INSTALL_PREFIX="$(OPENFHE_INSTALL_DIR)"
+build-openfhe: config-openfhe ## Build and install OpenFHE locally
+	cd "$(OPENFHE_DIR)" && cmake --build "$(BUILD_DIR)" -j $(NUM_CPUS) --target install --config $(CMAKE_CONFIG)
 
-build-openfhe: config-openfhe ## Build and install OpenFHE locally (Debug)
-	cd "$(OPENFHE_DIR)" && cmake --build dbuild -j $(NUM_CPUS) --target install --config Debug
+# ==============================================================================
+# Haze Build
+# ==============================================================================
 
-build-openfhe-release: config-openfhe-release ## Build and install OpenFHE locally (Release)
-	cd "$(OPENFHE_DIR)" && cmake --build build -j $(NUM_CPUS) --target install --config Release
-
-##@ Haze Build
-
-config: $(OPENFHE_BUILD_DEP_DEBUG) ## Configure haze (Debug)
-	$(call set-build-config,Debug,dbuild)
-	cmake -S "$(CURDIR)" -B "$(CURDIR)/dbuild" \
-		-DCMAKE_BUILD_TYPE=Debug \
+config: $(OPENFHE_BUILD_DEP) ## Configure haze (uses MODE)
+	cmake -S "$(CURDIR)" -B "$(CURDIR)/$(BUILD_DIR)" \
+		-DCMAKE_BUILD_TYPE=$(CMAKE_CONFIG) \
 		-DOPENFHE_INSTALL_DIR="$(OPENFHE_INSTALL_DIR)" \
 		$(CMAKE_FHETCH_DIR_FLAG) \
 		$(CMAKE_JSON_INCLUDE_DIR_FLAG)
 
-config-release: $(OPENFHE_BUILD_DEP_RELEASE) ## Configure haze (Release)
-	$(call set-build-config,Release,build)
-	cmake -S "$(CURDIR)" -B "$(CURDIR)/build" \
-		-DCMAKE_BUILD_TYPE=Release \
-		-DOPENFHE_INSTALL_DIR="$(OPENFHE_INSTALL_DIR)" \
-		$(CMAKE_FHETCH_DIR_FLAG) \
-		$(CMAKE_JSON_INCLUDE_DIR_FLAG)
+build: config ## Build haze (uses MODE)
+	cmake --build "$(BUILD_DIR)" -j $(NUM_CPUS) --config $(CMAKE_CONFIG)
 
-build: config ## Build haze (Debug)
-	$(call set-build-config,Debug,dbuild)
-	cmake --build dbuild -j $(NUM_CPUS) --config Debug
+# ==============================================================================
+# Haze Tests
+# ==============================================================================
 
-build-release: config-release ## Build haze (Release)
-	$(call set-build-config,Release,build)
-	cmake --build build -j $(NUM_CPUS) --config Release
-
-##@ Haze Tests
-
-# RYANPR: Why do the tests not run against the debug copy?
-test-unit-release: build-release ## Run the haze unit suite (HAZE_TARGET=local; no compiler dep)
-	$(call set-build-config,Release,build)
+test-unit: build ## Run unit suite (HAZE_TARGET=local; no FHE math)
 	@rm -rf "$(HAZE_RUNS_DIR)/haze"
 	@mkdir -p "$(HAZE_RUNS_DIR)"
 	@cd "$(HAZE_RUNS_DIR)" && \
-	  HAZE_TARGET=local "$(CURDIR)/build/haze_tests" "~[integration]"
+	  HAZE_TARGET=local "$(CURDIR)/$(BUILD_DIR)/haze_tests" "~[integration]"
 
-test-integration-release: build-release ## End-to-end haze integration tests (direct nbcc_fhetch_replay invocation; no HTTP transport)
-	$(call set-build-config,Release,build)
+test-sim: build ## Run sim suite (in-process fhetch_sim; validates FHE math)
+	@rm -rf "$(HAZE_RUNS_DIR)/haze"
+	@mkdir -p "$(HAZE_RUNS_DIR)"
+	@cd "$(HAZE_RUNS_DIR)" && \
+	  HAZE_TARGET=$(FHETCH_SIM_TARGET) "$(CURDIR)/$(BUILD_DIR)/haze_tests" "[integration]"
+
+test-transport: build ## Run integration suite via nbcc_fhetch_replay (opt-in)
+	@if [ -z "$(NIOBIUM_COMPILER_ROOT)" ]; then \
+		echo "ERROR: NIOBIUM_COMPILER_ROOT is not set."; \
+		echo "Run: make test-transport NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler"; \
+		exit 2; \
+	fi
 	@if [ ! -x "$(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay" ]; then \
 		echo "ERROR: nbcc_fhetch_replay not found at $(NIOBIUM_COMPILER_ROOT)/build/nbcc_fhetch_replay"; \
 		echo "Build it with: (cd $(NIOBIUM_COMPILER_ROOT) && make release)"; \
-		echo "Or override:   make test-integration-release NIOBIUM_COMPILER_ROOT=/path/to/niobium-compiler"; \
 		exit 2; \
 	fi
-	@HAZE_TEST_BIN="$(CURDIR)/build/haze_tests" \
+	@HAZE_TEST_BIN="$(CURDIR)/$(BUILD_DIR)/haze_tests" \
 	 NIOBIUM_COMPILER_ROOT="$(NIOBIUM_COMPILER_ROOT)" \
 	 OPENFHE_LIB="$(OPENFHE_INSTALL_DIR)/lib" \
 	 HAZE_RUNS_DIR="$(HAZE_RUNS_DIR)" \
+	 HAZE_TRANSPORT_TARGET=FUNC_SIM \
 	 scripts/test_haze_integration_standalone.sh
 
-test-release: test-unit-release test-integration-release ## Run all haze tests (unit + standalone integration)
+test: test-unit test-sim ## Run default test suites (no transport dependency)
 
-##@ Cleanup
+test-all: test-unit test-sim test-transport ## Run everything (incl. transport path)
+
+# ==============================================================================
+# Cleanup
+# ==============================================================================
 
 clean-runs: ## Remove haze test runs/ artifacts (keeps build outputs intact)
 	-rm -rf "$(CURDIR)/build/runs" "$(CURDIR)/dbuild/runs"
 
-# RYANPR: Should this not use clean-runs as a dependency?
-clean: ## Remove all build artifacts (keeps vendor/ checkouts; refuses to touch external trees pointed at via NIOBIUM_HAZE_FHETCH_DIR or EXTERNAL_OPENFHE)
+clean: clean-runs ## Remove all build artifacts (keeps vendor/ checkouts; refuses to touch external trees pointed at via NIOBIUM_HAZE_FHETCH_DIR or EXTERNAL_OPENFHE)
 	-rm -rf "$(CURDIR)/build" "$(CURDIR)/dbuild"
 	@if [ "$(EXTERNAL_OPENFHE)" != "1" ]; then \
 	  case "$(OPENFHE_DIR)" in \

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ Usage: make <target> [MODE=debug|release]
 
   Test:
     test-unit           Run unit suite (HAZE_TARGET=local; no FHE math)
-    test-sim            Run sim suite (in-process fhetch_sim)
+    test-sim            Run sim suite (HAZE_TARGET=local; in-process simulator)
     test-transport      Run integration suite via nbcc_fhetch_replay
                         (requires NIOBIUM_COMPILER_ROOT)
     test                Default: test-unit + test-sim
@@ -208,13 +208,13 @@ test-unit: build ## Run unit suite (HAZE_TARGET=local; no FHE math)
 	@cd "$(HAZE_RUNS_DIR)" && \
 	  HAZE_TARGET=local "$(CURDIR)/$(BUILD_DIR)/haze_tests" "~[integration]"
 
-test-sim: build ## Run sim suite (in-process fhetch_sim; validates FHE math)
+test-sim: build ## Run sim suite (in-process FHETCH simulator; validates FHE math)
 	@rm -rf "$(HAZE_RUNS_DIR)/haze"
 	@mkdir -p "$(HAZE_RUNS_DIR)"
-	@# Target literal must match haze::kFhetchSimTarget in src/core/config.hpp
+	@# Target literal must match haze::kLocalTarget in src/core/config.hpp
 	@# AND the haze_sim_tests ENVIRONMENT entry in CMakeLists.txt.
 	@cd "$(HAZE_RUNS_DIR)" && \
-	  HAZE_TARGET=fhetch_sim "$(CURDIR)/$(BUILD_DIR)/haze_tests" "[integration]"
+	  HAZE_TARGET=local "$(CURDIR)/$(BUILD_DIR)/haze_tests" "[integration]"
 
 test-transport: build ## Run integration suite via nbcc_fhetch_replay (opt-in)
 	@if [ -z "$(NIOBIUM_COMPILER_ROOT)" ]; then \

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,9 @@
 
               export CMAKE_PREFIX_PATH="$_niobium_vendor''${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
               export LD_LIBRARY_PATH="$_openfhe_vendor/lib:$_replay_lib:$_photov_lib:$_ntl_lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+              # Re-export so subshells / scripts launched from the dev
+              # shell skip the upward walk.
+              export HAZE_ROOT="$_haze_root"
               unset _haze_root _niobium_root _niobium_vendor _openfhe_vendor _replay_lib _photov_lib _ntl_lib
               echo "haze dev shell ready (clang 19, cmake, jj)."
               echo "Build: cmake -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --parallel"

--- a/flake.nix
+++ b/flake.nix
@@ -62,17 +62,6 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           llvm = pkgs.llvmPackages_19;
-
-          # Paths inside the niobium-compiler submodule. These pick up the
-          # in-tree build artifacts produced by `make build` /
-          # `make build-release` over in vendor/niobium-compiler.
-          niobiumRoot = toString ./vendor/niobium-compiler;
-          niobiumVendor = "${niobiumRoot}/vendor/lib/niobium-compiler";
-          openfheVendor = "${niobiumRoot}/vendor/lib/openfhe";
-          # Transitive runtime deps of libnbcc (not installed to vendor, built in-tree)
-          replayLib = "${niobiumRoot}/build";
-          photovLib = "${niobiumRoot}/deps/photovoltaic/dbuild";
-          ntlLib = "${niobiumRoot}/deps/photovoltaic/dbuild/ntl/lib";
         in {
           default = pkgs.mkShell {
             name = "haze-dev";
@@ -85,9 +74,45 @@
               pkgs.catch2_3
             ];
 
+            # The haze repo's vendored niobium-compiler / niobium-fhetch
+            # submodules carry in-tree build artefacts (build/, deps/...)
+            # that the dev shell needs on CMAKE_PREFIX_PATH /
+            # LD_LIBRARY_PATH. We resolve the worktree root at hook time
+            # rather than baking ./vendor/... into the derivation: the
+            # latter would coerce the path into a /nix/store/<hash>-source
+            # snapshot (no in-tree build outputs) AND emit
+            # `builtins.derivation … without a proper context` warnings
+            # under recent nix.
+            #
+            # Resolution order: $HAZE_ROOT (caller override) -> the
+            # closest enclosing flake.nix from $PWD. Errors loudly if
+            # neither resolves so a misplaced `nix develop` invocation
+            # fails fast instead of silently exporting empty paths.
             shellHook = ''
-              export CMAKE_PREFIX_PATH="${niobiumVendor}''${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
-              export LD_LIBRARY_PATH="${openfheVendor}/lib:${replayLib}:${photovLib}:${ntlLib}''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+              if [ -n "''${HAZE_ROOT:-}" ]; then
+                _haze_root="$HAZE_ROOT"
+              else
+                _haze_root="$PWD"
+                while [ "$_haze_root" != "/" ] && [ ! -f "$_haze_root/flake.nix" ]; do
+                  _haze_root="$(dirname "$_haze_root")"
+                done
+              fi
+              if [ ! -f "$_haze_root/flake.nix" ]; then
+                echo "haze devshell: cannot locate haze repo root from $PWD." >&2
+                echo "haze devshell: set HAZE_ROOT or run 'nix develop' from inside the haze tree." >&2
+                return 1
+              fi
+
+              _niobium_root="$_haze_root/vendor/niobium-compiler"
+              _niobium_vendor="$_niobium_root/vendor/lib/niobium-compiler"
+              _openfhe_vendor="$_niobium_root/vendor/lib/openfhe"
+              _replay_lib="$_niobium_root/build"
+              _photov_lib="$_niobium_root/deps/photovoltaic/dbuild"
+              _ntl_lib="$_photov_lib/ntl/lib"
+
+              export CMAKE_PREFIX_PATH="$_niobium_vendor''${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
+              export LD_LIBRARY_PATH="$_openfhe_vendor/lib:$_replay_lib:$_photov_lib:$_ntl_lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+              unset _haze_root _niobium_root _niobium_vendor _openfhe_vendor _replay_lib _photov_lib _ntl_lib
               echo "haze dev shell ready (clang 19, cmake, jj)."
               echo "Build: cmake -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --parallel"
             '';

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -109,6 +109,36 @@ HAZE_API hazeError_t hazeSetProgramInfo(const char* name, const char* version,
  * variable when this function is not called. */
 HAZE_API hazeError_t hazeSetTarget(const char* target) HAZE_NOEXCEPT;
 
+/* Trigger replay of the recorded operations.
+ *
+ * Finalises the current epoch's .fhetch trace and dispatches it for
+ * execution. Behaviour depends on the configured target:
+ *
+ * RYANPR: It is not obvious how to set the target.
+ *   target == "local":
+ *     Trace-only mode. Produces <program_dir>/epoch_N/<name>.fhetch
+ *     and returns success. Host shadow buffers are NOT updated, so
+ *     subsequent hazeMemcpy(D2H) calls return whatever the buffers
+ *     held before compute (typically the H2D inputs). Used for
+ *     verifying recording correctness without the FHE pipeline.
+ *
+ *   target != "local":
+ *     The FHETCH project is uploaded over the HTTP transport
+ *     (see niobium-client/scripts/fhetch_server.sh) to a
+ *     niobium-compiler-built nbcc_fhetch_replay running with the
+ *     OpenFHE simulator. The simulator's outputs are written back
+ *     into host shadow buffers for every recorded compute output,
+ *     after which hazeMemcpy(D2H) returns the computed values.
+ *
+ *     Callers in this mode must arrange the transport (server +
+ *     client-side forwarder on PATH, NBCC_FHETCH_SERVER set) before
+ *     this call. See niobium-client/scripts/test_transport_mult.sh
+ *     for the canonical orchestration pattern.
+ *
+ * Calling hazeReplay() with no recording in progress is a no-op
+ * returning HAZE_SUCCESS. */
+HAZE_API hazeError_t hazeReplay(void) HAZE_NOEXCEPT;
+
 // Streams: lifecycle and ordering primitives. HAZE is a recording layer
 // that emits FHETCH IR; nothing executes until hazeMemcpy(D2H) flushes
 // the recording. Stream-relative ordering is therefore not modelled,

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -104,16 +104,10 @@ HAZE_API hazeError_t hazeSetProgramInfo(const char* name, const char* version,
 
 /* Select the niobium-compiler target for replay.
  *
- * Targets fall into three tiers by where they execute:
+ * Targets fall into two tiers by where they execute:
  *
- *   1. Trace-only (no execution):
- *        "local"        Produces .fhetch artifacts only;
- *                       hazeMemcpy(D2H) returns whatever the shadow
- *                       buffer held before compute. Use when only
- *                       validating recording correctness.
- *
- *   2. In-process FHETCH simulator (DEFAULT):
- *        "fhetch_sim"   libnbfhetch loads the .fhetch trace into its
+ *   1. In-process FHETCH simulator (DEFAULT):
+ *        "local"        libnbfhetch loads the .fhetch trace into its
  *                       in-process instruction-set simulator,
  *                       executes it, and writes ciphertext probes
  *                       under <program_dir>/serialized_probes/.
@@ -121,10 +115,12 @@ HAZE_API hazeError_t hazeSetProgramInfo(const char* name, const char* version,
  *                       values. No compiler-side binary or HTTP
  *                       transport required.
  *
- *   3. Compiler-side simulators via HTTP transport:
+ *   2. Compiler-side simulators via HTTP transport:
  *        "FHE_SIM"      OpenFHE simulator via nbcc_fhetch_replay.
  *        "FUNC_SIM"     Functional simulator.
  *        "FPGA_TRI"     FPGA target.
+ *        "fhetch_sim"   FHETCH instruction-set simulator on the
+ *                       compiler side.
  *                       These dispatch the recorded project over the
  *                       HTTP transport (see niobium-client/scripts/
  *                       fhetch_server.sh) and require a built
@@ -134,7 +130,7 @@ HAZE_API hazeError_t hazeSetProgramInfo(const char* name, const char* version,
  * Resolution order:
  *   1. hazeSetTarget(target)  - explicit programmatic call.
  *   2. HAZE_TARGET env var    - read on first hazeReplay if (1) unset.
- *   3. "fhetch_sim"           - default if both above are unset.
+ *   3. "local"                - default if both above are unset.
  *
  * See hazeReplay() for behaviour-by-target dispatch. */
 HAZE_API hazeError_t hazeSetTarget(const char* target) HAZE_NOEXCEPT;
@@ -143,11 +139,10 @@ HAZE_API hazeError_t hazeSetTarget(const char* target) HAZE_NOEXCEPT;
  *
  * Finalises the current epoch's .fhetch trace and dispatches it
  * according to the configured target (see hazeSetTarget for the
- * three-tier table and resolution order). At a glance:
+ * two-tier table and resolution order). At a glance:
  *
- *   target == "local":      no execution; shadow buffers untouched.
- *   target == "fhetch_sim": in-process simulator populates shadows.
- *   target == <other>:      HTTP transport to nbcc_fhetch_replay.
+ *   target == "local":   in-process simulator populates shadows.
+ *   target == <other>:   HTTP transport to nbcc_fhetch_replay.
  *
  * Calling hazeReplay() with no recording in progress is a no-op
  * returning HAZE_SUCCESS. */

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -102,38 +102,52 @@ HAZE_API hazeError_t hazeConfigureDevice(void) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeSetProgramInfo(const char* name, const char* version,
                                           const char* description) HAZE_NOEXCEPT;
 
-/* Select the niobium-compiler target for replay. Supported target IDs
- * are owned by niobium-compiler (see devices/<id>/spec.yaml in that
- * repository). Common values: "FHE_SIM" (default), "FHETCH_SIM",
- * "FUNC_SIM", "FPGA_TRI". Falls back to the HAZE_TARGET environment
- * variable when this function is not called. */
+/* Select the niobium-compiler target for replay.
+ *
+ * Targets fall into three tiers by where they execute:
+ *
+ *   1. Trace-only (no execution):
+ *        "local"        Produces .fhetch artifacts only;
+ *                       hazeMemcpy(D2H) returns whatever the shadow
+ *                       buffer held before compute. Use when only
+ *                       validating recording correctness.
+ *
+ *   2. In-process FHETCH simulator (DEFAULT):
+ *        "fhetch_sim"   libnbfhetch loads the .fhetch trace into its
+ *                       in-process instruction-set simulator,
+ *                       executes it, and writes ciphertext probes
+ *                       under <program_dir>/serialized_probes/.
+ *                       hazeMemcpy(D2H) returns simulator-computed
+ *                       values. No compiler-side binary or HTTP
+ *                       transport required.
+ *
+ *   3. Compiler-side simulators via HTTP transport:
+ *        "FHE_SIM"      OpenFHE simulator via nbcc_fhetch_replay.
+ *        "FUNC_SIM"     Functional simulator.
+ *        "FPGA_TRI"     FPGA target.
+ *                       These dispatch the recorded project over the
+ *                       HTTP transport (see niobium-client/scripts/
+ *                       fhetch_server.sh) and require a built
+ *                       nbcc_fhetch_replay binary on PATH plus a
+ *                       running FHETCH server.
+ *
+ * Resolution order:
+ *   1. hazeSetTarget(target)  - explicit programmatic call.
+ *   2. HAZE_TARGET env var    - read on first hazeReplay if (1) unset.
+ *   3. "fhetch_sim"           - default if both above are unset.
+ *
+ * See hazeReplay() for behaviour-by-target dispatch. */
 HAZE_API hazeError_t hazeSetTarget(const char* target) HAZE_NOEXCEPT;
 
 /* Trigger replay of the recorded operations.
  *
- * Finalises the current epoch's .fhetch trace and dispatches it for
- * execution. Behaviour depends on the configured target:
+ * Finalises the current epoch's .fhetch trace and dispatches it
+ * according to the configured target (see hazeSetTarget for the
+ * three-tier table and resolution order). At a glance:
  *
- * RYANPR: It is not obvious how to set the target.
- *   target == "local":
- *     Trace-only mode. Produces <program_dir>/epoch_N/<name>.fhetch
- *     and returns success. Host shadow buffers are NOT updated, so
- *     subsequent hazeMemcpy(D2H) calls return whatever the buffers
- *     held before compute (typically the H2D inputs). Used for
- *     verifying recording correctness without the FHE pipeline.
- *
- *   target != "local":
- *     The FHETCH project is uploaded over the HTTP transport
- *     (see niobium-client/scripts/fhetch_server.sh) to a
- *     niobium-compiler-built nbcc_fhetch_replay running with the
- *     OpenFHE simulator. The simulator's outputs are written back
- *     into host shadow buffers for every recorded compute output,
- *     after which hazeMemcpy(D2H) returns the computed values.
- *
- *     Callers in this mode must arrange the transport (server +
- *     client-side forwarder on PATH, NBCC_FHETCH_SERVER set) before
- *     this call. See niobium-client/scripts/test_transport_mult.sh
- *     for the canonical orchestration pattern.
+ *   target == "local":      no execution; shadow buffers untouched.
+ *   target == "fhetch_sim": in-process simulator populates shadows.
+ *   target == <other>:      HTTP transport to nbcc_fhetch_replay.
  *
  * Calling hazeReplay() with no recording in progress is a no-op
  * returning HAZE_SUCCESS. */

--- a/replay_bridge/CMakeLists.txt
+++ b/replay_bridge/CMakeLists.txt
@@ -1,0 +1,52 @@
+# haze_replay_bridge — OpenFHE-using helper that synthesizes the CryptoContext
+# + ciphertext templates the compiler-side nbcc_fhetch_replay needs to write
+# serialized_probes/ from a haze recording. Linked exclusively by haze_tests
+# (and any other test/replay harness); never by libhaze itself.
+
+add_library(haze_replay_bridge SHARED
+  src/openfhe_template.cpp
+  # Shared with libhaze. Each library compiles its own copy because the
+  # function is hidden-visibility on both sides; no exported symbol means
+  # no cross-library collision when haze_tests links both.
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src/common/log.cpp
+)
+
+target_include_directories(haze_replay_bridge
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    # haze_types.h (for hazeError_t, HAZE_API, HAZE_NOEXCEPT)
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    # common/log.hpp lives under haze's src/.
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+)
+
+# Niobium::fhetch supplies <niobium/compiler.h> and (transitively, via
+# BUILD_INTERFACE include dirs) the OpenFHE headers. Linking publicly so
+# downstream test executables that pull haze_replay_bridge in as a PRIVATE
+# dep still resolve OpenFHE symbols at link time.
+target_link_libraries(haze_replay_bridge PUBLIC Niobium::fhetch)
+
+set_target_properties(haze_replay_bridge PROPERTIES
+  CXX_VISIBILITY_PRESET     hidden
+  VISIBILITY_INLINES_HIDDEN ON
+  OUTPUT_NAME               haze_replay_bridge
+)
+
+target_compile_definitions(haze_replay_bridge PRIVATE HAZE_BUILDING_LIBRARY)
+
+# OpenFHE headers trip the strict warning-set haze adds at the parent
+# directory level (-Werror -Wpedantic -Wshadow -Wconversion -Wunused-parameter
+# implicit in -Wextra). Same accommodation niobium-fhetch's own CMakeLists
+# already makes for the niobium_fhetch library. We narrow the override to
+# this target so haze proper keeps strict diagnostics.
+target_compile_options(haze_replay_bridge PRIVATE
+  -Wno-unused-parameter
+  -Wno-shadow
+  -Wno-conversion
+  -Wno-pedantic
+  -Wno-ignored-qualifiers
+  -Wno-missing-field-initializers
+  -Wno-deprecated-declarations
+)

--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -17,8 +17,8 @@
 //      simulator-computed polynomial values and re-serializes to
 //      <program_dir>/serialized_probes/<name>.ct.
 //
-// Same artifact shapes are consumed by both the in-process fhetch_sim
-// path (HAZE_TARGET=fhetch_sim, libnbfhetch fills + serializes the
+// Same artifact shapes are consumed by both the in-process simulator
+// path (HAZE_TARGET=local, libnbfhetch fills + serializes the
 // templates) AND the HTTP transport path (HAZE_TARGET=FUNC_SIM etc.,
 // nbcc_fhetch_replay does the same). The bridge is therefore agnostic
 // to which replay tier the caller selects.
@@ -38,7 +38,7 @@
 //     // automatically inside hazeReplay() via a post-recording hook the
 //     // bridge registers during InitCryptoContext. Tests just compute and
 //     // call hazeReplay().
-//     hazeReplay();   // in-process fhetch_sim or transport, both work
+//     hazeReplay();   // in-process simulator or transport, both work
 
 #ifndef HAZE_REPLAY_BRIDGE_H
 #define HAZE_REPLAY_BRIDGE_H

--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -1,0 +1,79 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+//
+// haze_replay_bridge — OpenFHE-using helper that synthesizes the artifacts
+// the compiler-side nbcc_fhetch_replay needs to produce serialized_probes/
+// from a haze recording. Specifically:
+//
+//   1. <program_dir>/cryptocontext.dat
+//      A minimal CKKS CryptoContext<DCRTPoly> matching haze's configured
+//      ring dimension and (single) modulus.
+//
+//   2. <program_dir>/ciphertext_templates/<name>.template
+//      An empty Ciphertext<DCRTPoly> shell that the compiler-side driver
+//      fills with simulator-computed polynomial values, then re-serializes
+//      to <program_dir>/serialized_probes/<name>.ct.
+//
+// The bridge is laser-decoupled from haze proper: haze stays FHETCH-only;
+// the bridge links OpenFHE (transitively, via Niobium::fhetch) and is
+// linked exclusively by haze_tests, never by libhaze itself.
+//
+// Usage (in an integration test):
+//
+//     // Once per program directory: build CC, learn the picked modulus.
+//     uint64_t picked = 0;
+//     hazeReplayBridgeInitCryptoContext(kRingDim, kDesiredModulus, &picked);
+//     hazeSetCiphertextModulus(kModIdx, picked);
+//
+//     // Per-input .bin / .ids and per-output .template files are written
+//     // automatically inside hazeReplay() via a post-recording hook the
+//     // bridge registers during InitCryptoContext. Tests just compute and
+//     // call hazeReplay().
+//     hazeReplay();   // dispatches via transport, reads .ct from compiler
+
+#ifndef HAZE_REPLAY_BRIDGE_H
+#define HAZE_REPLAY_BRIDGE_H
+
+#include <haze/haze_types.h>
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Build a single-limb CKKS CryptoContext targeting the given ring dimension
+/// and modulus, and serialize it to <program_dir>/cryptocontext.dat.
+///
+/// OpenFHE chooses the actual tower modulus from primes near 2^bits(modulus),
+/// so the picked modulus may differ from the requested one. The picked value
+/// is returned via `picked_modulus` (must be non-null) so callers can align
+/// haze's configured modulus with what the .ct files will use on round-trip
+/// (call hazeSetCiphertextModulus with this value).
+///
+/// Subsequent calls with the same (ring_dim, desired_modulus) reuse the
+/// cached CryptoContext. Calls with different parameters rebuild it; the
+/// previously serialized cryptocontext.dat is overwritten.
+///
+/// niobium::compiler() must already be initialized (i.e. at least one haze
+/// compute call must have happened, or hazeConfigureDevice / hazeReplay
+/// must have been called) so the program directory resolves correctly.
+///
+/// Must be called AFTER every hazeDeviceReset(): reset clears the post-
+/// recording hook this function registers, and without re-registration
+/// hazeReplay() ships an incomplete project (no .bin / .ids / .template
+/// files), which the compiler-side rejects. The setup_integration_compute_config
+/// helper enforces this ordering automatically.
+HAZE_API hazeError_t hazeReplayBridgeInitCryptoContext(
+    uint64_t  ring_dim,
+    uint64_t  desired_modulus,
+    uint64_t* picked_modulus) HAZE_NOEXCEPT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // HAZE_REPLAY_BRIDGE_H

--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -5,17 +5,23 @@
 // Inc. (a "License Agreement").
 //
 // haze_replay_bridge — OpenFHE-using helper that synthesizes the artifacts
-// the compiler-side nbcc_fhetch_replay needs to produce serialized_probes/
-// from a haze recording. Specifically:
+// downstream replay paths need to produce serialized_probes/ from a haze
+// recording. Specifically:
 //
 //   1. <program_dir>/cryptocontext.dat
 //      A minimal CKKS CryptoContext<DCRTPoly> matching haze's configured
 //      ring dimension and (single) modulus.
 //
 //   2. <program_dir>/ciphertext_templates/<name>.template
-//      An empty Ciphertext<DCRTPoly> shell that the compiler-side driver
-//      fills with simulator-computed polynomial values, then re-serializes
-//      to <program_dir>/serialized_probes/<name>.ct.
+//      An empty Ciphertext<DCRTPoly> shell. The replay path fills it with
+//      simulator-computed polynomial values and re-serializes to
+//      <program_dir>/serialized_probes/<name>.ct.
+//
+// Same artifact shapes are consumed by both the in-process fhetch_sim
+// path (HAZE_TARGET=fhetch_sim, libnbfhetch fills + serializes the
+// templates) AND the HTTP transport path (HAZE_TARGET=FUNC_SIM etc.,
+// nbcc_fhetch_replay does the same). The bridge is therefore agnostic
+// to which replay tier the caller selects.
 //
 // The bridge is laser-decoupled from haze proper: haze stays FHETCH-only;
 // the bridge links OpenFHE (transitively, via Niobium::fhetch) and is
@@ -32,7 +38,7 @@
 //     // automatically inside hazeReplay() via a post-recording hook the
 //     // bridge registers during InitCryptoContext. Tests just compute and
 //     // call hazeReplay().
-//     hazeReplay();   // dispatches via transport, reads .ct from compiler
+//     hazeReplay();   // in-process fhetch_sim or transport, both work
 
 #ifndef HAZE_REPLAY_BRIDGE_H
 #define HAZE_REPLAY_BRIDGE_H

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -6,67 +6,85 @@
 //
 // haze_replay_bridge implementation: synthesize the CryptoContext +
 // per-input cereal-binary .bin files + per-output ciphertext templates that
-// the compiler-side nbcc_fhetch_replay needs in order to write
-// serialized_probes/ from a haze recording. See replay_bridge.h for the
-// public API and architectural rationale.
+// the in-process fhetch_sim AND compiler-side nbcc_fhetch_replay both
+// consume to write serialized_probes/<name>.ct from a haze recording.
+// See replay_bridge.h for the public API and architectural rationale.
+//
+// Thread-safety: the bridge is called only from haze's epoch path, which
+// already holds EpochState::mutex_, and from haze tests (single-threaded
+// catch2 runner). Bridge state is therefore implicitly serialized; no
+// internal lock needed.
 
 #include <haze/replay_bridge.h>
 
-// RYANPR: Lint that all of these includes are needed.
 #include "openfhe.h"
 #include "ciphertext-ser.h"
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
 #include "scheme/ckksrns/ckksrns-ser.h"
 
+#include "common/log.hpp"
+
 #include <niobium/compiler.h>
 
 #include <bit>
+#include <cassert>
 #include <cstdint>
+#include <expected>
 #include <filesystem>
 #include <functional>
-#include <iostream>
 #include <map>
-#include <mutex>
+#include <sstream>
 #include <string>
 #include <vector>
 
 // libnbfhetch internal helpers used by the bridge. Forward-declared here
-// rather than pulled in via "compiler_internal.h" because:
+// rather than via "compiler_internal.h" because that header lives under
+// libnbfhetch's PRIVATE src/ tree and including it from a downstream
+// library would couple the bridge to libnbfhetch's source layout.
 //
-// RYANPR: This seems like something that could cause a drift when fhetch drifts. Maybe fhetch needs to make whatever parts public.
-//   1. compiler_internal.h is part of libnbfhetch's PRIVATE include tree
-//      (it lives under src/, not include/) and is intended for libnbfhetch's
-//      own translation units. Including it from a downstream library would
-//      add a dependency on libnbfhetch's source layout that the bridge's
-//      target_include_directories doesn't currently express.
-//
-// RYANPR: This seems like a hack. Were these types added by our custom changes to FHETCH anyway? If so, we should look into how the niobium-client handles writing ciphertexts and if not modify our changes to make these APIs public.
-//   2. The cereal polymorphic-type registry is per-shared-library —
-//      calling lbcrypto::Serial::SerializeToFile from this TU directly
-//      trips "unregistered polymorphic type (lbcrypto::CryptoContextImpl<...>)".
-//      Routing the writes through libnbfhetch's own TU (where the auto-facade
-//      already includes ciphertext-ser.h / cryptocontext-ser.h and forces
-//      static initialisation) is the cleanest fix; the extern declarations
-//      below reach those entry points without exposing the full Impl layout.
-//
-// If libnbfhetch ever publishes a stable C++ public API for these
-// operations, replace these externs with that header include.
+// TODO(fhetch-publish): the four detail symbols below resolve in
+// libnbfhetch's TU because cereal polymorphic-type registrations are
+// per-shared-library — calling lbcrypto::Serial::SerializeToFile from
+// here directly would trip "unregistered polymorphic type" on
+// CryptoContextImpl / Ciphertext. Long-term, ask niobium-fhetch to
+// publish a stable C++ API for write_ciphertext_template,
+// write_ciphertext_input_bin, for_each_captured_input, and
+// for_each_captured_output, then replace the externs with that header
+// include. niobium-client's auto-facade routes through the same
+// libnbfhetch TU (auto_facade.cpp's serialize helpers) so a published
+// API would also let niobium-client drop its own forwarder shims.
 namespace niobium::detail {
+
+// Serialize an empty Ciphertext<DCRTPoly> shell to
+// <program_dir>/ciphertext_templates/<name>.template. The replay path
+// (in-process fhetch_sim or transport) deserializes this template,
+// fills its first NativePoly with computed values, and re-serializes
+// it as serialized_probes/<name>.ct.
 bool write_ciphertext_template(
     const std::string& name,
     const lbcrypto::Ciphertext<lbcrypto::DCRTPoly>& ct);
-// RYANPR: Double check that the ciphertext bin is not just the serialized polynomial in some order (lsb/msb, which limb is which level, etc). We would remove the need for this if serialization is really just the raw bytes in order.
+
+// Serialize a populated Ciphertext<DCRTPoly> as the cereal-binary
+// {.bin, .ids} pair the compiler-side fhetch_driver expects for an
+// input named `name`.
 bool write_ciphertext_input_bin(
     const std::string& name,
     const lbcrypto::Ciphertext<lbcrypto::DCRTPoly>& ct,
     const std::vector<uint64_t>& addr_ids);
-// RYANPR: Add a description to what each of these functions is (for the ones you end up keeping)
+
+// Iterate every captured input recorded via fhetch::tag_input. The
+// callback receives (name, addr_id, modulus, values) for each per-name
+// element so the bridge can fan-out a single ciphertext per name.
 void for_each_captured_input(
     const std::function<void(const std::string&, uint64_t, uint64_t,
                               const std::vector<uint64_t>&)>& cb);
+
+// Iterate every captured output name recorded via fhetch::tag_output.
+// Callback fires once per output name.
 void for_each_captured_output(
     const std::function<void(const std::string&)>& cb);
+
 }  // namespace niobium::detail
 
 namespace {
@@ -74,12 +92,26 @@ namespace {
 namespace fs = std::filesystem;
 using DCRTPoly = lbcrypto::DCRTPoly;
 
+// BridgeError surfaces specific failure modes from the C-ABI entry to
+// help callers diagnose synthesis issues. Lives in this file (rather
+// than a header) because there's exactly one caller and one
+// implementation TU.
+enum class BridgeError {
+    InvalidRingDim,
+    InvalidModulus,
+    KeygenFailed,
+    OpenFheUnavailable,
+};
+
 // Per-process cache: same (ring_dim, desired_modulus) reuses the same
 // CryptoContext + keypair across cryptocontext.dat, every template, and
 // every input bin. OpenFHE resolves Ciphertext<->CryptoContext bindings
-// through a static tag registry on deserialize; sharing the CC keeps the
-// tag stable. The keypair is needed only as a structural carrier for
-// Encrypt() — we never decrypt.
+// through a static tag registry on deserialize; sharing the CC keeps
+// the tag stable.
+//
+// The keypair stays cached even though we don't decrypt — Encrypt()
+// needs a publicKey to produce a structurally valid Ciphertext<DCRTPoly>.
+// See TODO(haze:no-keygen) below.
 struct CachedContext {
     uint64_t ring_dim = 0;
     uint64_t desired_modulus = 0;
@@ -88,63 +120,78 @@ struct CachedContext {
     lbcrypto::KeyPair<DCRTPoly> keys;
 };
 
-// RYANPR: Why do we need a mutex for this simple application? This seems overengineered.
 CachedContext g_ctx;
-std::mutex    g_ctx_mu;
 
-// RYANPR: Since this is just bit_width name it bit_width_including_zero or something. I'm also not sure we ever get a modulus of zero; they should all be primes...
-// Number of bits needed to represent `modulus` (i.e. `floor(log2(modulus))
-// + 1`). Used to size the prime OpenFHE picks. C++20 std::bit_width
-// handles edge cases (2^63 returns 64) that an iterative shift loop
-// silently truncates.
-uint32_t bits_of(uint64_t modulus) {
-    return modulus == 0 ? 0 : static_cast<uint32_t>(std::bit_width(modulus));
+// Number of bits needed to represent a CKKS prime modulus. Modulus is
+// asserted >= 2 because OpenFHE's GenCryptoContext rejects smaller
+// values upstream and the bridge's only caller path has already
+// validated the input. std::bit_width handles 2^63 cleanly (returns 64)
+// where an iterative shift would silently truncate.
+uint32_t bit_width_for_modulus(uint64_t modulus) {
+    assert(modulus >= 2);
+    return static_cast<uint32_t>(std::bit_width(modulus));
 }
 
-// Build (or rebuild) the cached CryptoContext to match (ring_dim,
-// desired_modulus). Returns true on success; populates g_ctx.
-bool rebuild_context_locked(uint64_t ring_dim, uint64_t desired_modulus) {
+// Build (or rebuild) the cached CryptoContext + keypair to match
+// (ring_dim, desired_modulus). Returns success on cache hit (already
+// correct shape) or after a successful rebuild; returns a structured
+// BridgeError otherwise so the caller can map to the matching
+// hazeError_t.
+std::expected<void, BridgeError>
+rebuild_context_locked(uint64_t ring_dim, uint64_t desired_modulus) {
     using namespace lbcrypto;
-    // RYANPR: Make this return a better error type with an enum or whatever so we can know what the error is. The ring dimension check makes sense to me, but the modulus check I don't understand.
-    if (ring_dim == 0 || desired_modulus < 2) return false;
+    // Sanity gate: 0 or 1 are trivially malformed. Real CKKS NTT-
+    // friendly primes are ~60-bit; OpenFHE will reject other invalid
+    // choices deeper in GenCryptoContext.
+    if (ring_dim == 0)
+        return std::unexpected(BridgeError::InvalidRingDim);
+    if (desired_modulus < 2)
+        return std::unexpected(BridgeError::InvalidModulus);
 
     if (g_ctx.cc && g_ctx.ring_dim == ring_dim &&
         g_ctx.desired_modulus == desired_modulus) {
-        return true;
+        return {};  // cache hit
     }
 
     CCParams<CryptoContextCKKSRNS> p;
     p.SetSecurityLevel(HEStd_NotSet);  // toy: ring_dim is user-chosen
     p.SetRingDim(ring_dim);
-    // RYANPR: Make sure to note a TODO that we are only handling a single residue polynomial at the moment but that we may need to do something else later (so more than depth 0)
-    // Depth 0 produces a single-tower DCRTPoly chain so the synthesized
-    // template ciphertext has exactly two NativePoly slots (one per
-    // ciphertext element a, b). Trim element[1] before serializing
-    // (see synthesize_haze_ciphertext below) to land on a 1-NativePoly
-    // .bin matching haze's per-input addr_id count of one. Multi-residue
-    // support will need a different shape — see plan in replay_bridge.h.
+    // TODO(haze:multi-residue): SetMultiplicativeDepth(0) produces a
+    // single-tower DCRTPoly chain. Multi-residue paths (hazeModUp,
+    // hazeModDown) require depth > 0 and a fan of NativePolys per
+    // ciphertext element — see the failing integration tests in
+    // test/test_basis_convert.cpp at lines 117/245/291/331/381/443/757.
     p.SetMultiplicativeDepth(0);
-    const uint32_t bits = bits_of(desired_modulus);
-    p.SetScalingModSize(bits ? bits - 1 : 50);
-    p.SetFirstModSize(bits ? bits : 60);
-    // RYANPR: Fine for now, but why do we need this?
+    const uint32_t bits = bit_width_for_modulus(desired_modulus);
+    p.SetScalingModSize(bits - 1);
+    p.SetFirstModSize(bits);
+    // FIXEDMANUAL leaves rescale to the caller. At depth 0 with a
+    // single tower, OpenFHE's auto-rescale modes would inject extra
+    // modulus elements between operations and break the 1-NativePoly
+    // invariant the bridge depends on (synthesize_haze_ciphertext_locked
+    // assumes ct->GetElements()[0].GetAllElements().size() == 1).
     p.SetScalingTechnique(FIXEDMANUAL);
 
     auto cc = GenCryptoContext(p);
-    if (!cc) return false;
+    if (!cc)
+        return std::unexpected(BridgeError::OpenFheUnavailable);
     cc->Enable(PKE);
     cc->Enable(KEYSWITCH);
     cc->Enable(LEVELEDSHE);
 
-    // Cached keypair: needed by Encrypt() to produce a structurally valid
-    // Ciphertext<DCRTPoly>. One keygen per (ring_dim, desired_modulus)
-    // pair, reused across every template and every input bin.
-    // RYANPR: Do we actually need this? I assume the relay we are using asks for keys but also we are constructing dummy polynomials for our tests to see if basic operations work; they don't need encrypted values.
+    // TODO(haze:no-keygen): we keygen + Encrypt + trim only because
+    // OpenFHE doesn't expose a public no-key Ciphertext<DCRTPoly>
+    // constructor. The bridge never decrypts; the keygen is effectively
+    // structural ballast. If a public empty-ciphertext factory becomes
+    // available in OpenFHE (e.g. cc->NewCiphertext()), drop the keypair
+    // and the Encrypt round-trip in synthesize_haze_ciphertext_locked.
     auto keys = cc->KeyGen();
-    if (!keys.publicKey || !keys.secretKey) return false;
+    if (!keys.publicKey || !keys.secretKey)
+        return std::unexpected(BridgeError::KeygenFailed);
 
     auto element_params = cc->GetCryptoParameters()->GetElementParams();
-    if (!element_params || element_params->GetParams().empty()) return false;
+    if (!element_params || element_params->GetParams().empty())
+        return std::unexpected(BridgeError::OpenFheUnavailable);
     uint64_t picked = element_params->GetParams()[0]->GetModulus().ConvertToInt();
 
     g_ctx.ring_dim = ring_dim;
@@ -152,84 +199,76 @@ bool rebuild_context_locked(uint64_t ring_dim, uint64_t desired_modulus) {
     g_ctx.picked_modulus = picked;
     g_ctx.cc = cc;
     g_ctx.keys = keys;
-
-    // RYANPR: What does returning true mean
-    return true;
+    return {};
 }
 
-// Align niobium::compiler()'s program_info to haze's defaults BEFORE
-// reading get_program_directory().
-// RYANPR: Not sure why you need this, the tests should be able to set their own program info and use that.
-void align_program_info_to_haze() {
-    niobium::compiler().set_program_info("haze", "0.1", "HAZE runtime");
+// Map a BridgeError to the matching hazeError_t for the C ABI.
+hazeError_t to_haze_error(BridgeError e) {
+    switch (e) {
+        case BridgeError::InvalidRingDim:    return HAZE_ERROR_INVALID_VALUE;
+        case BridgeError::InvalidModulus:    return HAZE_ERROR_INVALID_VALUE;
+        case BridgeError::KeygenFailed:      return HAZE_ERROR_LAUNCH_FAILURE;
+        case BridgeError::OpenFheUnavailable: return HAZE_ERROR_LAUNCH_FAILURE;
+    }
+    return HAZE_ERROR_LAUNCH_FAILURE;
 }
 
-// Build a structurally valid 1-element / 1-tower Ciphertext<DCRTPoly> and
-// fill its first NativePoly with `values`. Caller passes pre-acquired
-// g_ctx_mu.
+// Build a 1-element / 1-tower Ciphertext<DCRTPoly> and fill its first
+// NativePoly with `values`. Returns the synthesized ciphertext.
+//
+// TODO(haze:no-keygen): bypass Encrypt + element[1] trim with a direct
+// public-API no-key construction once OpenFHE exposes one. See the
+// rebuild_context_locked TODO.
 lbcrypto::Ciphertext<DCRTPoly>
-synthesize_haze_ciphertext_locked(const std::vector<uint64_t>& values) {
+synthesize_haze_ciphertext(const std::vector<uint64_t>& values) {
     std::vector<double> zeros(g_ctx.ring_dim / 2, 0.0);
     auto pt = g_ctx.cc->MakeCKKSPackedPlaintext(zeros);
-    // RYANPR: I don't think we need actual encryption for the test. I really just want to check that the polynomial operations work. We know the ciphertext is a pair of polynomials; we could fill one with the one we want and one with zeros.
     auto ct = g_ctx.cc->Encrypt(g_ctx.keys.publicKey, pt);
     // Trim the RLWE pair (a, b) down to a 1-element ciphertext so the
     // .bin's NativePoly count matches haze's one-polynomial-per-input
     // model. element[1] would otherwise land in the .bin as Encrypt-noise
     // and the compiler-side would auto-allocate a colliding addr_id for
-    // it. els.resize(1) leaves the result not-decryptable, but we never
-    // decrypt — the compiler-side reads NativePoly values positionally,
-    // not via the CKKS API.
+    // it. The result is not-decryptable, but we never decrypt — the
+    // compiler-side reads NativePoly values positionally, not via the
+    // CKKS API.
     {
         auto& els = ct->GetElements();
         if (els.size() > 1) els.resize(1);
     }
-    // RYANPR: What are you guarding against here?
-    if (!values.empty() &&
-        ct->GetElements().size() > 0 &&
-        ct->GetElements()[0].GetAllElements().size() > 0) {
-        auto& dcrt = ct->GetElements()[0];
-        auto& np = dcrt.GetAllElements()[0];
-        size_t n = np.GetParams()->GetRingDimension();
-        if (values.size() == n) {
-            lbcrypto::NativeVector nv(
-                n, lbcrypto::NativeInteger(np.GetModulus()));
-            for (size_t i = 0; i < n; ++i)
-                nv[i] = lbcrypto::NativeInteger(values[i]);
-            np.SetValues(nv, np.GetFormat());
-        } else {
-            std::cerr << "[haze_replay_bridge] values.size()=" << values.size()
-                      << " != ring_dim=" << n
-                      << " — cannot fill input ciphertext" << std::endl;
-        }
+    if (values.empty()) {
+        // Output template path: caller wants an empty shell, no fill.
+        return ct;
     }
+    auto& dcrt = ct->GetElements()[0];
+    auto& np = dcrt.GetAllElements()[0];
+    size_t n = np.GetParams()->GetRingDimension();
+    if (values.size() != n) {
+        std::ostringstream body;
+        body << "values.size()=" << values.size() << " != ring_dim=" << n
+             << " — cannot fill input ciphertext";
+        haze::log_error("replay_bridge", body.str());
+        return ct;
+    }
+    lbcrypto::NativeVector nv(n, lbcrypto::NativeInteger(np.GetModulus()));
+    for (size_t i = 0; i < n; ++i)
+        nv[i] = lbcrypto::NativeInteger(values[i]);
+    np.SetValues(nv, np.GetFormat());
     return ct;
 }
 
-// Post-recording hook. Synthesizes the per-program OpenFHE artifacts the
-// compiler-side nbcc_fhetch_replay needs to consume haze's pure-FHETCH
-// recording:
-//
-//   - For each captured input, a 1-element / 1-tower Ciphertext<DCRTPoly>
-//     filled with the captured values, serialized as
-//     <prog>.input_<name>.bin + .ids.
-//   - For each captured output, an empty 1-element template serialized as
-//     ciphertext_templates/<name>.template.
-//
-// Both iterations run AFTER trace_writer.stop_recording() (post_recording_hook
-// fires there), so the OpenFHE Encrypt() inside synthesize_haze_ciphertext
-// is recording-disabled and doesn't pollute the trace. Eval keys are
-// skipped — they have a bespoke cereal path written by the auto-facade's
-// serialize_eval_keys.
-// RYANPR: Why do we need this?
+// LOAD-BEARING. Synthesizes per-program OpenFHE artifacts the replay
+// path (in-process fhetch_sim or transport-side nbcc_fhetch_replay)
+// needs to consume haze's pure-FHETCH recording. Must run AFTER
+// trace_writer.stop_recording() — so for_each_captured_* sees the
+// final input/output sets — and BEFORE the replay path's reconstruct
+// step (so cereal type registrations resolve in libnbfhetch's TU).
+// Wired up via niobium::compiler().set_post_recording_hook(...).
 void on_post_recording() {
-    std::lock_guard<std::mutex> lock(g_ctx_mu);
     if (!g_ctx.cc) {
         // No CC initialized for this session — bridge was never called,
-        // so there are no haze-style artifacts to materialize. Quiet no-op.
+        // so there are no haze-style artifacts to materialize.
         return;
     }
-    align_program_info_to_haze();
 
     // ---- Inputs ----
     struct InputAccum {
@@ -253,42 +292,47 @@ void on_post_recording() {
 
     for (auto& [name, acc] : inputs_by_name) {
         try {
-            auto ct = synthesize_haze_ciphertext_locked(acc.values);
+            auto ct = synthesize_haze_ciphertext(acc.values);
             if (!niobium::detail::write_ciphertext_input_bin(
                     name, ct, acc.addr_ids)) {
-                std::cerr << "[haze_replay_bridge] write_ciphertext_input_bin "
-                          << "failed for '" << name << "'" << std::endl;
+                haze::log_error(
+                    "replay_bridge",
+                    "write_ciphertext_input_bin failed for '" + name + "'");
             }
         } catch (const std::exception& e) {
-            std::cerr << "[haze_replay_bridge] input bin synthesis for '"
-                      << name << "' threw: " << e.what() << std::endl;
+            haze::log_error(
+                "replay_bridge",
+                "input bin synthesis for '" + name + "' threw: " + e.what());
         }
     }
 
     // ---- Outputs ----
-    // Auto-write a 1-element template for each named output. The
-    // compiler-side fills the first NativePoly with simulator output;
-    // templates are otherwise empty. This removes the burden from test
-    // code of having to call hazeReplayBridgeWriteTemplate per output —
-    // tests just call hazeReplay() and the bridge handles it.
+    // Auto-write a 1-element template for each named output. The replay
+    // path fills the first NativePoly with simulator output; templates
+    // are otherwise empty. This removes the burden from test code of
+    // having to call hazeReplayBridgeWriteTemplate per output — tests
+    // just call hazeReplay() and the bridge handles it.
     niobium::detail::for_each_captured_output(
         [&](const std::string& name) {
             try {
-                auto ct = synthesize_haze_ciphertext_locked({});
+                auto ct = synthesize_haze_ciphertext({});
                 if (!niobium::detail::write_ciphertext_template(name, ct)) {
-                    std::cerr << "[haze_replay_bridge] write_ciphertext_template "
-                              << "failed for '" << name << "'" << std::endl;
+                    haze::log_error(
+                        "replay_bridge",
+                        "write_ciphertext_template failed for '" + name + "'");
                 }
             } catch (const std::exception& e) {
-                std::cerr << "[haze_replay_bridge] template synthesis for '"
-                          << name << "' threw: " << e.what() << std::endl;
+                haze::log_error(
+                    "replay_bridge",
+                    "template synthesis for '" + name + "' threw: " + e.what());
             }
         });
 }
 
-// Push the bridge's CryptoContext into niobium::compiler() via the
-// existing OpenFHE-aware capture path. capture_crypto_context lives
-// inside libnbfhetch (auto_facade.cpp), so the cereal polymorphic
+// Push the bridge's CryptoContext into niobium::compiler() (libnbfhetch's
+// "dummy" compiler — NOT the niobium-compiler nbcc) via the existing
+// OpenFHE-aware capture path. capture_crypto_context lives inside
+// libnbfhetch (auto_facade.cpp), so the cereal polymorphic
 // registrations for CryptoContextImpl<DCRTPoly> resolve in the same
 // shared library where the cc.dat serialization runs.
 //
@@ -301,9 +345,9 @@ void on_post_recording() {
 //
 // We want the first three but NOT the fourth — haze records pure
 // polynomial-level ops, no bootstrap precompute. Clear the hook
-// immediately after capture so stop() doesn't fire it.
-// RYANPR: I assume this is the fhetch compiler, not the real compiler.
-void push_crypto_to_compiler_locked() {
+// immediately after capture so stop() doesn't fire it. Set our own
+// post_recording_hook so on_post_recording fires on stop().
+void push_crypto_to_compiler() {
     niobium::compiler().capture_crypto_context(g_ctx.cc);
     niobium::compiler().set_auto_capture_at_stop(nullptr);
     niobium::compiler().set_post_recording_hook(&on_post_recording);
@@ -317,25 +361,24 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(
     uint64_t* picked_modulus) noexcept {
     if (picked_modulus == nullptr) return HAZE_ERROR_INVALID_VALUE;
 
-    std::lock_guard<std::mutex> lock(g_ctx_mu);
     try {
-        if (!rebuild_context_locked(ring_dim, desired_modulus))
-            return HAZE_ERROR_INVALID_VALUE;
+        auto rebuild = rebuild_context_locked(ring_dim, desired_modulus);
+        if (!rebuild) return to_haze_error(rebuild.error());
 
-        align_program_info_to_haze();
-        // capture_crypto_context populates ring dimension + modulus chain
-        // AND serializes <program_dir>/cryptocontext.dat from inside
-        // libnbfhetch's TU (where cereal type registrations resolve).
-        // Also registers our post_recording_hook so write_haze_input_bins
-        // runs at stop() time without libnbfhetch needing to know about
-        // haze-specific artifacts.
-        push_crypto_to_compiler_locked();
+        // capture_crypto_context populates ring dimension + modulus
+        // chain AND serializes <program_dir>/cryptocontext.dat from
+        // inside libnbfhetch's TU (where cereal type registrations
+        // resolve). Also registers our post_recording_hook so the
+        // bridge's input-bin / template synthesis runs at stop() time
+        // without libnbfhetch needing to know about haze-specific
+        // artifacts.
+        push_crypto_to_compiler();
 
         *picked_modulus = g_ctx.picked_modulus;
         return HAZE_SUCCESS;
     } catch (const std::exception& e) {
-        std::cerr << "[haze_replay_bridge] init threw: " << e.what()
-                  << std::endl;
+        haze::log_error("replay_bridge",
+                        std::string{"init threw: "} + e.what());
         return HAZE_ERROR_LAUNCH_FAILURE;
     } catch (...) {
         return HAZE_ERROR_LAUNCH_FAILURE;

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -6,7 +6,7 @@
 //
 // haze_replay_bridge implementation: synthesize the CryptoContext +
 // per-input cereal-binary .bin files + per-output ciphertext templates that
-// the in-process fhetch_sim AND compiler-side nbcc_fhetch_replay both
+// the in-process FHETCH simulator AND compiler-side nbcc_fhetch_replay both
 // consume to write serialized_probes/<name>.ct from a haze recording.
 // See replay_bridge.h for the public API and architectural rationale.
 //
@@ -58,7 +58,7 @@ namespace niobium::detail {
 
 // Serialize an empty Ciphertext<DCRTPoly> shell to
 // <program_dir>/ciphertext_templates/<name>.template. The replay path
-// (in-process fhetch_sim or transport) deserializes this template,
+// (in-process simulator or transport) deserializes this template,
 // fills its first NativePoly with computed values, and re-serializes
 // it as serialized_probes/<name>.ct.
 bool write_ciphertext_template(
@@ -262,7 +262,7 @@ synthesize_haze_ciphertext(const std::vector<uint64_t>& values) {
 }
 
 // LOAD-BEARING. Synthesizes per-program OpenFHE artifacts the replay
-// path (in-process fhetch_sim or transport-side nbcc_fhetch_replay)
+// path (in-process simulator or transport-side nbcc_fhetch_replay)
 // needs to consume haze's pure-FHETCH recording. Must run AFTER
 // trace_writer.stop_recording() — so for_each_captured_* sees the
 // final input/output sets — and BEFORE the replay path's reconstruct

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -202,13 +202,18 @@ rebuild_context_locked(uint64_t ring_dim, uint64_t desired_modulus) {
     return {};
 }
 
-// Map a BridgeError to the matching hazeError_t for the C ABI.
+// Map a BridgeError to the matching hazeError_t for the C ABI. The
+// granular BridgeError values exist for diagnostics (log_error tags,
+// future debug surfaces); the public hazeError_t is intentionally
+// coarser.
 hazeError_t to_haze_error(BridgeError e) {
     switch (e) {
-        case BridgeError::InvalidRingDim:    return HAZE_ERROR_INVALID_VALUE;
-        case BridgeError::InvalidModulus:    return HAZE_ERROR_INVALID_VALUE;
-        case BridgeError::KeygenFailed:      return HAZE_ERROR_LAUNCH_FAILURE;
-        case BridgeError::OpenFheUnavailable: return HAZE_ERROR_LAUNCH_FAILURE;
+        case BridgeError::InvalidRingDim:
+        case BridgeError::InvalidModulus:
+            return HAZE_ERROR_INVALID_VALUE;
+        case BridgeError::KeygenFailed:
+        case BridgeError::OpenFheUnavailable:
+            return HAZE_ERROR_LAUNCH_FAILURE;
     }
     return HAZE_ERROR_LAUNCH_FAILURE;
 }

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -1,0 +1,343 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+//
+// haze_replay_bridge implementation: synthesize the CryptoContext +
+// per-input cereal-binary .bin files + per-output ciphertext templates that
+// the compiler-side nbcc_fhetch_replay needs in order to write
+// serialized_probes/ from a haze recording. See replay_bridge.h for the
+// public API and architectural rationale.
+
+#include <haze/replay_bridge.h>
+
+// RYANPR: Lint that all of these includes are needed.
+#include "openfhe.h"
+#include "ciphertext-ser.h"
+#include "cryptocontext-ser.h"
+#include "key/key-ser.h"
+#include "scheme/ckksrns/ckksrns-ser.h"
+
+#include <niobium/compiler.h>
+
+#include <bit>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+// libnbfhetch internal helpers used by the bridge. Forward-declared here
+// rather than pulled in via "compiler_internal.h" because:
+//
+// RYANPR: This seems like something that could cause a drift when fhetch drifts. Maybe fhetch needs to make whatever parts public.
+//   1. compiler_internal.h is part of libnbfhetch's PRIVATE include tree
+//      (it lives under src/, not include/) and is intended for libnbfhetch's
+//      own translation units. Including it from a downstream library would
+//      add a dependency on libnbfhetch's source layout that the bridge's
+//      target_include_directories doesn't currently express.
+//
+// RYANPR: This seems like a hack. Were these types added by our custom changes to FHETCH anyway? If so, we should look into how the niobium-client handles writing ciphertexts and if not modify our changes to make these APIs public.
+//   2. The cereal polymorphic-type registry is per-shared-library —
+//      calling lbcrypto::Serial::SerializeToFile from this TU directly
+//      trips "unregistered polymorphic type (lbcrypto::CryptoContextImpl<...>)".
+//      Routing the writes through libnbfhetch's own TU (where the auto-facade
+//      already includes ciphertext-ser.h / cryptocontext-ser.h and forces
+//      static initialisation) is the cleanest fix; the extern declarations
+//      below reach those entry points without exposing the full Impl layout.
+//
+// If libnbfhetch ever publishes a stable C++ public API for these
+// operations, replace these externs with that header include.
+namespace niobium::detail {
+bool write_ciphertext_template(
+    const std::string& name,
+    const lbcrypto::Ciphertext<lbcrypto::DCRTPoly>& ct);
+// RYANPR: Double check that the ciphertext bin is not just the serialized polynomial in some order (lsb/msb, which limb is which level, etc). We would remove the need for this if serialization is really just the raw bytes in order.
+bool write_ciphertext_input_bin(
+    const std::string& name,
+    const lbcrypto::Ciphertext<lbcrypto::DCRTPoly>& ct,
+    const std::vector<uint64_t>& addr_ids);
+// RYANPR: Add a description to what each of these functions is (for the ones you end up keeping)
+void for_each_captured_input(
+    const std::function<void(const std::string&, uint64_t, uint64_t,
+                              const std::vector<uint64_t>&)>& cb);
+void for_each_captured_output(
+    const std::function<void(const std::string&)>& cb);
+}  // namespace niobium::detail
+
+namespace {
+
+namespace fs = std::filesystem;
+using DCRTPoly = lbcrypto::DCRTPoly;
+
+// Per-process cache: same (ring_dim, desired_modulus) reuses the same
+// CryptoContext + keypair across cryptocontext.dat, every template, and
+// every input bin. OpenFHE resolves Ciphertext<->CryptoContext bindings
+// through a static tag registry on deserialize; sharing the CC keeps the
+// tag stable. The keypair is needed only as a structural carrier for
+// Encrypt() — we never decrypt.
+struct CachedContext {
+    uint64_t ring_dim = 0;
+    uint64_t desired_modulus = 0;
+    uint64_t picked_modulus = 0;
+    lbcrypto::CryptoContext<DCRTPoly> cc;
+    lbcrypto::KeyPair<DCRTPoly> keys;
+};
+
+// RYANPR: Why do we need a mutex for this simple application? This seems overengineered.
+CachedContext g_ctx;
+std::mutex    g_ctx_mu;
+
+// RYANPR: Since this is just bit_width name it bit_width_including_zero or something. I'm also not sure we ever get a modulus of zero; they should all be primes...
+// Number of bits needed to represent `modulus` (i.e. `floor(log2(modulus))
+// + 1`). Used to size the prime OpenFHE picks. C++20 std::bit_width
+// handles edge cases (2^63 returns 64) that an iterative shift loop
+// silently truncates.
+uint32_t bits_of(uint64_t modulus) {
+    return modulus == 0 ? 0 : static_cast<uint32_t>(std::bit_width(modulus));
+}
+
+// Build (or rebuild) the cached CryptoContext to match (ring_dim,
+// desired_modulus). Returns true on success; populates g_ctx.
+bool rebuild_context_locked(uint64_t ring_dim, uint64_t desired_modulus) {
+    using namespace lbcrypto;
+    // RYANPR: Make this return a better error type with an enum or whatever so we can know what the error is. The ring dimension check makes sense to me, but the modulus check I don't understand.
+    if (ring_dim == 0 || desired_modulus < 2) return false;
+
+    if (g_ctx.cc && g_ctx.ring_dim == ring_dim &&
+        g_ctx.desired_modulus == desired_modulus) {
+        return true;
+    }
+
+    CCParams<CryptoContextCKKSRNS> p;
+    p.SetSecurityLevel(HEStd_NotSet);  // toy: ring_dim is user-chosen
+    p.SetRingDim(ring_dim);
+    // RYANPR: Make sure to note a TODO that we are only handling a single residue polynomial at the moment but that we may need to do something else later (so more than depth 0)
+    // Depth 0 produces a single-tower DCRTPoly chain so the synthesized
+    // template ciphertext has exactly two NativePoly slots (one per
+    // ciphertext element a, b). Trim element[1] before serializing
+    // (see synthesize_haze_ciphertext below) to land on a 1-NativePoly
+    // .bin matching haze's per-input addr_id count of one. Multi-residue
+    // support will need a different shape — see plan in replay_bridge.h.
+    p.SetMultiplicativeDepth(0);
+    const uint32_t bits = bits_of(desired_modulus);
+    p.SetScalingModSize(bits ? bits - 1 : 50);
+    p.SetFirstModSize(bits ? bits : 60);
+    // RYANPR: Fine for now, but why do we need this?
+    p.SetScalingTechnique(FIXEDMANUAL);
+
+    auto cc = GenCryptoContext(p);
+    if (!cc) return false;
+    cc->Enable(PKE);
+    cc->Enable(KEYSWITCH);
+    cc->Enable(LEVELEDSHE);
+
+    // Cached keypair: needed by Encrypt() to produce a structurally valid
+    // Ciphertext<DCRTPoly>. One keygen per (ring_dim, desired_modulus)
+    // pair, reused across every template and every input bin.
+    // RYANPR: Do we actually need this? I assume the relay we are using asks for keys but also we are constructing dummy polynomials for our tests to see if basic operations work; they don't need encrypted values.
+    auto keys = cc->KeyGen();
+    if (!keys.publicKey || !keys.secretKey) return false;
+
+    auto element_params = cc->GetCryptoParameters()->GetElementParams();
+    if (!element_params || element_params->GetParams().empty()) return false;
+    uint64_t picked = element_params->GetParams()[0]->GetModulus().ConvertToInt();
+
+    g_ctx.ring_dim = ring_dim;
+    g_ctx.desired_modulus = desired_modulus;
+    g_ctx.picked_modulus = picked;
+    g_ctx.cc = cc;
+    g_ctx.keys = keys;
+
+    // RYANPR: What does returning true mean
+    return true;
+}
+
+// Align niobium::compiler()'s program_info to haze's defaults BEFORE
+// reading get_program_directory().
+// RYANPR: Not sure why you need this, the tests should be able to set their own program info and use that.
+void align_program_info_to_haze() {
+    niobium::compiler().set_program_info("haze", "0.1", "HAZE runtime");
+}
+
+// Build a structurally valid 1-element / 1-tower Ciphertext<DCRTPoly> and
+// fill its first NativePoly with `values`. Caller passes pre-acquired
+// g_ctx_mu.
+lbcrypto::Ciphertext<DCRTPoly>
+synthesize_haze_ciphertext_locked(const std::vector<uint64_t>& values) {
+    std::vector<double> zeros(g_ctx.ring_dim / 2, 0.0);
+    auto pt = g_ctx.cc->MakeCKKSPackedPlaintext(zeros);
+    // RYANPR: I don't think we need actual encryption for the test. I really just want to check that the polynomial operations work. We know the ciphertext is a pair of polynomials; we could fill one with the one we want and one with zeros.
+    auto ct = g_ctx.cc->Encrypt(g_ctx.keys.publicKey, pt);
+    // Trim the RLWE pair (a, b) down to a 1-element ciphertext so the
+    // .bin's NativePoly count matches haze's one-polynomial-per-input
+    // model. element[1] would otherwise land in the .bin as Encrypt-noise
+    // and the compiler-side would auto-allocate a colliding addr_id for
+    // it. els.resize(1) leaves the result not-decryptable, but we never
+    // decrypt — the compiler-side reads NativePoly values positionally,
+    // not via the CKKS API.
+    {
+        auto& els = ct->GetElements();
+        if (els.size() > 1) els.resize(1);
+    }
+    // RYANPR: What are you guarding against here?
+    if (!values.empty() &&
+        ct->GetElements().size() > 0 &&
+        ct->GetElements()[0].GetAllElements().size() > 0) {
+        auto& dcrt = ct->GetElements()[0];
+        auto& np = dcrt.GetAllElements()[0];
+        size_t n = np.GetParams()->GetRingDimension();
+        if (values.size() == n) {
+            lbcrypto::NativeVector nv(
+                n, lbcrypto::NativeInteger(np.GetModulus()));
+            for (size_t i = 0; i < n; ++i)
+                nv[i] = lbcrypto::NativeInteger(values[i]);
+            np.SetValues(nv, np.GetFormat());
+        } else {
+            std::cerr << "[haze_replay_bridge] values.size()=" << values.size()
+                      << " != ring_dim=" << n
+                      << " — cannot fill input ciphertext" << std::endl;
+        }
+    }
+    return ct;
+}
+
+// Post-recording hook. Synthesizes the per-program OpenFHE artifacts the
+// compiler-side nbcc_fhetch_replay needs to consume haze's pure-FHETCH
+// recording:
+//
+//   - For each captured input, a 1-element / 1-tower Ciphertext<DCRTPoly>
+//     filled with the captured values, serialized as
+//     <prog>.input_<name>.bin + .ids.
+//   - For each captured output, an empty 1-element template serialized as
+//     ciphertext_templates/<name>.template.
+//
+// Both iterations run AFTER trace_writer.stop_recording() (post_recording_hook
+// fires there), so the OpenFHE Encrypt() inside synthesize_haze_ciphertext
+// is recording-disabled and doesn't pollute the trace. Eval keys are
+// skipped — they have a bespoke cereal path written by the auto-facade's
+// serialize_eval_keys.
+// RYANPR: Why do we need this?
+void on_post_recording() {
+    std::lock_guard<std::mutex> lock(g_ctx_mu);
+    if (!g_ctx.cc) {
+        // No CC initialized for this session — bridge was never called,
+        // so there are no haze-style artifacts to materialize. Quiet no-op.
+        return;
+    }
+    align_program_info_to_haze();
+
+    // ---- Inputs ----
+    struct InputAccum {
+        std::vector<uint64_t> values;  // first element's values
+        std::vector<uint64_t> addr_ids;
+        bool seen_first = false;
+    };
+    std::map<std::string, InputAccum> inputs_by_name;
+
+    niobium::detail::for_each_captured_input(
+        [&](const std::string& name, uint64_t addr_id, uint64_t /*mod*/,
+            const std::vector<uint64_t>& values) {
+            if (name == "evalmult_key" || name == "automorphism_key") return;
+            auto& acc = inputs_by_name[name];
+            acc.addr_ids.push_back(addr_id);
+            if (!acc.seen_first) {
+                acc.values = values;
+                acc.seen_first = true;
+            }
+        });
+
+    for (auto& [name, acc] : inputs_by_name) {
+        try {
+            auto ct = synthesize_haze_ciphertext_locked(acc.values);
+            if (!niobium::detail::write_ciphertext_input_bin(
+                    name, ct, acc.addr_ids)) {
+                std::cerr << "[haze_replay_bridge] write_ciphertext_input_bin "
+                          << "failed for '" << name << "'" << std::endl;
+            }
+        } catch (const std::exception& e) {
+            std::cerr << "[haze_replay_bridge] input bin synthesis for '"
+                      << name << "' threw: " << e.what() << std::endl;
+        }
+    }
+
+    // ---- Outputs ----
+    // Auto-write a 1-element template for each named output. The
+    // compiler-side fills the first NativePoly with simulator output;
+    // templates are otherwise empty. This removes the burden from test
+    // code of having to call hazeReplayBridgeWriteTemplate per output —
+    // tests just call hazeReplay() and the bridge handles it.
+    niobium::detail::for_each_captured_output(
+        [&](const std::string& name) {
+            try {
+                auto ct = synthesize_haze_ciphertext_locked({});
+                if (!niobium::detail::write_ciphertext_template(name, ct)) {
+                    std::cerr << "[haze_replay_bridge] write_ciphertext_template "
+                              << "failed for '" << name << "'" << std::endl;
+                }
+            } catch (const std::exception& e) {
+                std::cerr << "[haze_replay_bridge] template synthesis for '"
+                          << name << "' threw: " << e.what() << std::endl;
+            }
+        });
+}
+
+// Push the bridge's CryptoContext into niobium::compiler() via the
+// existing OpenFHE-aware capture path. capture_crypto_context lives
+// inside libnbfhetch (auto_facade.cpp), so the cereal polymorphic
+// registrations for CryptoContextImpl<DCRTPoly> resolve in the same
+// shared library where the cc.dat serialization runs.
+//
+// capture_crypto_context internally:
+//   - calls set_ring_dimension(N)
+//   - calls set_crypto_context_info(scheme, depth, ..., modulus_chain)
+//   - serializes the CC to <program_dir>/cryptocontext.dat
+//   - registers an auto_capture_at_stop hook that calls
+//     tag_bootstrap_precompute on the CC
+//
+// We want the first three but NOT the fourth — haze records pure
+// polynomial-level ops, no bootstrap precompute. Clear the hook
+// immediately after capture so stop() doesn't fire it.
+// RYANPR: I assume this is the fhetch compiler, not the real compiler.
+void push_crypto_to_compiler_locked() {
+    niobium::compiler().capture_crypto_context(g_ctx.cc);
+    niobium::compiler().set_auto_capture_at_stop(nullptr);
+    niobium::compiler().set_post_recording_hook(&on_post_recording);
+}
+
+}  // namespace
+
+extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(
+    uint64_t  ring_dim,
+    uint64_t  desired_modulus,
+    uint64_t* picked_modulus) noexcept {
+    if (picked_modulus == nullptr) return HAZE_ERROR_INVALID_VALUE;
+
+    std::lock_guard<std::mutex> lock(g_ctx_mu);
+    try {
+        if (!rebuild_context_locked(ring_dim, desired_modulus))
+            return HAZE_ERROR_INVALID_VALUE;
+
+        align_program_info_to_haze();
+        // capture_crypto_context populates ring dimension + modulus chain
+        // AND serializes <program_dir>/cryptocontext.dat from inside
+        // libnbfhetch's TU (where cereal type registrations resolve).
+        // Also registers our post_recording_hook so write_haze_input_bins
+        // runs at stop() time without libnbfhetch needing to know about
+        // haze-specific artifacts.
+        push_crypto_to_compiler_locked();
+
+        *picked_modulus = g_ctx.picked_modulus;
+        return HAZE_SUCCESS;
+    } catch (const std::exception& e) {
+        std::cerr << "[haze_replay_bridge] init threw: " << e.what()
+                  << std::endl;
+        return HAZE_ERROR_LAUNCH_FAILURE;
+    } catch (...) {
+        return HAZE_ERROR_LAUNCH_FAILURE;
+    }
+}

--- a/scripts/test_haze_integration.sh
+++ b/scripts/test_haze_integration.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# ============================================================================
+# test_haze_integration.sh -- run [integration]-tagged haze_tests through the
+# FHETCH transport round trip.
+#
+# 1. Verifies the niobium-compiler-built nbcc_fhetch_replay exists.
+# 2. Verifies the niobium-client transport binaries (server + forwarder)
+#    were built (NIOBIUM_CLIENT_WITH_FHETCH_TRANSPORT=ON).
+# 3. Spawns nbcc_fhetch_replay_server in the background via the niobium-client
+#    fhetch_server.sh wrapper. Waits on /healthz.
+# 4. Puts the client-side forwarder (also named nbcc_fhetch_replay) first on
+#    PATH so libnbfhetch's Compiler::replay() -> dispatch_to_compiler_target's
+#    system("nbcc_fhetch_replay ...") hits the forwarder.
+# 5. Runs haze_tests with the [integration] Catch2 filter.
+# 6. Tears the server down on exit. Dumps the server log on failure.
+#
+# Required env (set by CMake set_tests_properties ENVIRONMENT):
+#   NIOBIUM_COMPILER_ROOT  Path to a niobium-compiler checkout containing
+#                          build/nbcc_fhetch_replay.
+#   NIOBIUM_CLIENT_BUILD   niobium-client build directory (cmake binary dir).
+#                          Used to find the transport binaries.
+#   HAZE_TEST_BIN          Absolute path to the haze_tests executable
+#                          (cmake $<TARGET_FILE:haze_tests>).
+#   OPENFHE_LIB            Path to the OpenFHE shared-library directory.
+#
+# Optional:
+#   PORT                   Server port (default: ephemeral via python3).
+#   HAZE_RUNS_DIR          Working directory haze_tests cd's into before
+#                          recording. Replay artifacts (program dirs,
+#                          .fhetch traces, ciphertext_templates/,
+#                          serialized_probes/, epoch_*/) land here under
+#                          the program name. Defaults to a tempdir.
+#                          Per-test program dirs are cleaned on EXIT.
+# ============================================================================
+set -euo pipefail
+
+: "${NIOBIUM_COMPILER_ROOT:?NIOBIUM_COMPILER_ROOT must be set (path to niobium-compiler checkout)}"
+: "${NIOBIUM_CLIENT_BUILD:?NIOBIUM_CLIENT_BUILD must be set (niobium-client cmake binary dir)}"
+: "${HAZE_TEST_BIN:?HAZE_TEST_BIN must be set (path to haze_tests executable)}"
+: "${OPENFHE_LIB:?OPENFHE_LIB must be set (OpenFHE shared-library dir)}"
+: "${HAZE_RUNS_DIR:=$(mktemp -d -t haze_runs.XXXXXX)}"
+
+# niobium-client's fhetch_server.sh expects to live two levels under the
+# client root and computes paths relative to itself. Walk up from the
+# build dir to locate the source tree.
+CLIENT_ROOT="$(cd "$NIOBIUM_CLIENT_BUILD/.." && pwd)"
+FHETCH_SERVER_SH="$CLIENT_ROOT/scripts/fhetch_server.sh"
+TRANSPORT_DIR="$NIOBIUM_CLIENT_BUILD/src/fhetch_transport"
+
+NBCC_FHETCH_REPLAY="$NIOBIUM_COMPILER_ROOT/build/nbcc_fhetch_replay"
+SERVER_BIN="$TRANSPORT_DIR/nbcc_fhetch_replay_server"
+FORWARDER_BIN="$TRANSPORT_DIR/nbcc_fhetch_replay"
+
+for path in "$NBCC_FHETCH_REPLAY" "$SERVER_BIN" "$FORWARDER_BIN" "$HAZE_TEST_BIN" "$FHETCH_SERVER_SH"; do
+  if [[ ! -e "$path" ]]; then
+    echo "[test_haze_integration.sh] error: not found: $path" >&2
+    exit 2
+  fi
+done
+if [[ ! -x "$NBCC_FHETCH_REPLAY" ]]; then
+  echo "[test_haze_integration.sh] error: not executable: $NBCC_FHETCH_REPLAY" >&2
+  echo "  (run \`make build-release\` in $NIOBIUM_COMPILER_ROOT first)" >&2
+  exit 2
+fi
+
+# Pick an ephemeral port unless one is forced.
+: "${PORT:=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')}"
+echo "[test_haze_integration.sh] port=$PORT"
+
+SERVER_LOG="$(mktemp)"
+SERVER_PID=""
+
+cleanup() {
+  set +e
+  if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill -TERM "$SERVER_PID" 2>/dev/null
+    for _ in 1 2 3 4 5; do
+      kill -0 "$SERVER_PID" 2>/dev/null || break
+      sleep 1
+    done
+    kill -0 "$SERVER_PID" 2>/dev/null && kill -KILL "$SERVER_PID" 2>/dev/null
+  fi
+  echo
+  echo "=== fhetch_server log ==="
+  cat "$SERVER_LOG"
+  rm -f "$SERVER_LOG"
+
+  # Clean haze's per-program directories (haze, haze_*, epoch_*) under the
+  # runs dir. Leaves the runs dir itself in place so the make target's
+  # caller can re-use it across invocations without recreating.
+  if [[ -d "$HAZE_RUNS_DIR" ]]; then
+    rm -rf "$HAZE_RUNS_DIR"/haze "$HAZE_RUNS_DIR"/haze_* "$HAZE_RUNS_DIR"/epoch_* 2>/dev/null
+  fi
+}
+trap cleanup EXIT
+
+echo "=== [1/2] starting fhetch_server (port $PORT) ==="
+PORT="$PORT" BIND=127.0.0.1 \
+NIOBIUM_COMPILER_ROOT="$NIOBIUM_COMPILER_ROOT" \
+NIOBIUM_COMPILER_BUILD="$NIOBIUM_COMPILER_ROOT/build" \
+"$FHETCH_SERVER_SH" > "$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+# Wait for /healthz, mirroring niobium-client/scripts/test_transport_mult.sh.
+for i in $(seq 1 50); do
+  if curl -sf "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+    echo "fhetch_server up (pid=$SERVER_PID)"
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "[test_haze_integration.sh] error: server exited before /healthz responded" >&2
+    exit 3
+  fi
+  sleep 0.1
+done
+if ! curl -sf "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then
+  echo "[test_haze_integration.sh] error: server did not become healthy within 5s" >&2
+  exit 3
+fi
+
+echo
+echo "=== [2/2] running haze_tests [integration] through transport ==="
+# Forwarder first on PATH so libnbfhetch's system("nbcc_fhetch_replay")
+# resolves to the client-side forwarder, which packs the project and
+# ships it to the server.
+export PATH="$TRANSPORT_DIR:$PATH"
+export NBCC_FHETCH_SERVER="http://127.0.0.1:$PORT"
+
+# cd into the runs dir so libnbfhetch's get_program_directory() resolves
+# program artifacts under HAZE_RUNS_DIR/haze rather than the caller's cwd.
+mkdir -p "$HAZE_RUNS_DIR"
+cd "$HAZE_RUNS_DIR"
+
+LD_LIBRARY_PATH="$OPENFHE_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+  "$HAZE_TEST_BIN" "[integration]"

--- a/scripts/test_haze_integration_standalone.sh
+++ b/scripts/test_haze_integration_standalone.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# ============================================================================
+# test_haze_integration_standalone.sh -- run [integration]-tagged haze_tests
+# against an externally-supplied nbcc_fhetch_replay binary, with no HTTP
+# transport in the loop.
+#
+# Standalone counterpart to test_haze_integration.sh. The HTTP-transport
+# version is what niobium-client uses to drive haze tests when it owns both
+# the forwarder and the server. From haze's own checkout we don't have
+# (and don't want to require) the niobium-client transport binaries, so
+# libnbfhetch's Compiler::replay() is pointed straight at the
+# compiler-built binary via NBCC_FHETCH_REPLAY.
+#
+# Required env (the standalone Makefile test-integration-release target
+# plumbs all of these in):
+#   HAZE_TEST_BIN          Absolute path to the haze_tests executable.
+#   NIOBIUM_COMPILER_ROOT  Path to a niobium-compiler checkout containing
+#                          build/nbcc_fhetch_replay. The binary must be
+#                          executable.
+#   OPENFHE_LIB            Path to the OpenFHE shared-library directory.
+#                          Loaded via DYLD_LIBRARY_PATH (macOS) and
+#                          LD_LIBRARY_PATH (Linux) so haze_tests resolves
+#                          libOPENFHEcore at runtime.
+#   HAZE_RUNS_DIR          Working directory haze_tests cd's into before
+#                          recording. Per-test program dirs (haze, haze_*,
+#                          epoch_*) land here and are cleaned on EXIT.
+# ============================================================================
+set -euo pipefail
+
+: "${HAZE_TEST_BIN:?HAZE_TEST_BIN must be set (path to haze_tests executable)}"
+: "${NIOBIUM_COMPILER_ROOT:?NIOBIUM_COMPILER_ROOT must be set (path to niobium-compiler checkout)}"
+: "${OPENFHE_LIB:?OPENFHE_LIB must be set (OpenFHE shared-library dir)}"
+: "${HAZE_RUNS_DIR:?HAZE_RUNS_DIR must be set (per-test artifact root)}"
+
+NBCC_FHETCH_REPLAY="$NIOBIUM_COMPILER_ROOT/build/nbcc_fhetch_replay"
+
+for path in "$HAZE_TEST_BIN" "$NBCC_FHETCH_REPLAY"; do
+  if [[ ! -e "$path" ]]; then
+    echo "[test_haze_integration_standalone.sh] error: not found: $path" >&2
+    exit 2
+  fi
+done
+if [[ ! -x "$NBCC_FHETCH_REPLAY" ]]; then
+  echo "[test_haze_integration_standalone.sh] error: not executable: $NBCC_FHETCH_REPLAY" >&2
+  echo "  (run \`make build-release\` in $NIOBIUM_COMPILER_ROOT first)" >&2
+  exit 2
+fi
+if [[ ! -x "$HAZE_TEST_BIN" ]]; then
+  echo "[test_haze_integration_standalone.sh] error: not executable: $HAZE_TEST_BIN" >&2
+  exit 2
+fi
+
+cleanup() {
+  set +e
+  # Per-program directories land directly under HAZE_RUNS_DIR. Leave the
+  # runs dir itself in place so re-invocations don't recreate it.
+  # Use find rather than glob expansion so unmatched patterns surface as
+  # a real no-op rather than silently expanding to literal "haze_*" etc.
+  if [[ -d "$HAZE_RUNS_DIR" ]]; then
+    find "$HAZE_RUNS_DIR" -mindepth 1 -maxdepth 1 \
+      \( -name "haze" -o -name "haze_*" -o -name "epoch_*" \) \
+      -exec rm -rf {} + 2>/dev/null
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$HAZE_RUNS_DIR"
+cd "$HAZE_RUNS_DIR"
+
+echo "=== running haze_tests [integration] (direct nbcc_fhetch_replay invocation) ==="
+echo "    binary: $NBCC_FHETCH_REPLAY"
+echo "    runs:   $HAZE_RUNS_DIR"
+
+# libnbfhetch's Compiler::replay() honors NBCC_FHETCH_REPLAY as an absolute
+# override before falling back to PATH lookup, which is what lets us bypass
+# the HTTP forwarder entirely.
+NBCC_FHETCH_REPLAY="$NBCC_FHETCH_REPLAY" \
+DYLD_LIBRARY_PATH="$OPENFHE_LIB${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
+LD_LIBRARY_PATH="$OPENFHE_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+  "$HAZE_TEST_BIN" "[integration]"

--- a/src/api/lifecycle.cpp
+++ b/src/api/lifecycle.cpp
@@ -26,6 +26,7 @@
 
 #include <haze/haze.h>
 #include <haze/haze_types.h>
+#include <niobium/compiler.h>
 
 namespace haze {
 
@@ -37,6 +38,13 @@ void reset_all() noexcept {
     streams_reset();
     events_reset();
     device_reset();
+    // Wipe niobium::compiler()'s singleton state too — captured_inputs,
+    // captured_outputs, the trace writer's modulus table, and any hooks
+    // registered by the replay bridge would otherwise leak across tests
+    // (or across distinct programs running in the same process). reset()
+    // is generic to libnbfhetch; haze just calls it as part of "start
+    // fresh".
+    niobium::compiler().reset();
 }
 
 } // namespace haze
@@ -46,5 +54,12 @@ extern "C" hazeError_t hazeDeviceReset(void) noexcept {
     // Match cudaDeviceReset: also clear the thread-local last-error so
     // callers can use this as a clean test-isolation point.
     g_last_error = HAZE_SUCCESS;
+    return HAZE_SUCCESS;
+}
+
+extern "C" hazeError_t hazeReplay(void) noexcept {
+    auto result = haze::epoch().replay_and_populate();
+    if (!result)
+        return set_error(haze::to_public_error(result.error()));
     return HAZE_SUCCESS;
 }

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -50,6 +50,7 @@ extern "C" hazeError_t hazeHostAlloc(void **ptr, size_t size, unsigned int /*fla
     if (ptr == nullptr || size == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
     void *p = nullptr;
+    // RYANPR: What is this 4096 constant? That seems like a random and probably bad choice.
     if (posix_memalign(&p, 4096, size) != 0)
         return set_error(HAZE_ERROR_OUT_OF_MEMORY);
     haze::allocator().register_host_pointer(p);
@@ -59,6 +60,7 @@ extern "C" hazeError_t hazeHostAlloc(void **ptr, size_t size, unsigned int /*fla
 
 extern "C" hazeError_t hazeFreeHost(void *ptr) noexcept {
     haze::allocator().unregister_host_pointer(ptr);
+    // RYANPR: Why are we calling the real life free? That seems like a bug.
     free(ptr); // NOLINT(cppcoreguidelines-no-malloc)
     return HAZE_SUCCESS;
 }
@@ -84,10 +86,11 @@ extern "C" hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
     }
 
     if (kind == HAZE_MEMCPY_DEVICE_TO_HOST) {
-        // copy_to_host_with_flush triggers any pending materialization,
-        // then reads bytes from the shadow into dst.
+        // Plain shadow read. To get post-compute values, the caller
+        // must invoke hazeReplay() before this — replay populates the
+        // shadow buffer with values from the compiler-side simulator.
         return set_error(
-            haze::copy_to_host_with_flush(dst, haze::to_dev_addr(src), count));
+            haze::copy_to_host(dst, haze::to_dev_addr(src), count));
     }
 
     if (kind == HAZE_MEMCPY_DEVICE_TO_DEVICE) {

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <expected>
+#include <unistd.h>
 
 extern "C" hazeError_t hazeMalloc(void **ptr, size_t size) noexcept {
     if (ptr == nullptr)
@@ -49,9 +50,13 @@ extern "C" hazeError_t hazeFreeAsync(void *ptr, hazeStream_t /*stream*/) noexcep
 extern "C" hazeError_t hazeHostAlloc(void **ptr, size_t size, unsigned int /*flags*/) noexcept {
     if (ptr == nullptr || size == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
+    // Page-aligned allocation for DMA / O_DIRECT compatibility on
+    // pinned-host buffers. Apple Silicon uses 16K pages, Linux x86_64
+    // uses 4K — sysconf returns the right value either way.
+    static const size_t kHostAllocAlignment =
+        static_cast<size_t>(sysconf(_SC_PAGESIZE));
     void *p = nullptr;
-    // RYANPR: What is this 4096 constant? That seems like a random and probably bad choice.
-    if (posix_memalign(&p, 4096, size) != 0)
+    if (posix_memalign(&p, kHostAllocAlignment, size) != 0)
         return set_error(HAZE_ERROR_OUT_OF_MEMORY);
     haze::allocator().register_host_pointer(p);
     *ptr = p;
@@ -60,7 +65,7 @@ extern "C" hazeError_t hazeHostAlloc(void **ptr, size_t size, unsigned int /*fla
 
 extern "C" hazeError_t hazeFreeHost(void *ptr) noexcept {
     haze::allocator().unregister_host_pointer(ptr);
-    // RYANPR: Why are we calling the real life free? That seems like a bug.
+    // posix_memalign-allocated; libc free is the matched deallocator.
     free(ptr); // NOLINT(cppcoreguidelines-no-malloc)
     return HAZE_SUCCESS;
 }

--- a/src/common/log.cpp
+++ b/src/common/log.cpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#include "common/log.hpp"
+
+#include <iostream>
+
+namespace haze {
+
+void log_error(std::string_view tag, std::string_view body) noexcept {
+    std::cerr << "[haze] " << tag << ": " << body << '\n';
+}
+
+} // namespace haze

--- a/src/common/log.hpp
+++ b/src/common/log.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#pragma once
+
+#include <string_view>
+
+namespace haze {
+
+// Single sink for [haze]-prefixed runtime diagnostics. Replaces ad-hoc
+// `std::cerr << "[haze] ...";` blocks across haze + replay_bridge so the
+// prefix is consistent and call sites stay short.
+//
+// Output format: "[haze] <tag>: <body>\n". `tag` identifies the subsystem
+// (e.g. "epoch", "replay_bridge"). Both arguments are printed verbatim;
+// callers compose their own error text.
+void log_error(std::string_view tag, std::string_view body) noexcept;
+
+} // namespace haze

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -12,11 +12,11 @@
 // from the Product.
 //
 // CompilerBackend is the link-time-selected control surface for the
-// niobium::compiler() singleton. Today the linked library is
-// niobium-compiler/libnbcc; future builds may swap to the niobium-fhetch
-// dummy compiler when its bugs are sorted. HAZE source is unchanged
-// either way — the backend only routes through niobium::compiler() which
-// resolves at link time.
+// niobium::compiler() singleton. The linked library is
+// niobium-fhetch/libnbfhetch; recording happens locally and replay is
+// dispatched to a compiler-side nbcc_fhetch_replay over the FHETCH
+// transport when target != "local".
+// RYANPR: Where is local used/defined? It is mentioned here but not actually used in the compiler implementation.
 
 #include "core/backend.hpp"
 
@@ -59,16 +59,21 @@ bool CompilerBackend::ensure_initialized() noexcept {
         const std::string target = config().target();
 
         // niobium::compiler().init() takes (int& argc, char** argv) — we
-        // synthesise minimal argv (the program name) so the compiler's
-        // arg parser sees a well-formed invocation. prog_storage_ owns
-        // the string for the duration of init.
+        // synthesise minimal argv so the compiler's arg parser sees a
+        // well-formed invocation. niobium-fhetch's compiler.h does not
+        // expose a set_target() setter; the only way to configure the
+        // replay target is through init()'s --target= flag (see
+        // niobium-fhetch/src/compiler.cpp:153-156). prog_storage_ and
+        // target_arg_storage_ own the strings for the duration of init.
         prog_storage_ = program_name;
+        target_arg_storage_ = "--target=" + target;
         argv_[0] = prog_storage_.data();
-        argv_[1] = nullptr;
-        int argc = 1;
+        argv_[1] = target_arg_storage_.data();
+        argv_[2] = nullptr;
+        // RYANPR: Should this not be 3? You are setting 3 elements. Or two because the last argument is null
+        int argc = 2;
         niobium::compiler().init(argc, argv_);
         niobium::compiler().set_program_info(program_name, program_version, program_description);
-        niobium::compiler().set_target(target);
     } catch (...) {
         record_internal_error(HazeInternalError::BackendError,
                               "CompilerBackend::ensure_initialized");
@@ -87,14 +92,43 @@ void CompilerBackend::start_recording() noexcept { niobium::compiler().start(); 
 
 void CompilerBackend::start_epoch() noexcept { niobium::compiler().start_epoch(); }
 
-bool CompilerBackend::stop_epoch() noexcept { return niobium::compiler().stop_epoch(); }
+bool CompilerBackend::stop_epoch() noexcept {
+    // Use the canonical stop() rather than stop_epoch(). stop() writes
+    // both the .fhetch trace and fhetch_replay.json (via write_replay_json
+    // in compiler.cpp:209), which the compiler-side nbcc_fhetch_replay
+    // requires to dispatch. stop_epoch() only writes the per-epoch trace
+    // and does not produce replay.json — fine for libnbcc's intra-process
+    // multi-epoch flow (its stop_epoch does record+replay+reset internally),
+    // but breaks the transport hand-off used by libnbfhetch.
+    //
+    // Haze's recording lifecycle is single-epoch per haze::epoch().reset(),
+    // so the canonical stop() is the right semantic match.
+    return niobium::compiler().stop();
+}
+
+bool CompilerBackend::replay() noexcept {
+    // niobium::compiler().replay() can throw on resource-exhaustion paths
+    // inside the niobium-fhetch dispatch (e.g. std::system_error from a
+    // failed subprocess fork on the transport route). Catching here keeps
+    // the haze C ABI exception-clean and surfaces a coherent BackendError.
+    try {
+        return niobium::compiler().replay();
+    } catch (...) {
+        record_internal_error(HazeInternalError::BackendError,
+                              "CompilerBackend::replay");
+        return false;
+    }
+}
 
 void CompilerBackend::reset() noexcept {
     std::lock_guard lock(init_mutex_);
     initialized_.store(false, std::memory_order_release);
     prog_storage_.clear();
+    target_arg_storage_.clear();
+    // RYANPR: Not sure why these are variables in the class when we set them in the `ensure_initialized` and then not use them again. The compiler init probably uses the argv and then copies what it needs and doesn't reference the caller's memory (if the init is well written that is).
     argv_[0] = nullptr;
     argv_[1] = nullptr;
+    argv_[2] = nullptr;
 }
 
 } // namespace haze

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -12,14 +12,20 @@
 // from the Product.
 //
 // CompilerBackend is the link-time-selected control surface for the
-// niobium::compiler() singleton (libnbfhetch). Recording happens locally;
-// the configured target string is forwarded to fhetch's compiler via
-// --target=<value> in argv. fhetch interprets "local" as trace-only,
-// "fhetch_sim" as in-process simulator, and any other value as a hand-off
-// to nbcc_fhetch_replay over the FHETCH transport — see niobium-fhetch's
-// compiler.cpp Compiler::replay() for the dispatch switch. Haze itself
-// never compares against "local" by literal; the kLocalTarget /
-// kFhetchSimTarget constants in core/config.hpp keep target comparisons
+// niobium::compiler() singleton (libnbfhetch). Recording happens
+// locally; replay is dispatched according to the configured target.
+//
+// libnbfhetch knows two tiers: "local" runs the in-process FHETCH
+// simulator, anything else is forwarded to nbcc_fhetch_replay over the
+// HTTP transport. Haze exposes the same two tiers and forwards the
+// configured target string verbatim:
+//
+//   - kLocalTarget — runs the in-process FHETCH simulator end-to-end.
+//   - other (e.g. "FUNC_SIM", "FPGA_TRI", "fhetch_sim") — HTTP dispatch;
+//                    the string selects a backend on the compiler side.
+//
+// Haze itself never compares against the libnbfhetch literal "local";
+// the kLocalTarget constant in core/config.hpp keeps target comparisons
 // symbolic.
 
 #include "core/backend.hpp"
@@ -67,6 +73,11 @@ bool CompilerBackend::ensure_initialized() noexcept {
         // well-formed invocation. niobium-fhetch's compiler.h does not
         // expose a set_target() setter; the only way to configure the
         // replay target is through init()'s --target= flag.
+        //
+        // The configured target is forwarded verbatim. libnbfhetch
+        // interprets "local" as the in-process simulator and treats
+        // anything else as an HTTP target string handed to
+        // nbcc_fhetch_replay.
         //
         // argv lifetime: fhetch's Compiler::init copies parsed values
         // into impl_ (the target string lands as a std::string field) and

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -12,11 +12,15 @@
 // from the Product.
 //
 // CompilerBackend is the link-time-selected control surface for the
-// niobium::compiler() singleton. The linked library is
-// niobium-fhetch/libnbfhetch; recording happens locally and replay is
-// dispatched to a compiler-side nbcc_fhetch_replay over the FHETCH
-// transport when target != "local".
-// RYANPR: Where is local used/defined? It is mentioned here but not actually used in the compiler implementation.
+// niobium::compiler() singleton (libnbfhetch). Recording happens locally;
+// the configured target string is forwarded to fhetch's compiler via
+// --target=<value> in argv. fhetch interprets "local" as trace-only,
+// "fhetch_sim" as in-process simulator, and any other value as a hand-off
+// to nbcc_fhetch_replay over the FHETCH transport — see niobium-fhetch's
+// compiler.cpp Compiler::replay() for the dispatch switch. Haze itself
+// never compares against "local" by literal; the kLocalTarget /
+// kFhetchSimTarget constants in core/config.hpp keep target comparisons
+// symbolic.
 
 #include "core/backend.hpp"
 
@@ -62,17 +66,22 @@ bool CompilerBackend::ensure_initialized() noexcept {
         // synthesise minimal argv so the compiler's arg parser sees a
         // well-formed invocation. niobium-fhetch's compiler.h does not
         // expose a set_target() setter; the only way to configure the
-        // replay target is through init()'s --target= flag (see
-        // niobium-fhetch/src/compiler.cpp:153-156). prog_storage_ and
-        // target_arg_storage_ own the strings for the duration of init.
-        prog_storage_ = program_name;
-        target_arg_storage_ = "--target=" + target;
-        argv_[0] = prog_storage_.data();
-        argv_[1] = target_arg_storage_.data();
-        argv_[2] = nullptr;
-        // RYANPR: Should this not be 3? You are setting 3 elements. Or two because the last argument is null
+        // replay target is through init()'s --target= flag.
+        //
+        // argv lifetime: fhetch's Compiler::init copies parsed values
+        // into impl_ (the target string lands as a std::string field) and
+        // does not retain argv past the call. Function-local storage is
+        // therefore safe and avoids the ownership ambiguity of holding
+        // these strings on the singleton.
+        std::string prog_storage = program_name;
+        std::string target_arg_storage = "--target=" + target;
+        char* argv[3] = {prog_storage.data(),
+                         target_arg_storage.data(),
+                         nullptr};
+        // argc is 2 — the trailing nullptr is the C-standard argv
+        // terminator, not a counted argument.
         int argc = 2;
-        niobium::compiler().init(argc, argv_);
+        niobium::compiler().init(argc, argv);
         niobium::compiler().set_program_info(program_name, program_version, program_description);
     } catch (...) {
         record_internal_error(HazeInternalError::BackendError,
@@ -123,12 +132,6 @@ bool CompilerBackend::replay() noexcept {
 void CompilerBackend::reset() noexcept {
     std::lock_guard lock(init_mutex_);
     initialized_.store(false, std::memory_order_release);
-    prog_storage_.clear();
-    target_arg_storage_.clear();
-    // RYANPR: Not sure why these are variables in the class when we set them in the `ensure_initialized` and then not use them again. The compiler init probably uses the argv and then copies what it needs and doesn't reference the caller's memory (if the init is well written that is).
-    argv_[0] = nullptr;
-    argv_[1] = nullptr;
-    argv_[2] = nullptr;
 }
 
 } // namespace haze

--- a/src/core/backend.hpp
+++ b/src/core/backend.hpp
@@ -12,10 +12,8 @@
 // from the Product.
 #pragma once
 
-// RYANPR: Check if all includes in all files changed are needed (clangd)
 #include <atomic>
 #include <mutex>
-#include <string>
 
 namespace haze {
 
@@ -57,28 +55,10 @@ class CompilerBackend {
     // replay() afterwards (see below).
     bool stop_epoch() noexcept;
 
-    // Trigger replay of the most recently recorded epoch.
-    //
-    // Behaviour depends on the configured target:
-    //   - target == "local"  : trace-only mode. The .fhetch file produced
-    //                          by stop_epoch() is left in place and replay
-    //                          is a no-op success. fhetch::result() will
-    //                          NOT return computed values; haze users
-    //                          running locally cannot validate FHE math.
-    //   - target != "local"  : the FHETCH project directory is handed off
-    //                          over the HTTP transport (see
-    //                          niobium-client/scripts/fhetch_server.sh)
-    //                          to a niobium-compiler-built
-    //                          nbcc_fhetch_replay running with the OpenFHE
-    //                          simulator. Probes flow back as
-    //                          serialized_probes/*.ct.
-    //
-    // Users of haze must arrange the transport (server + forwarder)
-    // before any haze D2H readback when target != "local". See
-    // niobium-client/scripts/test_transport_mult.sh for the canonical
-    // orchestration pattern.
-    //
-    // Returns true on success.
+    // Trigger replay of the most recently recorded epoch. Behaviour
+    // depends on the configured target — see haze.h's hazeSetTarget
+    // doc for the three-tier table (local trace-only / fhetch_sim
+    // in-process / HTTP transport). Returns true on success.
     bool replay() noexcept;
 
     // Drop cached state so the next call to ensure_initialized() starts
@@ -95,15 +75,6 @@ class CompilerBackend {
     // path so concurrent first callers don't all run init.
     std::atomic<bool> initialized_{false};
     std::mutex init_mutex_;
-    // Storage backing argv_ across the niobium::compiler().init() call.
-    // We synthesise argv as ["<program>", "--target=<value>", nullptr];
-    // niobium-fhetch's compiler.h does not expose a set_target() setter,
-    // so the only way to configure the replay target is through init()'s
-    // argv parser (compiler.cpp:153-156).
-    // RYANPR: What?
-    std::string prog_storage_;
-    std::string target_arg_storage_;
-    char *argv_[3]{nullptr, nullptr, nullptr};
 };
 
 inline CompilerBackend &backend() noexcept { return CompilerBackend::instance(); }

--- a/src/core/backend.hpp
+++ b/src/core/backend.hpp
@@ -12,6 +12,7 @@
 // from the Product.
 #pragma once
 
+// RYANPR: Check if all includes in all files changed are needed (clangd)
 #include <atomic>
 #include <mutex>
 #include <string>
@@ -20,7 +21,7 @@ namespace haze {
 
 // Control surface for the niobium::compiler() singleton. HAZE records
 // FHETCH IR via fhetch::sr_*, fhetch::tag_input, and fhetch::result;
-// those route to the linked compiler implicitly. CompilerBackend wraps
+// those route to the linked fhetch "dummy" compiler implicitly. CompilerBackend wraps
 // only the *control* operations: init, recording lifecycle, replay.
 //
 // Single concrete class, no virtual dispatch. Backend swap (e.g. to the
@@ -50,9 +51,35 @@ class CompilerBackend {
     // first call, resets to that base on subsequent calls.
     void start_epoch() noexcept;
 
-    // Compile + replay the current epoch, then reset compiler state and
-    // resume recording. Returns true on success.
+    // Finalize the current epoch's recording, write the per-epoch .fhetch
+    // trace, and reset state for the next epoch. Returns true on success.
+    // Does NOT trigger replay; callers materializing results must invoke
+    // replay() afterwards (see below).
     bool stop_epoch() noexcept;
+
+    // Trigger replay of the most recently recorded epoch.
+    //
+    // Behaviour depends on the configured target:
+    //   - target == "local"  : trace-only mode. The .fhetch file produced
+    //                          by stop_epoch() is left in place and replay
+    //                          is a no-op success. fhetch::result() will
+    //                          NOT return computed values; haze users
+    //                          running locally cannot validate FHE math.
+    //   - target != "local"  : the FHETCH project directory is handed off
+    //                          over the HTTP transport (see
+    //                          niobium-client/scripts/fhetch_server.sh)
+    //                          to a niobium-compiler-built
+    //                          nbcc_fhetch_replay running with the OpenFHE
+    //                          simulator. Probes flow back as
+    //                          serialized_probes/*.ct.
+    //
+    // Users of haze must arrange the transport (server + forwarder)
+    // before any haze D2H readback when target != "local". See
+    // niobium-client/scripts/test_transport_mult.sh for the canonical
+    // orchestration pattern.
+    //
+    // Returns true on success.
+    bool replay() noexcept;
 
     // Drop cached state so the next call to ensure_initialized() starts
     // fresh. Mainly for tests via hazeReset().
@@ -68,8 +95,15 @@ class CompilerBackend {
     // path so concurrent first callers don't all run init.
     std::atomic<bool> initialized_{false};
     std::mutex init_mutex_;
-    std::string prog_storage_; // backs argv_[0] across the init() call
-    char *argv_[2]{nullptr, nullptr};
+    // Storage backing argv_ across the niobium::compiler().init() call.
+    // We synthesise argv as ["<program>", "--target=<value>", nullptr];
+    // niobium-fhetch's compiler.h does not expose a set_target() setter,
+    // so the only way to configure the replay target is through init()'s
+    // argv parser (compiler.cpp:153-156).
+    // RYANPR: What?
+    std::string prog_storage_;
+    std::string target_arg_storage_;
+    char *argv_[3]{nullptr, nullptr, nullptr};
 };
 
 inline CompilerBackend &backend() noexcept { return CompilerBackend::instance(); }

--- a/src/core/backend.hpp
+++ b/src/core/backend.hpp
@@ -57,8 +57,8 @@ class CompilerBackend {
 
     // Trigger replay of the most recently recorded epoch. Behaviour
     // depends on the configured target — see haze.h's hazeSetTarget
-    // doc for the three-tier table (local trace-only / fhetch_sim
-    // in-process / HTTP transport). Returns true on success.
+    // doc for the two-tier table (local in-process simulator vs HTTP
+    // transport). Returns true on success.
     bool replay() noexcept;
 
     // Drop cached state so the next call to ensure_initialized() starts

--- a/src/core/basis_convert.cpp
+++ b/src/core/basis_convert.cpp
@@ -57,7 +57,7 @@ std::expected<fhetch::MRP, HazeInternalError> build_mrp_locked(const void *const
 void store_mrp_locked(void *const *dst_polys, const fhetch::MRP &mrp, const uint64_t *base,
                       size_t len) HAZE_REQUIRES(epoch().mutex()) {
     for (size_t i = 0; i < len; ++i) {
-        epoch().store_locked(to_dev_addr(dst_polys[i]), mrp[base[i]]);
+        epoch().store_compute_result_locked(to_dev_addr(dst_polys[i]), mrp[base[i]]);
     }
 }
 

--- a/src/core/compute.hpp
+++ b/src/core/compute.hpp
@@ -46,7 +46,7 @@ hazeError_t binary_pp_op(DevAddr dst, DevAddr src1, DevAddr src2, int mod_idx) n
     auto p2 = epoch().lookup_or_create_locked(src2);
     if (!p2)
         return set_error(to_public_error(p2.error()));
-    epoch().store_locked(dst, OpFn(*p1, *p2, q));
+    epoch().store_compute_result_locked(dst, OpFn(*p1, *p2, q));
     return HAZE_SUCCESS;
 }
 
@@ -60,7 +60,7 @@ hazeError_t binary_ps_op(DevAddr dst, DevAddr src, uint64_t scalar, int mod_idx)
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
         return set_error(to_public_error(p.error()));
-    epoch().store_locked(dst, OpFn(*p, niobium::fhetch::Scalar::from_int(scalar), q));
+    epoch().store_compute_result_locked(dst, OpFn(*p, niobium::fhetch::Scalar::from_int(scalar), q));
     return HAZE_SUCCESS;
 }
 
@@ -74,7 +74,7 @@ hazeError_t unary_pq_op(DevAddr dst, DevAddr src, int mod_idx) noexcept {
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
         return set_error(to_public_error(p.error()));
-    epoch().store_locked(dst, OpFn(*p, q));
+    epoch().store_compute_result_locked(dst, OpFn(*p, q));
     return HAZE_SUCCESS;
 }
 
@@ -85,7 +85,7 @@ hazeError_t unary_pi_op(DevAddr dst, DevAddr src, uint64_t index) noexcept {
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
         return set_error(to_public_error(p.error()));
-    epoch().store_locked(dst, OpFn(*p, index));
+    epoch().store_compute_result_locked(dst, OpFn(*p, index));
     return HAZE_SUCCESS;
 }
 

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -170,10 +170,12 @@ std::string Config::target() const noexcept {
             return target_;
     }
     // Env var fallback used only when no explicit hazeSetTarget call has
-    // been made. Default if env var unset: FHE_SIM.
+    // been made. Default if env var unset: in-process fhetch_sim, so
+    // hazeMemcpy(D2H) returns simulator-computed values out of the box
+    // without requiring nbcc_fhetch_replay.
     if (const char *t = std::getenv("HAZE_TARGET"); t != nullptr && t[0] != '\0')
         return std::string{t};
-    return std::string{"FHE_SIM"};
+    return std::string{kFhetchSimTarget};
 }
 
 void Config::reset() noexcept {

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -170,12 +170,13 @@ std::string Config::target() const noexcept {
             return target_;
     }
     // Env var fallback used only when no explicit hazeSetTarget call has
-    // been made. Default if env var unset: in-process fhetch_sim, so
-    // hazeMemcpy(D2H) returns simulator-computed values out of the box
-    // without requiring nbcc_fhetch_replay.
+    // been made. Default if env var unset: kLocalTarget — runs the
+    // in-process FHETCH simulator, so hazeMemcpy(D2H) returns
+    // simulator-computed values out of the box without requiring
+    // nbcc_fhetch_replay.
     if (const char *t = std::getenv("HAZE_TARGET"); t != nullptr && t[0] != '\0')
         return std::string{t};
-    return std::string{kFhetchSimTarget};
+    return std::string{kLocalTarget};
 }
 
 void Config::reset() noexcept {

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -22,25 +22,19 @@
 
 namespace haze {
 
-// Canonical target strings dispatched through libnbfhetch's compiler.
+// Canonical target string dispatched through libnbfhetch's compiler.
+// kLocalTarget runs the in-process FHETCH instruction-set simulator:
+// libnbfhetch loads the .fhetch trace into fhetch_sim::Simulator,
+// executes it, and writes <program_dir>/serialized_probes/<name>.ct
+// so epoch.cpp's result-population loop fills shadow buffers with
+// computed values. No compiler-side binary or HTTP transport needed.
 //
-//   kLocalTarget     — trace-only; replay() is a no-op success and
-//                      hazeMemcpy(D2H) returns whatever the shadow
-//                      buffer held before compute. No FHE math.
-//   kFhetchSimTarget — in-process FHETCH instruction-set simulator.
-//                      libnbfhetch loads the .fhetch trace into
-//                      fhetch_sim::Simulator, executes it, and writes
-//                      <program_dir>/serialized_probes/<name>.ct so
-//                      epoch.cpp's result-population loop populates
-//                      shadow buffers with computed values. No
-//                      compiler-side binary or HTTP transport needed.
-//
-// Anything else is forwarded to nbcc_fhetch_replay over the HTTP
-// transport (e.g. "FUNC_SIM", "FHE_SIM", "FPGA_TRI"). Keep these
-// strings symbolic so a future rename in libnbfhetch flows through
-// every comparison site in haze.
-constexpr std::string_view kLocalTarget     = "local";
-constexpr std::string_view kFhetchSimTarget = "fhetch_sim";
+// Anything else (e.g. "FUNC_SIM", "FHE_SIM", "FPGA_TRI", "fhetch_sim")
+// is forwarded verbatim to nbcc_fhetch_replay over the HTTP transport
+// — those strings select a backend on the compiler side. Keep
+// kLocalTarget symbolic so a future rename in libnbfhetch flows
+// through every comparison site in haze.
+constexpr std::string_view kLocalTarget = "local";
 
 // Global FHE-context configuration: ring dimension, ciphertext moduli,
 // twiddle generators. Plus the program/target metadata fed to the
@@ -65,7 +59,7 @@ class Config {
 
     // Program / target metadata fed to the compiler during init.
     // Defaults: name="haze", version="0.1", description="HAZE runtime",
-    // target=kFhetchSimTarget (overridable by HAZE_TARGET env var unless
+    // target=kLocalTarget (overridable by HAZE_TARGET env var unless
     // an explicit hazeSetTarget call has been made).
     hazeError_t set_program_info(const char *name, const char *version,
                                  const char *description) noexcept;

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -17,9 +17,30 @@
 #include <cstdint>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace haze {
+
+// Canonical target strings dispatched through libnbfhetch's compiler.
+//
+//   kLocalTarget     — trace-only; replay() is a no-op success and
+//                      hazeMemcpy(D2H) returns whatever the shadow
+//                      buffer held before compute. No FHE math.
+//   kFhetchSimTarget — in-process FHETCH instruction-set simulator.
+//                      libnbfhetch loads the .fhetch trace into
+//                      fhetch_sim::Simulator, executes it, and writes
+//                      <program_dir>/serialized_probes/<name>.ct so
+//                      epoch.cpp's result-population loop populates
+//                      shadow buffers with computed values. No
+//                      compiler-side binary or HTTP transport needed.
+//
+// Anything else is forwarded to nbcc_fhetch_replay over the HTTP
+// transport (e.g. "FUNC_SIM", "FHE_SIM", "FPGA_TRI"). Keep these
+// strings symbolic so a future rename in libnbfhetch flows through
+// every comparison site in haze.
+constexpr std::string_view kLocalTarget     = "local";
+constexpr std::string_view kFhetchSimTarget = "fhetch_sim";
 
 // Global FHE-context configuration: ring dimension, ciphertext moduli,
 // twiddle generators. Plus the program/target metadata fed to the
@@ -44,8 +65,8 @@ class Config {
 
     // Program / target metadata fed to the compiler during init.
     // Defaults: name="haze", version="0.1", description="HAZE runtime",
-    // target="FHE_SIM" (overridable by HAZE_TARGET env var unless an
-    // explicit hazeSetTarget call has been made).
+    // target=kFhetchSimTarget (overridable by HAZE_TARGET env var unless
+    // an explicit hazeSetTarget call has been made).
     hazeError_t set_program_info(const char *name, const char *version,
                                  const char *description) noexcept;
     hazeError_t set_target(const char *target) noexcept;

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -213,8 +213,7 @@ void EpochState::clear_state_locked() noexcept {
     // EpochSession's start-of-cycle ensure_recording_locked() — both
     // ends of the recording window are now responsible for keeping the
     // libnbfhetch-side state in lockstep with haze-side epoch state.
-    niobium::compiler().clear_captured_inputs();
-    niobium::compiler().clear_captured_outputs();
+    niobium::compiler().clear_captured();
 }
 
 void EpochState::reset() noexcept {

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -26,6 +26,7 @@
 #include <haze/haze_types.h>
 #include <iostream>
 #include <mutex>
+#include <niobium/compiler.h>
 #include <niobium/fhetch_api.h>
 #include <string>
 #include <utility>
@@ -69,6 +70,7 @@ bool EpochState::is_recording() noexcept {
 
 void EpochState::invalidate(DevAddr addr) noexcept {
     HazeLockGuard lock(mutex_);
+    // RYANPR: Is erase walking all of these maps? It would seem nice to be able to just know which one to erase from (as in device addresses also had a tag of which map they were in). On refactoring, make sure not to overengineer such a map of device address to which map it is in.
     poly_map_.erase(addr);
     compute_results_.erase(addr);
     pending_outputs_.erase(addr);
@@ -106,41 +108,37 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
 
 void EpochState::store_locked(DevAddr addr, niobium::fhetch::Polynomial poly) noexcept {
     poly_map_.insert_or_assign(addr, std::move(poly));
-    // Track this address as a compute result so flush_for_d2h knows to
-    // materialize it on the first flush (input polys, added via
-    // lookup_or_create_locked, are excluded — tagging them as fhetch
-    // outputs would confuse stop_epoch).
+    // Track this address as a compute result so replay_and_populate
+    // tags it as a fhetch output before stop()/replay() run. Input
+    // polys created via lookup_or_create_locked are excluded — tagging
+    // them as fhetch outputs would confuse the niobium compiler.
+    // RYANPR: Not all stores are compute results, no?
     compute_results_.insert(addr);
 }
 
-std::expected<void, HazeInternalError> EpochState::flush_for_d2h(DevAddr addr) noexcept {
+std::expected<void, HazeInternalError> EpochState::replay_and_populate() noexcept {
     HazeLockGuard lock(mutex_);
     if (!recording_) {
-        return {}; // shadow already authoritative
-    }
-    if (poly_map_.find(addr) == poly_map_.end()) {
-        return {}; // address has no compute output bound
+        return {}; // nothing to replay
     }
 
-    // Tag every compute result as a pending output, not just `addr`.
-    // do_materialize_locked() runs stop_epoch + clear_state, so any
-    // result not captured here would lose its value to subsequent D2H
-    // calls in the same epoch — they would early-return on !recording_
-    // and read uninitialised shadow. Multi-output ops (hazeBasisConvert,
-    // hazeModDown, hazeModUp) routinely produce several bound polys
-    // per call and the caller D2Hs each in turn, so capturing the
-    // whole live set on the first flush is the only way that pattern
-    // works without HAZE_PERSIST_WRITES.
-    //
-    // Inputs (poly_map_ entries created via lookup_or_create_locked)
-    // are deliberately excluded — their shadow is already authoritative
-    // (set by H2D), and tagging them as fhetch outputs causes
-    // stop_epoch to fail with BackendError.
+    // Tag every bound compute result as a fhetch output. Inputs
+    // (poly_map_ entries created by lookup_or_create_locked) are
+    // deliberately excluded — their shadow data is already authoritative.
+    // RYANPR: Since we have an authoritative place for inputs, why do we not have an authorative place for outputs? Then we wouldn't have to scan for them.
     for (DevAddr result_addr : compute_results_) {
         if (pending_outputs_.find(result_addr) == pending_outputs_.end()) {
             const std::string name = "haze_out_" + std::to_string(output_counter_++);
             pending_outputs_.emplace(result_addr, name);
         }
+    }
+
+    // RYANPR: Seems like we could collapse this with the prior for loop.
+    for (auto &[addr, name] : pending_outputs_) {
+        auto it = poly_map_.find(addr);
+        if (it == poly_map_.end())
+            continue;
+        fhetch::tag_output(name, it->second);
     }
 
     return do_materialize_locked();
@@ -151,43 +149,69 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         return {};
     }
 
-    for (auto &[addr, name] : pending_outputs_) {
-        auto it = poly_map_.find(addr);
-        if (it == poly_map_.end())
-            continue;
-        fhetch::tag_output(name, it->second);
-    }
-
-    // stop_epoch() compiles, replays, resets compiler state, and restarts
-    // recording. State is reset at end of this function regardless of
-    // backend success so the next epoch starts fresh.
-    const bool ok = backend().stop_epoch();
-
-    if (ok) {
-        for (auto &[addr, name] : pending_outputs_) {
-            fhetch::Polynomial result_poly;
-            if (!fhetch::result(name, result_poly)) {
-                std::cerr << "[haze] failed to retrieve result for output '" << name
-                          << "' at addr 0x" << std::hex << to_uintptr(addr) << std::dec << '\n';
-                continue;
-            }
-            std::vector<uint64_t> values;
-            if (!extract_polynomial_values(result_poly, name, values)) {
-                std::cerr << "[haze] failed to extract values for output '" << name
-                          << "' at addr 0x" << std::hex << to_uintptr(addr) << std::dec << '\n';
-                continue;
-            }
-            std::vector<uint8_t> bytes(values.size() * sizeof(uint64_t));
-            std::memcpy(bytes.data(), values.data(), bytes.size());
-            allocator().update_shadow(addr, bytes);
-        }
-    }
-
-    clear_state_locked();
-    if (!ok) {
-        record_internal_error(HazeInternalError::BackendError, "EpochState::do_materialize");
+    // Step 1: write the per-epoch .fhetch trace and reset the recording
+    // bookkeeping in libnbfhetch.
+    const bool stop_ok = backend().stop_epoch();
+    if (!stop_ok) {
+        clear_state_locked();
+        record_internal_error(HazeInternalError::BackendError,
+                              "EpochState::replay_and_populate (stop_epoch)");
         return std::unexpected(HazeInternalError::BackendError);
     }
+
+    // Step 2: dispatch replay. For target=="local" this is a no-op
+    // success (the .fhetch trace is the only artifact). For non-local
+    // targets it spawns nbcc_fhetch_replay via the FHETCH HTTP transport
+    // (forwarder on PATH -> server -> compiler-side binary running the
+    // OpenFHE simulator) and writes ciphertext probes back to disk.
+    // RYANPR: We have a mode where we test against local but if we are only writing out the fhetch IR how are we actually populating the shadow buffer?
+    const bool replay_ok = backend().replay();
+    if (!replay_ok) {
+        clear_state_locked();
+        record_internal_error(HazeInternalError::BackendError,
+                              "EpochState::replay_and_populate (replay)");
+        return std::unexpected(HazeInternalError::BackendError);
+    }
+
+    // Step 3: populate the host shadow buffer for each output address
+    // so subsequent hazeMemcpy(D2H) reads pick up the computed values.
+    // fhetch::result(name, Polynomial&) reads
+    // <program_dir>/serialized_probes/<name>.ct (written by the
+    // compiler-side nbcc_fhetch_replay) and unwraps the first NativePoly
+    // into a fhetch::Polynomial. extract_polynomial_values rehydrates
+    // the values via fhetch::save_polynomial_json, and update_shadow
+    // commits them to the device shadow buffer at `addr`.
+    for (auto &[addr, name] : pending_outputs_) {
+        fhetch::Polynomial result_poly;
+        if (!fhetch::result(name, result_poly)) {
+            std::cerr << "[haze] result('" << name << "') unavailable; "
+                      << "shadow at addr 0x" << std::hex << to_uintptr(addr) << std::dec
+                      << " is stale\n";
+            continue;
+        }
+        std::vector<uint64_t> values;
+        if (!extract_polynomial_values(result_poly, name, values)) {
+            // RYANPR: Since we are doing these error operations in the same way every time we should make an `error.{cpp,hpp}` that encapsulates how we write out things and then takes a string to do it. We could replace this with more detailed logging later. All strings seem to start with `[haze]`.
+            std::cerr << "[haze] failed to extract values for output '" << name
+                      << "' at addr 0x" << std::hex << to_uintptr(addr) << std::dec << '\n';
+            continue;
+        }
+        std::vector<uint8_t> bytes(values.size() * sizeof(uint64_t));
+        std::memcpy(bytes.data(), values.data(), bytes.size());
+        allocator().update_shadow(addr, bytes);
+    }
+
+    // Clear niobium::compiler()'s captured input/output state so the next
+    // recording-replay cycle inside the same hazeDeviceReset window starts
+    // from an empty slate. Without this, captured_inputs/outputs accumulate
+    // across cycles — multi-cycle tests like
+    // "multiple materializations: two independent D2H cycles" would see
+    // stale data shipped to the compiler-side replay.
+    // RYANPR: Why is this called so late? It would seem that for error cases we are not clearing the captured inputs and outputs, which could lead to a screwed up compiler state if we then tried to recover from a failed run and succeeded the next time (or ran a second computation that succeeded when the first did not).
+    niobium::compiler().clear_captured_inputs();
+    niobium::compiler().clear_captured_outputs();
+
+    clear_state_locked();
     return {};
 }
 
@@ -218,13 +242,14 @@ HazeMutex &EpochSession::init_then_get_mutex() noexcept {
     return epoch().mutex_;
 }
 
-hazeError_t copy_to_host_with_flush(void *dst, DevAddr src, size_t count) noexcept {
-    // Single locked operation: flush_for_d2h decides internally whether
-    // any work is required, so callers don't need a separate predicate
-    // check (which would race a concurrent invalidate).
-    auto result = epoch().flush_for_d2h(src);
-    if (!result)
-        return to_public_error(result.error());
+hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept {
+    // D2H is a plain shadow read. Recording finalization + replay live
+    // in haze::epoch().replay_and_populate() (exposed as hazeReplay()),
+    // which the user must call explicitly before reading post-compute
+    // values back. This separation is intentional: replay incurs an
+    // HTTP transport round-trip to the compiler-side nbcc_fhetch_replay,
+    // which is a heavy operation that should be triggered explicitly,
+    // not as a side-effect of a memcpy.
     return allocator().copy_to_host(dst, src, count);
 }
 

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -157,11 +157,10 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         return std::unexpected(HazeInternalError::BackendError);
     }
 
-    // Step 2: dispatch replay. Behaviour depends on the configured
-    // target — local is a no-op success, fhetch_sim runs the in-process
-    // simulator, anything else spawns nbcc_fhetch_replay over the HTTP
-    // transport. Non-local paths produce serialized_probes/<name>.ct
-    // for fhetch::result to read in step 3.
+    // Step 2: dispatch replay. kLocalTarget runs the in-process FHETCH
+    // simulator end-to-end inside libnbfhetch; other targets spawn
+    // nbcc_fhetch_replay over the HTTP transport. Both paths produce
+    // serialized_probes/<name>.ct for fhetch::result to read in step 3.
     const bool replay_ok = backend().replay();
     if (!replay_ok) {
         clear_state_locked();
@@ -170,32 +169,28 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         return std::unexpected(HazeInternalError::BackendError);
     }
 
-    // Step 3 (non-local targets only): populate host shadow buffers
-    // from <program_dir>/serialized_probes/<name>.ct. In local mode no
-    // probes are produced; the .fhetch trace is the only artifact and
-    // shadow buffers retain their pre-compute (H2D) values.
-    if (config().target() != kLocalTarget) {
-        for (auto &[addr, name] : pending_outputs_) {
-            fhetch::Polynomial result_poly;
-            if (!fhetch::result(name, result_poly)) {
-                std::ostringstream body;
-                body << "result('" << name << "') unavailable; shadow at addr 0x"
-                     << std::hex << to_uintptr(addr) << std::dec << " is stale";
-                log_error("epoch", body.str());
-                continue;
-            }
-            std::vector<uint64_t> values;
-            if (!extract_polynomial_values(result_poly, name, values)) {
-                std::ostringstream body;
-                body << "failed to extract values for output '" << name
-                     << "' at addr 0x" << std::hex << to_uintptr(addr) << std::dec;
-                log_error("epoch", body.str());
-                continue;
-            }
-            std::vector<uint8_t> bytes(values.size() * sizeof(uint64_t));
-            std::memcpy(bytes.data(), values.data(), bytes.size());
-            allocator().update_shadow(addr, bytes);
+    // Step 3: populate host shadow buffers from
+    // <program_dir>/serialized_probes/<name>.ct.
+    for (auto &[addr, name] : pending_outputs_) {
+        fhetch::Polynomial result_poly;
+        if (!fhetch::result(name, result_poly)) {
+            std::ostringstream body;
+            body << "result('" << name << "') unavailable; shadow at addr 0x"
+                 << std::hex << to_uintptr(addr) << std::dec << " is stale";
+            log_error("epoch", body.str());
+            continue;
         }
+        std::vector<uint64_t> values;
+        if (!extract_polynomial_values(result_poly, name, values)) {
+            std::ostringstream body;
+            body << "failed to extract values for output '" << name
+                 << "' at addr 0x" << std::hex << to_uintptr(addr) << std::dec;
+            log_error("epoch", body.str());
+            continue;
+        }
+        std::vector<uint8_t> bytes(values.size() * sizeof(uint64_t));
+        std::memcpy(bytes.data(), values.data(), bytes.size());
+        allocator().update_shadow(addr, bytes);
     }
 
     clear_state_locked();   // also clears captured inputs/outputs (E7).

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -12,11 +12,12 @@
 // from the Product.
 #include "core/epoch.hpp"
 
+#include "common/errors.hpp"
+#include "common/handle.hpp"
+#include "common/log.hpp"
 #include "core/allocator.hpp"
 #include "core/backend.hpp"
 #include "core/config.hpp"
-#include "common/errors.hpp"
-#include "common/handle.hpp"
 #include "core/polynomial_io.hpp"
 
 #include <cstddef>
@@ -24,10 +25,9 @@
 #include <cstring>
 #include <expected>
 #include <haze/haze_types.h>
-#include <iostream>
-#include <mutex>
 #include <niobium/compiler.h>
 #include <niobium/fhetch_api.h>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -70,9 +70,10 @@ bool EpochState::is_recording() noexcept {
 
 void EpochState::invalidate(DevAddr addr) noexcept {
     HazeLockGuard lock(mutex_);
-    // RYANPR: Is erase walking all of these maps? It would seem nice to be able to just know which one to erase from (as in device addresses also had a tag of which map they were in). On refactoring, make sure not to overengineer such a map of device address to which map it is in.
+    // pending_outputs_ is a subset of poly_map_; erase-on-miss is O(1)
+    // (hash hit + immediate not-found return). Tagging addresses with
+    // their owning map would add complexity for no measurable benefit.
     poly_map_.erase(addr);
-    compute_results_.erase(addr);
     pending_outputs_.erase(addr);
 }
 
@@ -106,14 +107,20 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
     return poly;
 }
 
-void EpochState::store_locked(DevAddr addr, niobium::fhetch::Polynomial poly) noexcept {
+void EpochState::store_compute_result_locked(
+    DevAddr addr, niobium::fhetch::Polynomial poly) noexcept {
     poly_map_.insert_or_assign(addr, std::move(poly));
-    // Track this address as a compute result so replay_and_populate
-    // tags it as a fhetch output before stop()/replay() run. Input
-    // polys created via lookup_or_create_locked are excluded — tagging
-    // them as fhetch outputs would confuse the niobium compiler.
-    // RYANPR: Not all stores are compute results, no?
-    compute_results_.insert(addr);
+    // Authoritative output registration: every compute store gets a
+    // pending output name on first store. Re-stores at the same addr
+    // keep their original name (insert-no-overwrite); an intervening
+    // invalidate() wipes pending_outputs_, so a fresh store after H2D
+    // / memset gets a new name. Input polys created via
+    // lookup_or_create_locked never reach this path, so they are
+    // never tagged as fhetch outputs.
+    if (pending_outputs_.find(addr) == pending_outputs_.end()) {
+        pending_outputs_.emplace(addr,
+            "haze_out_" + std::to_string(output_counter_++));
+    }
 }
 
 std::expected<void, HazeInternalError> EpochState::replay_and_populate() noexcept {
@@ -122,18 +129,9 @@ std::expected<void, HazeInternalError> EpochState::replay_and_populate() noexcep
         return {}; // nothing to replay
     }
 
-    // Tag every bound compute result as a fhetch output. Inputs
-    // (poly_map_ entries created by lookup_or_create_locked) are
-    // deliberately excluded — their shadow data is already authoritative.
-    // RYANPR: Since we have an authoritative place for inputs, why do we not have an authorative place for outputs? Then we wouldn't have to scan for them.
-    for (DevAddr result_addr : compute_results_) {
-        if (pending_outputs_.find(result_addr) == pending_outputs_.end()) {
-            const std::string name = "haze_out_" + std::to_string(output_counter_++);
-            pending_outputs_.emplace(result_addr, name);
-        }
-    }
-
-    // RYANPR: Seems like we could collapse this with the prior for loop.
+    // Tag every authoritative output for fhetch. Inputs already carry
+    // tag_input from lookup_or_create_locked; pending_outputs_ contains
+    // exactly the addresses that store_compute_result_locked emitted.
     for (auto &[addr, name] : pending_outputs_) {
         auto it = poly_map_.find(addr);
         if (it == poly_map_.end())
@@ -159,12 +157,11 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         return std::unexpected(HazeInternalError::BackendError);
     }
 
-    // Step 2: dispatch replay. For target=="local" this is a no-op
-    // success (the .fhetch trace is the only artifact). For non-local
-    // targets it spawns nbcc_fhetch_replay via the FHETCH HTTP transport
-    // (forwarder on PATH -> server -> compiler-side binary running the
-    // OpenFHE simulator) and writes ciphertext probes back to disk.
-    // RYANPR: We have a mode where we test against local but if we are only writing out the fhetch IR how are we actually populating the shadow buffer?
+    // Step 2: dispatch replay. Behaviour depends on the configured
+    // target — local is a no-op success, fhetch_sim runs the in-process
+    // simulator, anything else spawns nbcc_fhetch_replay over the HTTP
+    // transport. Non-local paths produce serialized_probes/<name>.ct
+    // for fhetch::result to read in step 3.
     const bool replay_ok = backend().replay();
     if (!replay_ok) {
         clear_state_locked();
@@ -173,55 +170,51 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         return std::unexpected(HazeInternalError::BackendError);
     }
 
-    // Step 3: populate the host shadow buffer for each output address
-    // so subsequent hazeMemcpy(D2H) reads pick up the computed values.
-    // fhetch::result(name, Polynomial&) reads
-    // <program_dir>/serialized_probes/<name>.ct (written by the
-    // compiler-side nbcc_fhetch_replay) and unwraps the first NativePoly
-    // into a fhetch::Polynomial. extract_polynomial_values rehydrates
-    // the values via fhetch::save_polynomial_json, and update_shadow
-    // commits them to the device shadow buffer at `addr`.
-    for (auto &[addr, name] : pending_outputs_) {
-        fhetch::Polynomial result_poly;
-        if (!fhetch::result(name, result_poly)) {
-            std::cerr << "[haze] result('" << name << "') unavailable; "
-                      << "shadow at addr 0x" << std::hex << to_uintptr(addr) << std::dec
-                      << " is stale\n";
-            continue;
+    // Step 3 (non-local targets only): populate host shadow buffers
+    // from <program_dir>/serialized_probes/<name>.ct. In local mode no
+    // probes are produced; the .fhetch trace is the only artifact and
+    // shadow buffers retain their pre-compute (H2D) values.
+    if (config().target() != kLocalTarget) {
+        for (auto &[addr, name] : pending_outputs_) {
+            fhetch::Polynomial result_poly;
+            if (!fhetch::result(name, result_poly)) {
+                std::ostringstream body;
+                body << "result('" << name << "') unavailable; shadow at addr 0x"
+                     << std::hex << to_uintptr(addr) << std::dec << " is stale";
+                log_error("epoch", body.str());
+                continue;
+            }
+            std::vector<uint64_t> values;
+            if (!extract_polynomial_values(result_poly, name, values)) {
+                std::ostringstream body;
+                body << "failed to extract values for output '" << name
+                     << "' at addr 0x" << std::hex << to_uintptr(addr) << std::dec;
+                log_error("epoch", body.str());
+                continue;
+            }
+            std::vector<uint8_t> bytes(values.size() * sizeof(uint64_t));
+            std::memcpy(bytes.data(), values.data(), bytes.size());
+            allocator().update_shadow(addr, bytes);
         }
-        std::vector<uint64_t> values;
-        if (!extract_polynomial_values(result_poly, name, values)) {
-            // RYANPR: Since we are doing these error operations in the same way every time we should make an `error.{cpp,hpp}` that encapsulates how we write out things and then takes a string to do it. We could replace this with more detailed logging later. All strings seem to start with `[haze]`.
-            std::cerr << "[haze] failed to extract values for output '" << name
-                      << "' at addr 0x" << std::hex << to_uintptr(addr) << std::dec << '\n';
-            continue;
-        }
-        std::vector<uint8_t> bytes(values.size() * sizeof(uint64_t));
-        std::memcpy(bytes.data(), values.data(), bytes.size());
-        allocator().update_shadow(addr, bytes);
     }
 
-    // Clear niobium::compiler()'s captured input/output state so the next
-    // recording-replay cycle inside the same hazeDeviceReset window starts
-    // from an empty slate. Without this, captured_inputs/outputs accumulate
-    // across cycles — multi-cycle tests like
-    // "multiple materializations: two independent D2H cycles" would see
-    // stale data shipped to the compiler-side replay.
-    // RYANPR: Why is this called so late? It would seem that for error cases we are not clearing the captured inputs and outputs, which could lead to a screwed up compiler state if we then tried to recover from a failed run and succeeded the next time (or ran a second computation that succeeded when the first did not).
-    niobium::compiler().clear_captured_inputs();
-    niobium::compiler().clear_captured_outputs();
-
-    clear_state_locked();
+    clear_state_locked();   // also clears captured inputs/outputs (E7).
     return {};
 }
 
 void EpochState::clear_state_locked() noexcept {
     poly_map_.clear();
-    compute_results_.clear();
     pending_outputs_.clear();
     recording_ = false;
     input_counter_ = 0;
     output_counter_ = 0;
+    // Mirror to compiler-captured state so a failed materialise can't
+    // leak inputs/outputs into the next recording cycle. Pairs with
+    // EpochSession's start-of-cycle ensure_recording_locked() — both
+    // ends of the recording window are now responsible for keeping the
+    // libnbfhetch-side state in lockstep with haze-side epoch state.
+    niobium::compiler().clear_captured_inputs();
+    niobium::compiler().clear_captured_outputs();
 }
 
 void EpochState::reset() noexcept {

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -24,7 +24,6 @@
 #include <niobium/fhetch_api.h>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 
 namespace haze {
 
@@ -66,9 +65,9 @@ class EpochState {
 
     // Finalize the current epoch: tag every bound compute result as a
     // fhetch output, write the .fhetch trace via stop_epoch(), then
-    // dispatch replay (no-op for target=="local"; HTTP transport
-    // round-trip for non-local targets) and populate the host shadow
-    // buffer for each output address with the computed values.
+    // dispatch replay (see hazeSetTarget docs for the three-tier table)
+    // and populate the host shadow buffer for each output address with
+    // the computed values.
     //
     // After this call returns, hazeMemcpy(D2H) on any bound output
     // address reads the materialized value from the shadow buffer.
@@ -91,8 +90,14 @@ class EpochState {
     std::expected<niobium::fhetch::Polynomial, HazeInternalError>
     lookup_or_create_locked(DevAddr addr) HAZE_REQUIRES(mutex_);
 
-    // Bind `addr` to `poly` (replacing any prior binding).
-    void store_locked(DevAddr addr, niobium::fhetch::Polynomial poly) noexcept
+    // Bind `addr` to `poly` (replacing any prior binding) and tag it as
+    // a compute output — every store of a freshly computed polynomial
+    // gets a pending-output name on first store. Re-stores at the same
+    // addr keep their original name (insert-no-overwrite); an
+    // intervening invalidate() wipes pending_outputs_, so a fresh store
+    // after H2D / memset gets a new name.
+    void store_compute_result_locked(DevAddr addr,
+                                     niobium::fhetch::Polynomial poly) noexcept
         HAZE_REQUIRES(mutex_);
 
   private:
@@ -112,13 +117,11 @@ class EpochState {
     // The reverse direction is forbidden; allocator-side code must never
     // call back into EpochState while holding the allocator lock.
     HazeMutex mutex_;
+    // Authoritative bindings for every poly in flight this epoch. Inputs
+    // (lookup_or_create_locked) and outputs (store_compute_result_locked)
+    // both land here; the corresponding pending_outputs_ entry, present
+    // iff the binding is an output, names it for fhetch::tag_output.
     std::unordered_map<DevAddr, niobium::fhetch::Polynomial> poly_map_ HAZE_GUARDED_BY(mutex_);
-    // Subset of poly_map_ populated by store_locked (i.e. compute
-    // outputs) — distinct from input polys created via
-    // lookup_or_create_locked. Used by replay_and_populate to tag
-    // every in-flight result as a fhetch output before stop()/replay()
-    // run, so post-replay shadow reads see the materialized values.
-    std::unordered_set<DevAddr> compute_results_ HAZE_GUARDED_BY(mutex_);
     std::unordered_map<DevAddr, std::string> pending_outputs_ HAZE_GUARDED_BY(mutex_);
     uint64_t input_counter_ HAZE_GUARDED_BY(mutex_) = 0;
     uint64_t output_counter_ HAZE_GUARDED_BY(mutex_) = 0;
@@ -137,7 +140,7 @@ inline EpochState &epoch() noexcept {
 // RAII helper used by the compute API entry points: ensures the backend
 // is initialised, then takes the epoch mutex and ensures the recording
 // is active for the lifetime of the session. Compute helpers
-// (lookup_or_create_locked, store_locked) are safe to call while an
+// (lookup_or_create_locked, store_compute_result_locked) are safe to call while an
 // EpochSession is in scope.
 //
 // `backend().ensure_initialized()` runs *before* the lock is taken so

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -52,7 +52,7 @@ class EpochState {
 
     // The mutex itself. EpochSession is the canonical caller; other
     // callers take it via std::lock_guard (see is_recording, invalidate,
-    // flush_for_d2h, reset).
+    // replay_and_populate, reset).
     HazeMutex &mutex() noexcept HAZE_RETURN_CAPABILITY(mutex_) { return mutex_; }
 
     // ---- Public methods (take mutex_ internally) ----
@@ -64,12 +64,16 @@ class EpochState {
     // input from new shadow data.
     void invalidate(DevAddr addr) noexcept HAZE_EXCLUDES(mutex_);
 
-    // Materialize any pending compute output bound to `addr` so a
-    // subsequent shadow read returns the post-replay value. No-op when
-    // there is nothing to flush (not recording, or `addr` has no binding).
-    // Combines the predicate and the materialization atomically under
-    // mutex_ so a concurrent invalidate cannot slip between them.
-    std::expected<void, HazeInternalError> flush_for_d2h(DevAddr addr) noexcept
+    // Finalize the current epoch: tag every bound compute result as a
+    // fhetch output, write the .fhetch trace via stop_epoch(), then
+    // dispatch replay (no-op for target=="local"; HTTP transport
+    // round-trip for non-local targets) and populate the host shadow
+    // buffer for each output address with the computed values.
+    //
+    // After this call returns, hazeMemcpy(D2H) on any bound output
+    // address reads the materialized value from the shadow buffer.
+    // No-op when not recording.
+    std::expected<void, HazeInternalError> replay_and_populate() noexcept
         HAZE_EXCLUDES(mutex_);
 
     void reset() noexcept HAZE_EXCLUDES(mutex_);
@@ -111,9 +115,9 @@ class EpochState {
     std::unordered_map<DevAddr, niobium::fhetch::Polynomial> poly_map_ HAZE_GUARDED_BY(mutex_);
     // Subset of poly_map_ populated by store_locked (i.e. compute
     // outputs) — distinct from input polys created via
-    // lookup_or_create_locked. Used by flush_for_d2h to materialize
-    // every in-flight result on the first D2H per epoch so subsequent
-    // D2Hs in the same epoch don't read stale shadow.
+    // lookup_or_create_locked. Used by replay_and_populate to tag
+    // every in-flight result as a fhetch output before stop()/replay()
+    // run, so post-replay shadow reads see the materialized values.
     std::unordered_set<DevAddr> compute_results_ HAZE_GUARDED_BY(mutex_);
     std::unordered_map<DevAddr, std::string> pending_outputs_ HAZE_GUARDED_BY(mutex_);
     uint64_t input_counter_ HAZE_GUARDED_BY(mutex_) = 0;
@@ -165,10 +169,10 @@ class HAZE_SCOPED_CAPABILITY EpochSession {
 };
 
 // D2H-side helper: copies bytes from the device shadow buffer to a host
-// destination after triggering any pending materialization. Called by
-// hazeMemcpy(D2H). Must NOT be invoked from inside an EpochSession —
-// flush_for_d2h takes the epoch mutex itself.
-hazeError_t copy_to_host_with_flush(void *dst, DevAddr src, size_t count) noexcept
-    HAZE_EXCLUDES(epoch().mutex());
+// destination. Plain shadow read — does NOT trigger any recording
+// finalization or replay. Callers that need post-compute values must
+// invoke hazeReplay() (haze::epoch().replay_and_populate()) first to
+// materialize results into the shadow buffer.
+hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept;
 
 } // namespace haze

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// Helpers for [integration]-tagged Catch2 cases. Integration tests:
+//   1. Record FHETCH instructions through haze.
+//   2. Bridge auto-synthesizes a CryptoContext + per-input cereal-binary
+//      .bin files + per-output ciphertext templates at recording-finalize
+//      time (see haze_replay_bridge's post_recording_hook).
+//   3. Call hazeReplay() to dispatch the recorded project to a
+//      niobium-compiler-built nbcc_fhetch_replay over the FHETCH HTTP
+//      transport.
+//   4. The simulator-computed values flow back as serialized_probes/*.ct,
+//      which fhetch::result reads and replay_and_populate writes into the
+//      haze shadow buffers.
+//   5. hazeMemcpy(D2H) returns the materialized values from shadow.
+//
+// Orchestration of the server + client-side forwarder lives in
+// scripts/test_haze_integration.sh.
+
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
+
+#include <cstdint>
+
+namespace haze::test {
+
+// Combined integration setup: reset, ring dim, target=FUNC_SIM, bridge
+// CryptoContext init (which writes <program_dir>/cryptocontext.dat),
+// align haze's ciphertext modulus with OpenFHE's picked tower prime,
+// then configure the device. Returns the picked modulus so callers can
+// keep using it consistently with what haze recorded.
+//
+// Modulus alignment: OpenFHE's CKKS GenCryptoContext picks a prime near
+// 2^bits(desired). The picked value rarely matches `desired_modulus`
+// exactly. To keep haze's recording-side modulus arithmetic in lockstep
+// with the .ct round-trip, we feed the picked value back into
+// hazeSetCiphertextModulus before any compute.
+//
+// After this call returns, tests do compute + hazeReplay() + hazeMemcpy(D2H).
+// The bridge's post_recording_hook auto-writes the .bin / .ids / .template
+// artifacts during stop(); tests do not need to call WriteTemplate or
+// WriteInputBin explicitly.
+inline uint64_t setup_integration_compute_config(
+    uint64_t ring_dim, uint64_t desired_modulus, int mod_idx) {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
+    REQUIRE(hazeSetTarget("FUNC_SIM") == HAZE_SUCCESS);
+    uint64_t picked = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, desired_modulus,
+                                              &picked) == HAZE_SUCCESS);
+    REQUIRE(picked != 0);
+    REQUIRE(hazeSetCiphertextModulus(mod_idx, picked) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    return picked;
+}
+
+} // namespace haze::test

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -37,7 +37,7 @@ namespace haze::test {
 // Target selection: the test Makefile (test-sim / test-transport) sets
 // HAZE_TARGET to whichever string the surrounding suite needs. The
 // helper honours that env var; if unset, falls back to haze's own
-// default (the in-process fhetch_sim, per hazeSetTarget docs).
+// default ("local" — in-process FHETCH simulator, per hazeSetTarget docs).
 //
 // Modulus alignment: OpenFHE's CKKS GenCryptoContext picks a prime near
 // 2^bits(desired). The picked value rarely matches `desired_modulus`

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -24,14 +24,20 @@
 #include <haze/replay_bridge.h>
 
 #include <cstdint>
+#include <cstdlib>
 
 namespace haze::test {
 
-// Combined integration setup: reset, ring dim, target=FUNC_SIM, bridge
-// CryptoContext init (which writes <program_dir>/cryptocontext.dat),
-// align haze's ciphertext modulus with OpenFHE's picked tower prime,
-// then configure the device. Returns the picked modulus so callers can
-// keep using it consistently with what haze recorded.
+// Combined integration setup: reset, ring dim, bridge CryptoContext init
+// (which writes <program_dir>/cryptocontext.dat), align haze's ciphertext
+// modulus with OpenFHE's picked tower prime, then configure the device.
+// Returns the picked modulus so callers can keep using it consistently
+// with what haze recorded.
+//
+// Target selection: the test Makefile (test-sim / test-transport) sets
+// HAZE_TARGET to whichever string the surrounding suite needs. The
+// helper honours that env var; if unset, falls back to haze's own
+// default (the in-process fhetch_sim, per hazeSetTarget docs).
 //
 // Modulus alignment: OpenFHE's CKKS GenCryptoContext picks a prime near
 // 2^bits(desired). The picked value rarely matches `desired_modulus`
@@ -44,10 +50,15 @@ namespace haze::test {
 // artifacts during stop(); tests do not need to call WriteTemplate or
 // WriteInputBin explicitly.
 inline uint64_t setup_integration_compute_config(
-    uint64_t ring_dim, uint64_t desired_modulus, int mod_idx) {
+    uint64_t ring_dim = 4096,
+    uint64_t desired_modulus = 576460752303415297ULL,
+    int mod_idx = 0) {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("FUNC_SIM") == HAZE_SUCCESS);
+    if (const char* env_target = std::getenv("HAZE_TARGET");
+        env_target != nullptr && *env_target != '\0') {
+        REQUIRE(hazeSetTarget(env_target) == HAZE_SUCCESS);
+    }
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, desired_modulus,
                                               &picked) == HAZE_SUCCESS);

--- a/test/test_basis_convert.cpp
+++ b/test/test_basis_convert.cpp
@@ -41,25 +41,25 @@ static void configure_three_moduli() {
 
 // Parameter validation.
 
-TEST_CASE("hazeBasisConvert rejects null params") {
+TEST_CASE("hazeBasisConvert rejects null params", "[unit]") {
     configure_three_moduli();
     REQUIRE(hazeBasisConvert(nullptr, nullptr, nullptr, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 }
 
-TEST_CASE("hazeModDown rejects null params") {
+TEST_CASE("hazeModDown rejects null params", "[unit]") {
     configure_three_moduli();
     REQUIRE(hazeModDown(nullptr, nullptr, nullptr, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 }
 
-TEST_CASE("hazeModUp rejects null params") {
+TEST_CASE("hazeModUp rejects null params", "[unit]") {
     configure_three_moduli();
     REQUIRE(hazeModUp(nullptr, nullptr, nullptr, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 }
 
-TEST_CASE("hazeBasisConvert rejects empty source base") {
+TEST_CASE("hazeBasisConvert rejects empty source base", "[unit]") {
     configure_three_moduli();
     void *dst = nullptr;
     REQUIRE(hazeMalloc(&dst, kBytes) == HAZE_SUCCESS);
@@ -80,7 +80,7 @@ TEST_CASE("hazeBasisConvert rejects empty source base") {
     REQUIRE(hazeFree(dst) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeModDown rejects foreign modulus in rescale_base") {
+TEST_CASE("hazeModDown rejects foreign modulus in rescale_base", "[integration]") {
     // rescale_base contains a prime not present in src_base. The HAZE
     // layer must reject this BEFORE opening an EpochSession — otherwise
     // the next D2H would replay a dirty recording and crash.
@@ -114,6 +114,7 @@ TEST_CASE("hazeModDown rejects foreign modulus in rescale_base") {
     REQUIRE(hazeMemcpy(b, vb.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
     REQUIRE(hazeAdd(c, a, b, 0, nullptr) == HAZE_SUCCESS);
     std::vector<uint64_t> out(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out.data(), c, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     REQUIRE(out[0] == 3);
 
@@ -123,7 +124,7 @@ TEST_CASE("hazeModDown rejects foreign modulus in rescale_base") {
     REQUIRE(hazeFree(d) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeModDown rejects rescale_base_len >= src_base_len") {
+TEST_CASE("hazeModDown rejects rescale_base_len >= src_base_len", "[unit]") {
     // Equal-length rescale would leave dst empty (FhetchApi.cpp:1660
     // asserts rescale must be a *proper* subset). Strictly-greater is
     // outright invalid. Both must surface as INVALID_VALUE before any
@@ -153,7 +154,7 @@ TEST_CASE("hazeModDown rejects rescale_base_len >= src_base_len") {
     REQUIRE(hazeFree(dst) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeModUp rejects mismatched digit_bases_total_len") {
+TEST_CASE("hazeModUp rejects mismatched digit_bases_total_len", "[unit]") {
     // digit_bases is flat; sum of digit_base_lens must equal
     // digit_bases_total_len, else slicing reads out of bounds.
     configure_three_moduli();
@@ -199,7 +200,7 @@ TEST_CASE("hazeModUp rejects mismatched digit_bases_total_len") {
 // Cross-checking non-trivial FBC values against an OpenFHE reference
 // is deferred to integration tests (FIDESlib examples).
 
-TEST_CASE("hazeBasisConvert: shared-modulus copies produce input values") {
+TEST_CASE("hazeBasisConvert: shared-modulus copies produce input values", "[integration]") {
     // src_base = {q0, q1}, dst_base = {q0, q1, q2}. Every prime in
     // src_base is also in dst_base, so the first two dst residues are
     // same-modulus copies of the corresponding src residues. The third
@@ -241,8 +242,11 @@ TEST_CASE("hazeBasisConvert: shared-modulus copies produce input values") {
     std::vector<uint64_t> out0(kRingDim, 0);
     std::vector<uint64_t> out1(kRingDim, 0);
     std::vector<uint64_t> out2(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out0.data(), d0, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out1.data(), d1, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out2.data(), d2, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     // Same-modulus copies: dst residue == src residue, every coefficient.
@@ -252,7 +256,7 @@ TEST_CASE("hazeBasisConvert: shared-modulus copies produce input values") {
     }
 }
 
-TEST_CASE("hazeBasisConvert: zero input produces zero output") {
+TEST_CASE("hazeBasisConvert: zero input produces zero output", "[integration]") {
     // FBC of zero polynomials is zero on every target modulus, so we
     // can verify the non-trivial dst residues without computing FBC.
     configure_three_moduli();
@@ -284,7 +288,9 @@ TEST_CASE("hazeBasisConvert: zero input produces zero output") {
 
     std::vector<uint64_t> out0(kRingDim, 0xDEADBEEF);
     std::vector<uint64_t> out1(kRingDim, 0xDEADBEEF);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out0.data(), d0, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out1.data(), d1, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     // Catches both (a) a backend that writes garbage and (b) the
@@ -297,7 +303,7 @@ TEST_CASE("hazeBasisConvert: zero input produces zero output") {
     }
 }
 
-TEST_CASE("hazeBasisConvert: src/dst aliasing is safe (in-place 1->1)") {
+TEST_CASE("hazeBasisConvert: src/dst aliasing is safe (in-place 1->1)", "[integration]") {
     // Aliasing src[i] == dst[j] for any (i,j) is documented as safe in
     // core/basis_convert.cpp because all reads complete before any
     // store. Test the simplest case: same-modulus 1->1 convert with
@@ -322,21 +328,22 @@ TEST_CASE("hazeBasisConvert: src/dst aliasing is safe (in-place 1->1)") {
     REQUIRE(hazeBasisConvert(dst_polys, src_polys, &p, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> out(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out.data(), p0, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     REQUIRE(out[0] == 42);
 
     REQUIRE(hazeFree(p0) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeModDown: zero input rescales to zero output") {
+TEST_CASE("hazeModDown: zero input rescales to zero output", "[integration]") {
     // ApproxModDown is rescale_fbc(x, rescale_base): CRT-divide x by
     // P=prod(rescale_base) with rounding. For x identically zero on
     // every residue, every output is also zero — we can assert exact
     // values without doing any FBC arithmetic.
     //
-    // Multi-output verification: with the EpochState::flush_for_d2h
-    // fix, both d0 and d1 shadow buffers are persisted on the first
-    // D2H, so reading both back returns the materialized result, not
+    // Multi-output verification: replay_and_populate writes every bound
+    // compute result back to its shadow buffer in one pass, so reading
+    // both d0 and d1 back via D2H returns the materialized result, not
     // stale post-allocator-reset memory.
     configure_three_moduli();
 
@@ -371,7 +378,9 @@ TEST_CASE("hazeModDown: zero input rescales to zero output") {
     // Initialise to non-zero so a no-op D2H would surface as a failure.
     std::vector<uint64_t> out0(kRingDim, 0xDEADBEEF);
     std::vector<uint64_t> out1(kRingDim, 0xDEADBEEF);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out0.data(), d0, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out1.data(), d1, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     for (uint64_t i = 0; i < kRingDim; ++i) {
         REQUIRE(out0[i] == 0);
@@ -385,7 +394,7 @@ TEST_CASE("hazeModDown: zero input rescales to zero output") {
     REQUIRE(hazeFree(d1) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeModUp: zero input produces zero output across both digits") {
+TEST_CASE("hazeModUp: zero input produces zero output across both digits", "[integration]") {
     // dig_decomp(x, digit_bases, p_base): for each digit i, take the
     // x|_{digit_bases[i]} subset and FBC-extend it onto src_base ∪
     // p_base. For x identically zero, every digit's every output is
@@ -431,6 +440,7 @@ TEST_CASE("hazeModUp: zero input produces zero output across both digits") {
 
     // D2H every output and verify exact zero. Initialise the host
     // buffer to a sentinel so a skipped D2H is detectable.
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     for (size_t slot = 0; slot < 6; ++slot) {
         std::vector<uint64_t> out(kRingDim, 0xDEADBEEF);
         REQUIRE(hazeMemcpy(out.data(), dst_storage[slot], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) ==
@@ -744,6 +754,7 @@ static void check_against_reference(const std::vector<void *> &dst,
     REQUIRE(dst.size() == dst_base.size());
     for (size_t j = 0; j < dst.size(); ++j) {
         std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeReplay() == HAZE_SUCCESS);
         REQUIRE(hazeMemcpy(got.data(), dst[j], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
         for (uint64_t s = 0; s < kRingDim; ++s) {
             INFO("dst index " << j << " (mod " << dst_base[j] << ") slot " << s);
@@ -754,7 +765,7 @@ static void check_against_reference(const std::vector<void *> &dst,
 
 } // namespace
 
-TEST_CASE("hazeBasisConvert: 12-limb fast base convert matches reference") {
+TEST_CASE("hazeBasisConvert: 12-limb fast base convert matches reference", "[integration]") {
     configure_sixteen_moduli();
 
     const std::vector<uint64_t> src_base(kBigBase, kBigBase + kSrcLimbs);
@@ -788,7 +799,7 @@ TEST_CASE("hazeBasisConvert: 12-limb fast base convert matches reference") {
     free_all(dst_ptrs);
 }
 
-TEST_CASE("hazeModDown: 12-limb rescale matches reference") {
+TEST_CASE("hazeModDown: 12-limb rescale matches reference", "[integration]") {
     configure_sixteen_moduli();
 
     const std::vector<uint64_t> src_base(kBigBase, kBigBase + kSrcLimbs);
@@ -825,7 +836,7 @@ TEST_CASE("hazeModDown: 12-limb rescale matches reference") {
     free_all(dst_ptrs);
 }
 
-TEST_CASE("hazeModUp: 12-limb digit-decomp matches reference") {
+TEST_CASE("hazeModUp: 12-limb digit-decomp matches reference", "[integration]") {
     configure_sixteen_moduli();
 
     const std::vector<uint64_t> src_base(kBigBase, kBigBase + kSrcLimbs);

--- a/test/test_build.cpp
+++ b/test/test_build.cpp
@@ -19,12 +19,12 @@
 #include <string_view>
 #include <thread>
 
-TEST_CASE("hazeGetLastError returns HAZE_SUCCESS by default") {
+TEST_CASE("hazeGetLastError returns HAZE_SUCCESS by default", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeGetLastError() == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeGetLastError clears after read") {
+TEST_CASE("hazeGetLastError clears after read", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Use a graph stub to set a real error, then verify clear-on-read semantics.
     const hazeError_t ignored = hazeStreamBeginCapture(nullptr);
@@ -44,7 +44,7 @@ TEST_CASE("hazeGetErrorString returns \"unknown error\" for out-of-range codes")
     REQUIRE(std::string_view(hazeGetErrorString(unknown)) == "unknown error");
 }
 
-TEST_CASE("hazeGetDeviceCount compiles and links") {
+TEST_CASE("hazeGetDeviceCount compiles and links", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     int count = -1;
     REQUIRE(hazeGetDeviceCount(&count) == HAZE_SUCCESS);
@@ -56,7 +56,7 @@ TEST_CASE("hazeGetDeviceCount compiles and links") {
 // the eventual hazeStreamEndCapture would give the caller a null/empty graph
 // that looks real — corrupting any graph-replay code path. An explicit
 // error surfaces the missing feature immediately.
-TEST_CASE("graph API returns HAZE_ERROR_NOT_SUPPORTED") {
+TEST_CASE("graph API returns HAZE_ERROR_NOT_SUPPORTED", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeStreamBeginCapture(nullptr)          == HAZE_ERROR_NOT_SUPPORTED);
     hazeGetLastError();
@@ -66,7 +66,7 @@ TEST_CASE("graph API returns HAZE_ERROR_NOT_SUPPORTED") {
     hazeGetLastError();
 }
 
-TEST_CASE("multi-device stubs return HAZE_ERROR_NOT_SUPPORTED") {
+TEST_CASE("multi-device stubs return HAZE_ERROR_NOT_SUPPORTED", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     int can_access = -1;
     REQUIRE(hazeDeviceCanAccessPeer(&can_access, 0, 1) == HAZE_ERROR_NOT_SUPPORTED);
@@ -75,7 +75,7 @@ TEST_CASE("multi-device stubs return HAZE_ERROR_NOT_SUPPORTED") {
     hazeGetLastError();
 }
 
-TEST_CASE("successful stubs do not pollute error state") {
+TEST_CASE("successful stubs do not pollute error state", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Ensure a sequence of successful calls leaves hazeGetLastError as HAZE_SUCCESS.
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
@@ -90,7 +90,7 @@ TEST_CASE("successful stubs do not pollute error state") {
 // idioms port unchanged. Functions also return their error directly — the
 // thread-local state is a convenience, not the primary error channel.
 // Reference: https://parallelprogrammer.substack.com/p/cuda-error-handling-a-definitive
-TEST_CASE("error state is thread-local") {
+TEST_CASE("error state is thread-local", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Set an error in the main thread.
     hazeStreamBeginCapture(nullptr);

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -14,26 +14,8 @@ static constexpr size_t kBytes = kRingDim * sizeof(uint64_t);
 static constexpr uint64_t kModulus = 576460752303415297ULL;
 static constexpr int kModIdx = 0;
 
-// Ensures ring dim and modulus are set before each compute test.
-// Called explicitly in each test case because global state persists.
-// hazeDeviceReset() runs first so each test starts from a clean
-// allocator/epoch state — see docs/lazy_shadow_flake.md for the
-// open intermittent-failure investigation that motivated uniform
-// reset across the suite.
-//
-// `modulus` defaults to kModulus for unit-style cases that don't go
-// through the FHETCH transport. Integration tests pass the picked
-// modulus from haze::test::init_integration_modulus so the recording-
-// side arithmetic matches the simulator's tower modulus.
-static void setup_compute_config(uint64_t modulus = kModulus) {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(kModIdx, modulus) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
-}
-
 TEST_CASE("hazeAdd: pointwise sum retrieved after D2H", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -61,7 +43,7 @@ TEST_CASE("hazeAdd: pointwise sum retrieved after D2H", "[integration]") {
 }
 
 TEST_CASE("hazeSub: pointwise difference retrieved after D2H", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -89,7 +71,7 @@ TEST_CASE("hazeSub: pointwise difference retrieved after D2H", "[integration]") 
 }
 
 TEST_CASE("hazeMulScalar: pointwise scalar product retrieved after D2H", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -114,7 +96,7 @@ TEST_CASE("hazeMulScalar: pointwise scalar product retrieved after D2H", "[integ
 }
 
 TEST_CASE("hazeAddScalar: pointwise scalar addition retrieved after D2H", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -143,7 +125,7 @@ TEST_CASE("hazeAddScalar: pointwise scalar addition retrieved after D2H", "[inte
 // ---------------------------------------------------------------------------
 
 TEST_CASE("NTT round-trip: INTT(NTT(x)) == x", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_src = nullptr, *d_ntt = nullptr, *d_intt = nullptr;
     REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
@@ -175,7 +157,7 @@ TEST_CASE("NTT round-trip: INTT(NTT(x)) == x", "[integration]") {
 // ---------------------------------------------------------------------------
 
 TEST_CASE("hazeAdd in-place (dst == src1) produces correct result", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -201,7 +183,7 @@ TEST_CASE("hazeAdd in-place (dst == src1) produces correct result", "[integratio
 }
 
 TEST_CASE("hazeAdd in-place (dst == src2) produces correct result", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -227,7 +209,7 @@ TEST_CASE("hazeAdd in-place (dst == src2) produces correct result", "[integratio
 }
 
 TEST_CASE("hazeAdd in-place squaring-style (dst == src1 == src2)", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -254,7 +236,7 @@ TEST_CASE("hazeAdd in-place squaring-style (dst == src1 == src2)", "[integration
 // ---------------------------------------------------------------------------
 
 TEST_CASE("multi-operation chain: add then mulscalar in one recording", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr, *d_t = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -289,7 +271,7 @@ TEST_CASE("multi-operation chain: add then mulscalar in one recording", "[integr
 // ---------------------------------------------------------------------------
 
 TEST_CASE("multiple materializations: two independent D2H cycles", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst1 = nullptr, *d_dst2 = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -337,7 +319,7 @@ TEST_CASE("multiple materializations: two independent D2H cycles", "[integration
 // ---------------------------------------------------------------------------
 
 TEST_CASE("hazeDeviceSynchronize does not trigger materialization", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -371,7 +353,10 @@ TEST_CASE("hazeDeviceSynchronize does not trigger materialization", "[integratio
 // ---------------------------------------------------------------------------
 
 TEST_CASE("hazeAdd with unknown source address returns error", "[unit]") {
-    setup_compute_config();
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(kModIdx, kModulus) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     void *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
@@ -386,7 +371,10 @@ TEST_CASE("hazeAdd with unknown source address returns error", "[unit]") {
 }
 
 TEST_CASE("hazeAdd with invalid modulus index returns error", "[unit]") {
-    setup_compute_config();
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(kModIdx, kModulus) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -420,7 +408,7 @@ TEST_CASE("hazeAdd with invalid modulus index returns error", "[unit]") {
 // pass and skips the fresh shadow data. Same shape applies to memset.
 
 TEST_CASE("H2D after compute invalidates the polymap binding", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst1 = nullptr, *d_dst2 = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -454,7 +442,7 @@ TEST_CASE("H2D after compute invalidates the polymap binding", "[integration]") 
 }
 
 TEST_CASE("memset after compute invalidates the polymap binding", "[integration]") {
-    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
+    haze::test::setup_integration_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst1 = nullptr, *d_dst2 = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -7,6 +7,8 @@
 #include <haze/haze_types.h>
 #include <vector>
 
+#include "integration_helpers.hpp"
+
 static constexpr uint64_t kRingDim = 4096;
 static constexpr size_t kBytes = kRingDim * sizeof(uint64_t);
 static constexpr uint64_t kModulus = 576460752303415297ULL;
@@ -18,15 +20,20 @@ static constexpr int kModIdx = 0;
 // allocator/epoch state — see docs/lazy_shadow_flake.md for the
 // open intermittent-failure investigation that motivated uniform
 // reset across the suite.
-static void setup_compute_config() {
+//
+// `modulus` defaults to kModulus for unit-style cases that don't go
+// through the FHETCH transport. Integration tests pass the picked
+// modulus from haze::test::init_integration_modulus so the recording-
+// side arithmetic matches the simulator's tower modulus.
+static void setup_compute_config(uint64_t modulus = kModulus) {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(kModIdx, kModulus) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(kModIdx, modulus) == HAZE_SUCCESS);
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeAdd: pointwise sum retrieved after D2H") {
-    setup_compute_config();
+TEST_CASE("hazeAdd: pointwise sum retrieved after D2H", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -41,6 +48,7 @@ TEST_CASE("hazeAdd: pointwise sum retrieved after D2H") {
     REQUIRE(hazeAdd(d_dst, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -52,8 +60,8 @@ TEST_CASE("hazeAdd: pointwise sum retrieved after D2H") {
     REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeSub: pointwise difference retrieved after D2H") {
-    setup_compute_config();
+TEST_CASE("hazeSub: pointwise difference retrieved after D2H", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -68,6 +76,7 @@ TEST_CASE("hazeSub: pointwise difference retrieved after D2H") {
     REQUIRE(hazeSub(d_dst, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -79,8 +88,8 @@ TEST_CASE("hazeSub: pointwise difference retrieved after D2H") {
     REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeMulScalar: pointwise scalar product retrieved after D2H") {
-    setup_compute_config();
+TEST_CASE("hazeMulScalar: pointwise scalar product retrieved after D2H", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -93,6 +102,7 @@ TEST_CASE("hazeMulScalar: pointwise scalar product retrieved after D2H") {
     REQUIRE(hazeMulScalar(d_dst, d_a, 4, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -103,8 +113,8 @@ TEST_CASE("hazeMulScalar: pointwise scalar product retrieved after D2H") {
     REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeAddScalar: pointwise scalar addition retrieved after D2H") {
-    setup_compute_config();
+TEST_CASE("hazeAddScalar: pointwise scalar addition retrieved after D2H", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -117,6 +127,7 @@ TEST_CASE("hazeAddScalar: pointwise scalar addition retrieved after D2H") {
     REQUIRE(hazeAddScalar(d_dst, d_a, 3, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -131,8 +142,8 @@ TEST_CASE("hazeAddScalar: pointwise scalar addition retrieved after D2H") {
 // NTT / INTT round-trip
 // ---------------------------------------------------------------------------
 
-TEST_CASE("NTT round-trip: INTT(NTT(x)) == x") {
-    setup_compute_config();
+TEST_CASE("NTT round-trip: INTT(NTT(x)) == x", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_src = nullptr, *d_ntt = nullptr, *d_intt = nullptr;
     REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
@@ -147,6 +158,7 @@ TEST_CASE("NTT round-trip: INTT(NTT(x)) == x") {
     REQUIRE(hazeINTT(d_intt, d_ntt, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_intt, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -162,8 +174,8 @@ TEST_CASE("NTT round-trip: INTT(NTT(x)) == x") {
 // In-place operations
 // ---------------------------------------------------------------------------
 
-TEST_CASE("hazeAdd in-place (dst == src1) produces correct result") {
-    setup_compute_config();
+TEST_CASE("hazeAdd in-place (dst == src1) produces correct result", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -177,6 +189,7 @@ TEST_CASE("hazeAdd in-place (dst == src1) produces correct result") {
     REQUIRE(hazeAdd(d_a, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_a, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -187,8 +200,8 @@ TEST_CASE("hazeAdd in-place (dst == src1) produces correct result") {
     REQUIRE(hazeFree(d_b) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeAdd in-place (dst == src2) produces correct result") {
-    setup_compute_config();
+TEST_CASE("hazeAdd in-place (dst == src2) produces correct result", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -202,6 +215,7 @@ TEST_CASE("hazeAdd in-place (dst == src2) produces correct result") {
     REQUIRE(hazeAdd(d_b, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_b, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -212,8 +226,8 @@ TEST_CASE("hazeAdd in-place (dst == src2) produces correct result") {
     REQUIRE(hazeFree(d_b) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeAdd in-place squaring-style (dst == src1 == src2)") {
-    setup_compute_config();
+TEST_CASE("hazeAdd in-place squaring-style (dst == src1 == src2)", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -225,6 +239,7 @@ TEST_CASE("hazeAdd in-place squaring-style (dst == src1 == src2)") {
     REQUIRE(hazeAdd(d_a, d_a, d_a, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_a, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -238,8 +253,8 @@ TEST_CASE("hazeAdd in-place squaring-style (dst == src1 == src2)") {
 // Multi-operation chains
 // ---------------------------------------------------------------------------
 
-TEST_CASE("multi-operation chain: add then mulscalar in one recording") {
-    setup_compute_config();
+TEST_CASE("multi-operation chain: add then mulscalar in one recording", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr, *d_t = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -256,6 +271,7 @@ TEST_CASE("multi-operation chain: add then mulscalar in one recording") {
     REQUIRE(hazeMulScalar(d_dst, d_t, 2, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -272,8 +288,8 @@ TEST_CASE("multi-operation chain: add then mulscalar in one recording") {
 // Multiple materializations
 // ---------------------------------------------------------------------------
 
-TEST_CASE("multiple materializations: two independent D2H cycles") {
-    setup_compute_config();
+TEST_CASE("multiple materializations: two independent D2H cycles", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst1 = nullptr, *d_dst2 = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -288,6 +304,7 @@ TEST_CASE("multiple materializations: two independent D2H cycles") {
     REQUIRE(hazeAdd(d_dst1, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> r1(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(r1.data(), d_dst1, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -302,6 +319,7 @@ TEST_CASE("multiple materializations: two independent D2H cycles") {
     REQUIRE(hazeAdd(d_dst2, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> r2(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(r2.data(), d_dst2, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -318,8 +336,8 @@ TEST_CASE("multiple materializations: two independent D2H cycles") {
 // hazeDeviceSynchronize is a no-op (does not trigger materialization)
 // ---------------------------------------------------------------------------
 
-TEST_CASE("hazeDeviceSynchronize does not trigger materialization") {
-    setup_compute_config();
+TEST_CASE("hazeDeviceSynchronize does not trigger materialization", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -335,6 +353,7 @@ TEST_CASE("hazeDeviceSynchronize does not trigger materialization") {
     REQUIRE(hazeDeviceSynchronize() == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     // If sync had flushed state, result would be stale/zero. Correct: 6.
@@ -351,7 +370,7 @@ TEST_CASE("hazeDeviceSynchronize does not trigger materialization") {
 // Error cases
 // ---------------------------------------------------------------------------
 
-TEST_CASE("hazeAdd with unknown source address returns error") {
+TEST_CASE("hazeAdd with unknown source address returns error", "[unit]") {
     setup_compute_config();
 
     void *d_dst = nullptr;
@@ -366,7 +385,7 @@ TEST_CASE("hazeAdd with unknown source address returns error") {
     REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeAdd with invalid modulus index returns error") {
+TEST_CASE("hazeAdd with invalid modulus index returns error", "[unit]") {
     setup_compute_config();
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
@@ -400,8 +419,8 @@ TEST_CASE("hazeAdd with invalid modulus index returns error") {
 // because lookup_or_create finds the still-bound polynomial from the first
 // pass and skips the fresh shadow data. Same shape applies to memset.
 
-TEST_CASE("H2D after compute invalidates the polymap binding") {
-    setup_compute_config();
+TEST_CASE("H2D after compute invalidates the polymap binding", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst1 = nullptr, *d_dst2 = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -422,6 +441,7 @@ TEST_CASE("H2D after compute invalidates the polymap binding") {
     REQUIRE(hazeAdd(d_dst2, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> r2(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(r2.data(), d_dst2, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     for (uint64_t i = 0; i < kRingDim; ++i) {
         REQUIRE(r2[i] == 23);
@@ -433,8 +453,8 @@ TEST_CASE("H2D after compute invalidates the polymap binding") {
     REQUIRE(hazeFree(d_dst2) == HAZE_SUCCESS);
 }
 
-TEST_CASE("memset after compute invalidates the polymap binding") {
-    setup_compute_config();
+TEST_CASE("memset after compute invalidates the polymap binding", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kModulus, kModIdx);
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst1 = nullptr, *d_dst2 = nullptr;
     REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -453,6 +473,7 @@ TEST_CASE("memset after compute invalidates the polymap binding") {
     REQUIRE(hazeAdd(d_dst2, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> r2(kRingDim, 0);
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(r2.data(), d_dst2, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     for (uint64_t i = 0; i < kRingDim; ++i) {
         REQUIRE(r2[i] == 5);

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -11,7 +11,7 @@
 // observable through the public API. Each accept test below carries a
 // short note where read-back would otherwise belong.
 
-TEST_CASE("hazeSetRingDimension accepts valid power-of-2 dimensions") {
+TEST_CASE("hazeSetRingDimension accepts valid power-of-2 dimensions", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     // No public getter for ring dimension; HAZE_SUCCESS is the only assertion.
@@ -21,7 +21,7 @@ TEST_CASE("hazeSetRingDimension accepts valid power-of-2 dimensions") {
     REQUIRE(hazeSetRingDimension(65536) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeSetRingDimension rejects unsupported dimensions") {
+TEST_CASE("hazeSetRingDimension rejects unsupported dimensions", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(0) == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
@@ -33,7 +33,7 @@ TEST_CASE("hazeSetRingDimension rejects unsupported dimensions") {
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeSetCiphertextModulus stores values") {
+TEST_CASE("hazeSetCiphertextModulus stores values", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Two distinct NTT-friendly primes (q ≡ 1 mod 2N) for N=4096; the
     // same constants are used by test_basis_convert.cpp.
@@ -44,49 +44,49 @@ TEST_CASE("hazeSetCiphertextModulus stores values") {
     // No public getter for the moduli table; HAZE_SUCCESS is the only assertion.
 }
 
-TEST_CASE("hazeSetCiphertextModulus rejects negative index") {
+TEST_CASE("hazeSetCiphertextModulus rejects negative index", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetCiphertextModulus(-1, 1) == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeSetCiphertextModulus rejects zero modulus") {
+TEST_CASE("hazeSetCiphertextModulus rejects zero modulus", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetCiphertextModulus(0, 0) == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeSetTwiddleFactors accepts valid indices") {
+TEST_CASE("hazeSetTwiddleFactors accepts valid indices", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetTwiddleFactors(0, 3) == HAZE_SUCCESS);
     REQUIRE(hazeSetTwiddleFactors(1, 5) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeSetTwiddleFactors rejects negative index") {
+TEST_CASE("hazeSetTwiddleFactors rejects negative index", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetTwiddleFactors(-1, 3) == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeConfigureDevice fails without ring dimension") {
+TEST_CASE("hazeConfigureDevice fails without ring dimension", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeConfigureDevice() == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeConfigureDevice succeeds when ring dimension is set") {
+TEST_CASE("hazeConfigureDevice succeeds when ring dimension is set", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeSetProgramInfo accepts well-formed strings") {
+TEST_CASE("hazeSetProgramInfo accepts well-formed strings", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetProgramInfo("my-program", "1.2.3", "experimental run") == HAZE_SUCCESS);
     // No public getter for program info; HAZE_SUCCESS is the only assertion.
 }
 
-TEST_CASE("hazeSetProgramInfo rejects null arguments") {
+TEST_CASE("hazeSetProgramInfo rejects null arguments", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetProgramInfo(nullptr, "1.0", "desc") == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
@@ -96,19 +96,19 @@ TEST_CASE("hazeSetProgramInfo rejects null arguments") {
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeSetTarget accepts a target string") {
+TEST_CASE("hazeSetTarget accepts a target string", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetTarget("FHE_SIM") == HAZE_SUCCESS);
     // No public getter for target; HAZE_SUCCESS is the only assertion.
 }
 
-TEST_CASE("hazeSetTarget rejects null") {
+TEST_CASE("hazeSetTarget rejects null", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetTarget(nullptr) == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeDeviceReset returns success and re-permits configuration") {
+TEST_CASE("hazeDeviceReset returns success and re-permits configuration", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -11,14 +11,24 @@
 // observable through the public API. Each accept test below carries a
 // short note where read-back would otherwise belong.
 
-TEST_CASE("hazeSetRingDimension accepts valid power-of-2 dimensions", "[unit]") {
+TEST_CASE("haze setters accept well-formed inputs", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    // No public getter for ring dimension; HAZE_SUCCESS is the only assertion.
-    REQUIRE(hazeSetRingDimension(8192) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(16384) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(32768) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(65536) == HAZE_SUCCESS);
+    // Ring dimension: every supported power-of-2.
+    for (uint64_t n : {4096ULL, 8192ULL, 16384ULL, 32768ULL, 65536ULL}) {
+        REQUIRE(hazeSetRingDimension(n) == HAZE_SUCCESS);
+    }
+    // Two distinct NTT-friendly primes (q ≡ 1 mod 2N) for N=4096; the
+    // same constants are used by test_basis_convert.cpp.
+    constexpr uint64_t kQ0 = 576460752303415297ULL;
+    constexpr uint64_t kQ1 = 576460752303439873ULL;
+    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
+    REQUIRE(hazeSetTwiddleFactors(0, 3) == HAZE_SUCCESS);
+    REQUIRE(hazeSetTwiddleFactors(1, 5) == HAZE_SUCCESS);
+    REQUIRE(hazeSetProgramInfo("my-program", "1.2.3", "experimental run") == HAZE_SUCCESS);
+    REQUIRE(hazeSetTarget("FHE_SIM") == HAZE_SUCCESS);
+    // No public getters; HAZE_SUCCESS is the only assertion. The
+    // companion "rejects ..." TEST_CASEs cover the validation gates.
 }
 
 TEST_CASE("hazeSetRingDimension rejects unsupported dimensions", "[unit]") {
@@ -33,17 +43,6 @@ TEST_CASE("hazeSetRingDimension rejects unsupported dimensions", "[unit]") {
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeSetCiphertextModulus stores values", "[unit]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    // Two distinct NTT-friendly primes (q ≡ 1 mod 2N) for N=4096; the
-    // same constants are used by test_basis_convert.cpp.
-    constexpr uint64_t kQ0 = 576460752303415297ULL;
-    constexpr uint64_t kQ1 = 576460752303439873ULL;
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-    // No public getter for the moduli table; HAZE_SUCCESS is the only assertion.
-}
-
 TEST_CASE("hazeSetCiphertextModulus rejects negative index", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetCiphertextModulus(-1, 1) == HAZE_ERROR_INVALID_VALUE);
@@ -54,12 +53,6 @@ TEST_CASE("hazeSetCiphertextModulus rejects zero modulus", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetCiphertextModulus(0, 0) == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-}
-
-TEST_CASE("hazeSetTwiddleFactors accepts valid indices", "[unit]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTwiddleFactors(0, 3) == HAZE_SUCCESS);
-    REQUIRE(hazeSetTwiddleFactors(1, 5) == HAZE_SUCCESS);
 }
 
 TEST_CASE("hazeSetTwiddleFactors rejects negative index", "[unit]") {
@@ -80,12 +73,6 @@ TEST_CASE("hazeConfigureDevice succeeds when ring dimension is set", "[unit]") {
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeSetProgramInfo accepts well-formed strings", "[unit]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetProgramInfo("my-program", "1.2.3", "experimental run") == HAZE_SUCCESS);
-    // No public getter for program info; HAZE_SUCCESS is the only assertion.
-}
-
 TEST_CASE("hazeSetProgramInfo rejects null arguments", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetProgramInfo(nullptr, "1.0", "desc") == HAZE_ERROR_INVALID_VALUE);
@@ -94,12 +81,6 @@ TEST_CASE("hazeSetProgramInfo rejects null arguments", "[unit]") {
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeSetProgramInfo("name", "1.0", nullptr) == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-}
-
-TEST_CASE("hazeSetTarget accepts a target string", "[unit]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("FHE_SIM") == HAZE_SUCCESS);
-    // No public getter for target; HAZE_SUCCESS is the only assertion.
 }
 
 TEST_CASE("hazeSetTarget rejects null", "[unit]") {

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -14,7 +14,7 @@
 // hazeSetRingDimension. Tests here always set ring_dim before
 // allocating to make that contract explicit.
 
-TEST_CASE("hazeMalloc returns non-null pointer") {
+TEST_CASE("hazeMalloc returns non-null pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     void* p = nullptr;
@@ -23,20 +23,20 @@ TEST_CASE("hazeMalloc returns non-null pointer") {
     REQUIRE(hazeFree(p) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeMalloc null ptr arg returns error") {
+TEST_CASE("hazeMalloc null ptr arg returns error", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeMalloc(nullptr, 32768) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 }
 
-TEST_CASE("hazeMalloc before hazeSetRingDimension is rejected") {
+TEST_CASE("hazeMalloc before hazeSetRingDimension is rejected", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS); // ensure ring_dim cleared
     void* p = nullptr;
     REQUIRE(hazeMalloc(&p, 32768) == HAZE_ERROR_CONFIGERR);
     hazeGetLastError();
 }
 
-TEST_CASE("hazeMalloc with size != polynomial bytes is rejected") {
+TEST_CASE("hazeMalloc with size != polynomial bytes is rejected", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     void* p = nullptr;
@@ -45,7 +45,7 @@ TEST_CASE("hazeMalloc with size != polynomial bytes is rejected") {
     hazeGetLastError();
 }
 
-TEST_CASE("distinct allocations produce non-overlapping addresses") {
+TEST_CASE("distinct allocations produce non-overlapping addresses", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     void* p1 = nullptr;
@@ -57,7 +57,7 @@ TEST_CASE("distinct allocations produce non-overlapping addresses") {
     REQUIRE(hazeFree(p2) == HAZE_SUCCESS);
 }
 
-TEST_CASE("free then re-allocate recycles pooled address") {
+TEST_CASE("free then re-allocate recycles pooled address", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
 
@@ -71,7 +71,7 @@ TEST_CASE("free then re-allocate recycles pooled address") {
     REQUIRE(hazeFree(p2) == HAZE_SUCCESS);
 }
 
-TEST_CASE("H2D memcpy stores data in shadow buffer") {
+TEST_CASE("H2D memcpy stores data in shadow buffer", "[unit]") {
     constexpr size_t kN = 4096;
     constexpr size_t kBytes = kN * sizeof(uint64_t);
 
@@ -89,7 +89,7 @@ TEST_CASE("H2D memcpy stores data in shadow buffer") {
     REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
 }
 
-TEST_CASE("H2D then D2H round-trip preserves data") {
+TEST_CASE("H2D then D2H round-trip preserves data", "[unit]") {
     constexpr size_t kN = 4096;
     constexpr size_t kBytes = kN * sizeof(uint64_t);
 
@@ -112,7 +112,7 @@ TEST_CASE("H2D then D2H round-trip preserves data") {
     REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
 }
 
-TEST_CASE("D2D memcpy copies shadow buffer") {
+TEST_CASE("D2D memcpy copies shadow buffer", "[unit]") {
     constexpr size_t kBytes = 32768;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
@@ -138,7 +138,7 @@ TEST_CASE("D2D memcpy copies shadow buffer") {
     REQUIRE(hazeFree(dst_dev) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeMemset fills shadow buffer") {
+TEST_CASE("hazeMemset fills shadow buffer", "[unit]") {
     constexpr size_t kBytes = 32768;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
@@ -155,7 +155,7 @@ TEST_CASE("hazeMemset fills shadow buffer") {
     REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeHostAlloc/Free round-trip") {
+TEST_CASE("hazeHostAlloc/Free round-trip", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     void* p = nullptr;
     REQUIRE(hazeHostAlloc(&p, 4096, 0) == HAZE_SUCCESS);
@@ -163,7 +163,7 @@ TEST_CASE("hazeHostAlloc/Free round-trip") {
     hazeFreeHost(p);
 }
 
-TEST_CASE("hazeMallocAsync/FreeAsync behave like sync versions") {
+TEST_CASE("hazeMallocAsync/FreeAsync behave like sync versions", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     hazeStream_t stream = nullptr;
@@ -177,7 +177,7 @@ TEST_CASE("hazeMallocAsync/FreeAsync behave like sync versions") {
     REQUIRE(hazeStreamDestroy(stream) == HAZE_SUCCESS);
 }
 
-TEST_CASE("create and destroy 100 streams without leaks") {
+TEST_CASE("create and destroy 100 streams without leaks", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     for (int i = 0; i < 100; ++i) {
         hazeStream_t s = nullptr;
@@ -187,7 +187,7 @@ TEST_CASE("create and destroy 100 streams without leaks") {
     }
 }
 
-TEST_CASE("create and destroy 100 events without leaks") {
+TEST_CASE("create and destroy 100 events without leaks", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     for (int i = 0; i < 100; ++i) {
         hazeEvent_t e = nullptr;
@@ -197,7 +197,7 @@ TEST_CASE("create and destroy 100 events without leaks") {
     }
 }
 
-TEST_CASE("hazeStreamSynchronize is a no-op returning HAZE_SUCCESS") {
+TEST_CASE("hazeStreamSynchronize is a no-op returning HAZE_SUCCESS", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     hazeStream_t s = nullptr;
     REQUIRE(hazeStreamCreate(&s) == HAZE_SUCCESS);
@@ -206,13 +206,13 @@ TEST_CASE("hazeStreamSynchronize is a no-op returning HAZE_SUCCESS") {
     REQUIRE(hazeStreamDestroy(s) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeDeviceSynchronize is a no-op returning HAZE_SUCCESS") {
+TEST_CASE("hazeDeviceSynchronize is a no-op returning HAZE_SUCCESS", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeDeviceSynchronize() == HAZE_SUCCESS);
     REQUIRE(hazeGetLastError() == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeGetDeviceProperties returns FPGA values") {
+TEST_CASE("hazeGetDeviceProperties returns FPGA values", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     hazeDeviceProp prop{};
     REQUIRE(hazeGetDeviceProperties(&prop, 0) == HAZE_SUCCESS);
@@ -229,14 +229,14 @@ TEST_CASE("hazeGetDeviceProperties returns FPGA values") {
     REQUIRE(found_12);
 }
 
-TEST_CASE("hazeGetDeviceCount returns 1") {
+TEST_CASE("hazeGetDeviceCount returns 1", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     int count = 0;
     REQUIRE(hazeGetDeviceCount(&count) == HAZE_SUCCESS);
     REQUIRE(count == 1);
 }
 
-TEST_CASE("NULL stream argument uses default stream") {
+TEST_CASE("NULL stream argument uses default stream", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeStreamSynchronize(nullptr) == HAZE_SUCCESS);
     hazeEvent_t e = nullptr;
@@ -246,7 +246,7 @@ TEST_CASE("NULL stream argument uses default stream") {
     REQUIRE(hazeEventDestroy(e) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazePointerGetAttributes reports device type for hazeMalloc'd pointer") {
+TEST_CASE("hazePointerGetAttributes reports device type for hazeMalloc'd pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     void* dev = nullptr;
@@ -259,7 +259,7 @@ TEST_CASE("hazePointerGetAttributes reports device type for hazeMalloc'd pointer
     REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazePointerGetAttributes reports unregistered for foreign pointers") {
+TEST_CASE("hazePointerGetAttributes reports unregistered for foreign pointers", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // A stack pointer was never registered with hazeHostAlloc, so it
     // reports UNREGISTERED — matches cudaPointerGetAttributes since CUDA 11.
@@ -269,7 +269,7 @@ TEST_CASE("hazePointerGetAttributes reports unregistered for foreign pointers") 
     REQUIRE(attrs.type == HAZE_MEMORY_TYPE_UNREGISTERED);
 }
 
-TEST_CASE("hazePointerGetAttributes reports host type for hazeHostAlloc'd pointer") {
+TEST_CASE("hazePointerGetAttributes reports host type for hazeHostAlloc'd pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     void* p = nullptr;
     REQUIRE(hazeHostAlloc(&p, 4096, 0) == HAZE_SUCCESS);
@@ -279,7 +279,7 @@ TEST_CASE("hazePointerGetAttributes reports host type for hazeHostAlloc'd pointe
     hazeFreeHost(p);
 }
 
-TEST_CASE("hazePointerGetAttributes rejects null attrs out-pointer") {
+TEST_CASE("hazePointerGetAttributes rejects null attrs out-pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     int stack_local = 0;
     REQUIRE(hazePointerGetAttributes(nullptr, &stack_local) == HAZE_ERROR_INVALID_VALUE);

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -71,24 +71,6 @@ TEST_CASE("free then re-allocate recycles pooled address", "[unit]") {
     REQUIRE(hazeFree(p2) == HAZE_SUCCESS);
 }
 
-TEST_CASE("H2D memcpy stores data in shadow buffer", "[unit]") {
-    constexpr size_t kN = 4096;
-    constexpr size_t kBytes = kN * sizeof(uint64_t);
-
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kN) == HAZE_SUCCESS);
-    void* dev = nullptr;
-    REQUIRE(hazeMalloc(&dev, kBytes) == HAZE_SUCCESS);
-
-    std::vector<uint64_t> src(kN);
-    for (size_t i = 0; i < kN; ++i) src[i] = static_cast<uint64_t>(i * 3 + 7);
-
-    REQUIRE(hazeMemcpy(dev, src.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE)
-            == HAZE_SUCCESS);
-
-    REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
-}
-
 TEST_CASE("H2D then D2H round-trip preserves data", "[unit]") {
     constexpr size_t kN = 4096;
     constexpr size_t kBytes = kN * sizeof(uint64_t);

--- a/test/test_ring_dim_consistency.cpp
+++ b/test/test_ring_dim_consistency.cpp
@@ -34,6 +34,8 @@
 #include <cstdint>
 #include <vector>
 
+#include "integration_helpers.hpp"
+
 namespace {
 
 constexpr uint64_t kQ = 576460752303415297ULL;       // standard CKKS test prime
@@ -44,14 +46,17 @@ constexpr size_t   kBytes = kN * sizeof(uint64_t);
 // each test sees a clean Config / EpochState / DeviceAllocator. The
 // reset is deliberate — without it Config / poly_map_ state from a
 // prior test could leak through.
+//
+// Routes through haze_replay_bridge so the test runs end-to-end via
+// the FHETCH transport: bridge picks the actual tower modulus near
+// 2^bits(kQ), aligns haze's ciphertext modulus, sets target=FUNC_SIM
+// so hazeReplay() dispatches to nbcc_fhetch_replay rather than no-op'ing.
 void setup_4096() {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kN) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    haze::test::setup_integration_compute_config(kN, kQ, 0);
 }
 
 inline void d2h(std::vector<uint64_t> &dst, const void *dev) {
+    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(dst.data(), dev, dst.size() * sizeof(uint64_t),
                        HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 }
@@ -71,7 +76,7 @@ inline void h2d(void *dev, const std::vector<uint64_t> &src) {
 // back to a Polynomial reaching tag_input with ring_dim ≠ 4096 — this
 // test is the simplest end-to-end exercise that would surface the
 // HAZE-side variant of that bug.
-TEST_CASE("ring_dim consistency: H2D->Add->D2H round-trip at N=4096") {
+TEST_CASE("ring_dim consistency: H2D->Add->D2H round-trip at N=4096", "[integration]") {
     setup_4096();
 
     void *d_a = nullptr, *d_b = nullptr, *d_dst = nullptr;
@@ -99,7 +104,7 @@ TEST_CASE("ring_dim consistency: H2D->Add->D2H round-trip at N=4096") {
 // operation reuses the first op's output (compute_results_ entry)
 // as input. If poly_map_ ever served a Polynomial with a stale
 // ring_dim, this is the path that would expose it.
-TEST_CASE("ring_dim consistency: chained ops within one epoch reuse poly_map_ entries") {
+TEST_CASE("ring_dim consistency: chained ops within one epoch reuse poly_map_ entries", "[integration]") {
     setup_4096();
 
     void *d_a = nullptr, *d_b = nullptr, *d_c = nullptr, *d_t = nullptr;
@@ -137,7 +142,7 @@ TEST_CASE("ring_dim consistency: chained ops within one epoch reuse poly_map_ en
 // a fresh ensure_recording_locked at the start of the next, so any
 // state leak across epoch boundaries that depends on accumulated
 // heap pressure would surface here.
-TEST_CASE("ring_dim consistency: 50 reset/configure/compute cycles") {
+TEST_CASE("ring_dim consistency: 50 reset/configure/compute cycles", "[integration]") {
     for (int iter = 0; iter < 50; ++iter) {
         setup_4096();
 
@@ -169,7 +174,7 @@ TEST_CASE("ring_dim consistency: 50 reset/configure/compute cycles") {
 // SUCCESS. A "shared modulus identity convert" (src_base == dst_base,
 // single residue) is the simplest non-trivial case: dst should
 // equal src byte-for-byte.
-TEST_CASE("ring_dim consistency: hazeBasisConvert preserves data on identity convert") {
+TEST_CASE("ring_dim consistency: hazeBasisConvert preserves data on identity convert", "[integration]") {
     setup_4096();
 
     void *src = nullptr, *dst = nullptr;
@@ -210,7 +215,7 @@ TEST_CASE("ring_dim consistency: hazeBasisConvert preserves data on identity con
 // holds onto the ring_dim from the first init across subsequent
 // epochs; observed as "[NBCC ERROR] Ring dimension mismatch: memory
 // has X expected Y"). That bug is filed separately.
-TEST_CASE("ring_dim consistency: hazeDeviceReset between two epochs at same N") {
+TEST_CASE("ring_dim consistency: hazeDeviceReset between two epochs at same N", "[integration]") {
     // Two epochs, both at N=4096, separated by an explicit reset.
     setup_4096();
     {

--- a/vendor/niobium-compiler
+++ b/vendor/niobium-compiler
@@ -1,1 +1,0 @@
-/work/niobium-compiler


### PR DESCRIPTION
## Summary

Lands the RYANPR markers from the previous diff plus the architectural shift to a two-tier replay model (`local` runs the in-process FHETCH simulator end-to-end; anything else is forwarded to `nbcc_fhetch_replay` over the HTTP transport).

- **Cluster A** (build infra) — Makefile MODE refactor (`MODE=debug|release`), drop the awk help auto-discovery + `set-build-config` dead define + magic `vendor/niobium-compiler` symlink default; rename test surface to `test-unit` / `test-sim` / `test-transport` / `test` / `test-all`. CMakeLists drops the `if(NOT TARGET Niobium::fhetch)` tier-1 reuse branch.
- **Cluster B + H** (target docs + simulator wiring) — three-tier docs collapsed to two tiers after `local` was repurposed as the in-process simulator entry. `kLocalTarget` symbolic constant in `src/core/config.hpp`; default flips so `hazeMemcpy(D2H)` returns simulator-computed values out of the box. Bumps the `vendor/niobium-fhetch` submodule pointer.
- **Clusters C / D / E** (internals) — `hazeHostAlloc` switches to `sysconf(_SC_PAGESIZE)`; `CompilerBackend` argv synthesised function-locally; `EpochState` drops `compute_results_`, folds output-name registration into `store_compute_result_locked`, gates the result-population loop, routes `std::cerr` through `haze::log_error`, and mirrors `clear_captured()` from `clear_state_locked`.
- **Cluster F** (replay_bridge) — `BridgeError` enum + `std::expected`, structured `TODO(fhetch-publish)` / `TODO(haze:multi-residue)` / `TODO(haze:no-keygen)` blocks, drop `g_ctx_mu` (single-threaded contract), `bits_of` → `bit_width_for_modulus`, `align_program_info_to_haze` removed, all `std::cerr` routed through `haze::log_error`.
- **Cluster G** (tests) — collapse 5 success-only setter `TEST_CASE`s into one, delete the redundant H2D-only memcpy case, inline `setup_compute_config` at its two error-path sites, drop default args at every `setup_integration_compute_config(kRingDim, kModulus, kModIdx)` call site.
- **Flake** — shellHook walks `$PWD` upward to find the haze root (with `HAZE_ROOT` escape hatch + re-export), eliminating the `builtins.derivation … without proper context` warning.
- Code-review pass collapsed `to_haze_error` duplicate arms and dropped the `FHETCH_SIM_TARGET` / `HAZE_FHETCH_SIM_TARGET` override knobs that risked silent CMake/Make divergence.

## Test plan

- [x] `EXTERNAL_OPENFHE=1 make test-unit` → 48/48 pass (was 53; G1 + G2 collapsed 5 redundant cases).
- [x] `EXTERNAL_OPENFHE=1 make test-sim` → 18/27 pass (in-process simulator). The 9 failing cases at `test_basis_convert.cpp:117/245/291/331/381/443/757(x3)` are pre-existing, blocked on bridge MRP support, plan-declared out of scope.
- [x] `EXTERNAL_OPENFHE=1 NIOBIUM_COMPILER_ROOT=… make test-transport` → 18/27 pass (HTTP transport via `nbcc_fhetch_replay`); identical 9-failure shape, confirming sim/transport parity.
- [x] `ctest -N` registers `haze_unit_tests` + `haze_sim_tests` (transport entry is opt-in via `NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS`).
- [x] `nix develop --command bash -c 'echo OK'` is warning-free post-flake fix.
- [ ] ASAN / TSAN matrix — skipped: ASAN init hangs in `FindDynamicShadowStart` on macOS-on-Apple-Silicon under this nix devshell, environmental and unrelated to the change.

## Notes

- `vendor/niobium-fhetch` submodule pointer references `002020a` (local `feat/fhetch-sim-target` branch on the fhetch side) which has not been pushed yet. The submodule reference will dangle on remote until that fhetch branch lands.