### PR TITLE
feat(replay_bridge): own niobium::fhetch::result, adopt fhetch post-recording hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,8 +160,6 @@ target_include_directories(haze
 
 target_compile_definitions(haze PRIVATE HAZE_BUILDING_LIBRARY)
 
-target_link_libraries(haze PRIVATE Niobium::fhetch)
-
 set_target_properties(haze PROPERTIES
   CXX_VISIBILITY_PRESET     hidden
   VISIBILITY_INLINES_HIDDEN ON
@@ -169,13 +167,16 @@ set_target_properties(haze PROPERTIES
 )
 
 # ---------------------------------------------------------------------------
-# Replay bridge — OpenFHE-using helper for synthesizing the CryptoContext +
-# ciphertext templates the compiler-side replay needs. Lives in its own
-# subdirectory and target so libhaze stays FHETCH-only; only haze_tests
-# (and any other replay-aware harness) link it in.
+# Replay bridge — OpenFHE-using helper that synthesizes CryptoContext +
+# ciphertext templates the compiler-side replay needs, and provides the
+# niobium::fhetch::result(...) overloads libhaze references from epoch.cpp.
+# Lives in its own subdirectory and target so the OpenFHE includes stay
+# out of libhaze sources; libhaze pulls the bridge in for symbol resolution.
 # ---------------------------------------------------------------------------
 
 add_subdirectory(replay_bridge)
+
+target_link_libraries(haze PRIVATE Niobium::fhetch haze_replay_bridge)
 
 # ---------------------------------------------------------------------------
 # Tests

--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -23,9 +23,9 @@
 // nbcc_fhetch_replay does the same). The bridge is therefore agnostic
 // to which replay tier the caller selects.
 //
-// The bridge is laser-decoupled from haze proper: haze stays FHETCH-only;
-// the bridge links OpenFHE (transitively, via Niobium::fhetch) and is
-// linked exclusively by haze_tests, never by libhaze itself.
+// The bridge is the OpenFHE boundary for haze: libhaze sources stay
+// FHETCH-only (no OpenFHE includes), but libhaze links the bridge to
+// resolve niobium::fhetch::result(...) references from epoch.cpp.
 //
 // Usage (in an integration test):
 //

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -43,17 +43,13 @@
 // libnbfhetch's PRIVATE src/ tree and including it from a downstream
 // library would couple the bridge to libnbfhetch's source layout.
 //
-// TODO(fhetch-publish): the four detail symbols below resolve in
-// libnbfhetch's TU because cereal polymorphic-type registrations are
-// per-shared-library — calling lbcrypto::Serial::SerializeToFile from
-// here directly would trip "unregistered polymorphic type" on
-// CryptoContextImpl / Ciphertext. Long-term, ask niobium-fhetch to
-// publish a stable C++ API for write_ciphertext_template,
-// write_ciphertext_input_bin, for_each_captured_input, and
-// for_each_captured_output, then replace the externs with that header
-// include. niobium-client's auto-facade routes through the same
-// libnbfhetch TU (auto_facade.cpp's serialize helpers) so a published
-// API would also let niobium-client drop its own forwarder shims.
+// Cereal's polymorphic-type registrations are per-shared-library on macOS:
+// inlining Serial::SerializeToFile here throws "unregistered polymorphic
+// type" on intnat::NativeVectorT (input bin path) and CryptoContextImpl
+// (template path) — empirically confirmed. The four detail symbols below
+// route the cereal calls through libnbfhetch's TU where the registrations
+// are live. Long-term, niobium-fhetch could publish a stable C++ API for
+// these so the bridge can include a header instead of forward-declaring.
 namespace niobium::detail {
 
 // Serialize an empty Ciphertext<DCRTPoly> shell to

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -26,6 +26,7 @@
 #include "common/log.hpp"
 
 #include <niobium/compiler.h>
+#include <niobium/fhetch_api.h>
 
 #include <bit>
 #include <cassert>
@@ -385,3 +386,129 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(
         return HAZE_ERROR_LAUNCH_FAILURE;
     }
 }
+// ============================================================================
+// fhetch::result() free-function overloads — read serialized_probes/<name>.ct
+// and pull the first polynomial residue out as a fhetch::Polynomial / MRP /
+// MRPArray for clients that record raw polynomial ops.
+//
+// Marked with default visibility because the bridge dylib is built with
+// CXX_VISIBILITY_PRESET=hidden; libhaze imports these symbols at link time.
+// ============================================================================
+
+#define NIOBIUM_FHETCH_RESULT_API __attribute__((visibility("default")))
+
+namespace niobium::fhetch {
+
+namespace {
+
+// Convert OpenFHE's Format (utils/inttypes.h, global enum) to fhetch::Format.
+inline Format openfhe_to_fhetch_format(::Format fmt) {
+    return fmt == ::Format::COEFFICIENT ? Format::Coefficient : Format::Evaluation;
+}
+
+// Load <program_dir>/serialized_probes/<name>.ct as a Ciphertext<DCRTPoly>.
+// Returns nullptr on any I/O / parse error.
+lbcrypto::Ciphertext<DCRTPoly> load_serialized_probe(const std::string& name) {
+    auto dir = niobium::compiler().get_program_directory();
+    auto ct_path = dir / "serialized_probes" / (name + ".ct");
+    if (!std::filesystem::exists(ct_path)) {
+        haze::log_error("fhetch::result",
+                        "'" + name + "' not found at " + ct_path.string());
+        return nullptr;
+    }
+    lbcrypto::Ciphertext<DCRTPoly> ct;
+    if (!lbcrypto::Serial::DeserializeFromFile(ct_path.string(), ct,
+                                               lbcrypto::SerType::BINARY)) {
+        haze::log_error("fhetch::result",
+                        "failed to deserialize " + ct_path.string());
+        return nullptr;
+    }
+    return ct;
+}
+
+// Pull a single residue's coefficients out of a NativePoly as
+// std::vector<uint64_t>.
+std::vector<uint64_t> native_poly_values(const lbcrypto::NativePoly& np) {
+    const auto& vals = np.GetValues();
+    const size_t n = vals.GetLength();
+    std::vector<uint64_t> out;
+    out.reserve(n);
+    for (size_t i = 0; i < n; ++i) {
+        out.push_back(vals[i].ConvertToInt());
+    }
+    return out;
+}
+
+}  // namespace
+
+NIOBIUM_FHETCH_RESULT_API
+bool result(const std::string& name, Polynomial& p) {
+    auto ct = load_serialized_probe(name);
+    if (!ct) return false;
+
+    const auto& elements = ct->GetElements();
+    if (elements.empty()) {
+        haze::log_error("fhetch::result",
+                        "'" + name + "' has no DCRTPoly elements");
+        return false;
+    }
+    const auto& towers = elements[0].GetAllElements();
+    if (towers.empty()) {
+        haze::log_error("fhetch::result",
+                        "'" + name + "' has no NativePoly towers");
+        return false;
+    }
+    const auto& np = towers[0];
+    auto values = native_poly_values(np);
+    p = Polynomial::from_data(values, values.size(),
+                              openfhe_to_fhetch_format(np.GetFormat()));
+    return true;
+}
+
+NIOBIUM_FHETCH_RESULT_API
+bool result(const std::string& name, MRP& m) {
+    auto ct = load_serialized_probe(name);
+    if (!ct) return false;
+
+    const auto& elements = ct->GetElements();
+    if (elements.empty()) return false;
+    const auto& towers = elements[0].GetAllElements();
+    if (towers.empty()) return false;
+
+    std::vector<std::pair<Polynomial, uint64_t>> pairs;
+    pairs.reserve(towers.size());
+    for (const auto& np : towers) {
+        auto values = native_poly_values(np);
+        auto poly = Polynomial::from_data(values, values.size(),
+                                          openfhe_to_fhetch_format(np.GetFormat()));
+        pairs.emplace_back(std::move(poly), np.GetModulus().ConvertToInt());
+    }
+    m = MRP::from_pairs(pairs);
+    return true;
+}
+
+NIOBIUM_FHETCH_RESULT_API
+bool result(const std::string& name, MRPArray& arr) {
+    auto ct = load_serialized_probe(name);
+    if (!ct) return false;
+
+    const auto& elements = ct->GetElements();
+    MRPArray out(elements.size());
+    for (size_t i = 0; i < elements.size(); ++i) {
+        const auto& dcrt = elements[i];
+        const auto& towers = dcrt.GetAllElements();
+        std::vector<std::pair<Polynomial, uint64_t>> pairs;
+        pairs.reserve(towers.size());
+        for (const auto& np : towers) {
+            auto values = native_poly_values(np);
+            auto poly = Polynomial::from_data(values, values.size(),
+                                              openfhe_to_fhetch_format(np.GetFormat()));
+            pairs.emplace_back(std::move(poly), np.GetModulus().ConvertToInt());
+        }
+        out[i] = MRP::from_pairs(pairs);
+    }
+    arr = std::move(out);
+    return true;
+}
+
+}  // namespace niobium::fhetch


### PR DESCRIPTION
Companion to niobium-fhetch PR #39 (drops `niobium::fhetch::result`
implementations from libnbfhetch). Three commits:

- `feat(replay_bridge): provide niobium::fhetch::result, link into libhaze`
  Adds the three `result(name, Polynomial&|MRP&|MRPArray&)` implementations
  to the bridge with default visibility, and links the bridge into libhaze
  (`target_link_libraries(haze PRIVATE Niobium::fhetch haze_replay_bridge)`)
  so `epoch.cpp`'s `fhetch::result(...)` reference resolves at link time.
  Updates the bridge banner to note libhaze now imports symbols from it.

- `build(submodule): bump niobium-fhetch to feat/fhetch-sim-target tip`
  Tracks the matching fhetch-side commit so the contracts line up.

- `docs(replay_bridge): record empirical confirmation of cereal dylib trap`
  Replaces the speculative TODO with the verified failure modes
  (intnat::NativeVectorT, CryptoContextImpl) so future readers don't
  repeat the inline-cereal experiment.

## Test plan

- [x] make build MODE=release
- [x] make test-unit MODE=release (48/48 PASS)
- [x] make test-sim MODE=release (18/27 PASS — same 9 pre-existing MRP failures, no new ones)