### PR TITLE
Remove replay API itself, just use D2H

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,12 @@ shapes one-for-one (`cudaMalloc` → `hazeMalloc`, `cudaMemcpy` → `hazeMemcpy`
 against CUDA — primarily FIDESlib — can port by mechanical prefix substitution.
 
 The implementation does not execute polynomial math. Every compute call records
-a node into FHETCH IR via `niobium::fhetch::sr_*`; an explicit `hazeReplay()`
+a node into FHETCH IR via `niobium::fhetch::sr_*`; the next `hazeMemcpy(D2H)`
 finalizes the trace, dispatches it to a backend (in-process simulator or HTTP
-transport to `nbcc_fhetch_replay`), and writes the simulator-computed values
-into shadow buffers. `hazeMemcpy(D2H)` then reads from the shadow.
+transport to `nbcc_fhetch_replay`), writes the simulator-computed values into
+shadow buffers, and only then copies the shadow bytes to the host destination.
+D2H is therefore the sole flush trigger; there is no separate explicit-replay
+entry point.
 
 ## Toolchain
 
@@ -222,21 +224,23 @@ guard that:
 No hardware, simulator, or polynomial math runs at this point. The
 recording phase only appends nodes to the FHETCH trace.
 
-Materialization is triggered explicitly via `hazeReplay()`:
+Materialization is triggered implicitly by `hazeMemcpy(D2H)`. The D2H
+path in `haze::copy_to_host` (src/core/epoch.cpp) calls
+`EpochState::replay_and_populate()` before reading the shadow buffer:
 
 1. `EpochState::replay_and_populate()` tags every output binding for
-   `fhetch::tag_output`.
+   `fhetch::tag_output`. No-op when no recording is in flight, so plain
+   H2D-then-D2H round-trips elide it for free.
 2. `CompilerBackend::stop_epoch()` writes the per-epoch `.fhetch` trace.
 3. `CompilerBackend::replay()` dispatches per the configured target.
 4. `niobium::fhetch::result(...)` is called for each tagged output to read
    the simulator-computed polynomial back, and `update_shadow` writes the
    bytes into the allocator's sparse `shadow_data_` map.
+5. `copy_to_host` then performs the shadow read into the host buffer.
 
-After replay, `hazeMemcpy(D2H)` is a plain shadow read via
-`copy_to_host`. `hazeDeviceSynchronize` and `hazeStreamSynchronize` are
-no-ops returning `HAZE_SUCCESS` — synchronization is implicit in the
-explicit `hazeReplay()` call. Streams and events exist for CUDA-shape
-parity but do not model ordering.
+`hazeDeviceSynchronize` and `hazeStreamSynchronize` are no-ops returning
+`HAZE_SUCCESS` — synchronization is implicit in the D2H itself. Streams
+and events exist for CUDA-shape parity but do not model ordering.
 
 ### Shadow storage model
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -257,8 +257,8 @@ option(NIOBIUM_CLIENT_HAZE_WITH_TRANSPORT_TESTS
 # Unit suite: in-process, no server, no compiler-side binary.
 # HAZE_TARGET=local pins the compiler target so haze never attempts to
 # dispatch to nbcc_fhetch_replay during unit tests. Unit tests observe
-# state-machine and recording behaviour only -- they do not call
-# hazeReplay() and do not validate FHE math results.
+# state-machine and recording behaviour only -- they do not perform a
+# D2H (which would trigger replay) and do not validate FHE math results.
 add_test(NAME haze_unit_tests
          COMMAND haze_tests "~[integration]")
 set_tests_properties(haze_unit_tests PROPERTIES

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ simulator internals, see the companion repository:
  |   compiler() singleton + fhetch::* recording API |
  +--------------------------------------------------+
          |
-         | hazeMemcpy(D2H) (or explicit hazeReplay())
-         | finalises the .fhetch trace + manifest
+         | hazeMemcpy(D2H) finalises the .fhetch trace +
+         | manifest, then dispatches replay before reading
          v
          +-------------------+--------------------+
          |                                        |
@@ -78,8 +78,7 @@ simulator internals, see the companion repository:
 4. **Replay & Read** — `hazeMemcpy(host_buf, dev_ptr, n, HAZE_MEMCPY_DEVICE_TO_HOST)`
    finalises the current epoch's `.fhetch` trace, dispatches it to the
    configured target, and copies the simulator-computed values into the host
-   buffer. `hazeReplay()` is also exposed for callers that want to flush the
-   recording without an immediate readback.
+   buffer. D2H is the sole flush trigger; replay happens implicitly inside it.
 
 5. **Submit (production)** — Choose a compiler-side target such as `FPGA_TRI`
    (or `FUNC_SIM` / `FHE_SIM` / `fhetch_sim`) before replay. Haze's transport
@@ -229,7 +228,7 @@ Runtime selector (consumed by `libhaze` itself, not the Makefile):
 
 | Variable      | Purpose                                                                                                                                                                                                                                                     |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `HAZE_TARGET` | Replay target: `local` (default; in-process simulator) or one of `FHE_SIM`, `FUNC_SIM`, `FPGA_TRI`, `fhetch_sim` (HTTP transport to `nbcc_fhetch_replay`). Read on first `hazeReplay`. See [`include/haze/haze.h`](include/haze/haze.h) for the full table. |
+| `HAZE_TARGET` | Replay target: `local` (default; in-process simulator) or one of `FHE_SIM`, `FUNC_SIM`, `FPGA_TRI`, `fhetch_sim` (HTTP transport to `nbcc_fhetch_replay`). Read on the first replay-triggering D2H. See [`include/haze/haze.h`](include/haze/haze.h) for the full table. |
 
 CMake-level toggles (`-D...`):
 
@@ -318,7 +317,7 @@ Three suites, all built into a single `haze_tests` Catch2 binary and split by
 tag plus environment:
 
 - `test-unit` — state-machine and recording-only coverage. Runs every case not
-  tagged `[integration]`. Does not call `hazeReplay` and does not validate FHE
+  tagged `[integration]`. Does not perform a D2H and does not validate FHE
   math results. Fast (~1 second).
 - `test-sim` — `[integration]`-tagged cases run through libnbfhetch's
   in-process FHETCH simulator (`HAZE_TARGET=local`). Validates real FHE math
@@ -366,10 +365,11 @@ niobium-haze/
   every reference to `cudaStream_t`.
 
 - **Recording, not execution** — Every haze call appends to an in-memory
-  FHETCH trace. Nothing executes until `hazeMemcpy(D2H)` (or an explicit
-  `hazeReplay()`) flushes the recording. Stream-relative ordering is therefore
-  not modelled; the recording is single-threaded by construction and the .fhetch
-  trace itself defines the schedule the compiler optimises against.
+  FHETCH trace. Nothing executes until `hazeMemcpy(D2H)` flushes the
+  recording: D2H finalises the trace, dispatches replay, then reads the
+  shadow buffer. Stream-relative ordering is therefore not modelled; the
+  recording is single-threaded by construction and the .fhetch trace
+  itself defines the schedule the compiler optimises against.
 
 - **Polynomial-level instead of OpenFHE-level** — `niobium-client` integrates
   at OpenFHE's `EvalAdd` / `EvalMult` boundary; haze sits one layer below at

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -127,24 +127,14 @@ HAZE_API hazeError_t hazeSetProgramInfo(const char *name, const char *version,
  *
  * Resolution order:
  *   1. hazeSetTarget(target)  - explicit programmatic call.
- *   2. HAZE_TARGET env var    - read on first hazeReplay if (1) unset.
+ *   2. HAZE_TARGET env var    - read on the first replay-triggering D2H
+ *                                if (1) is unset.
  *   3. "local"                - default if both above are unset.
  *
- * See hazeReplay() for behaviour-by-target dispatch. */
+ * Behaviour-by-target dispatch happens inside the next hazeMemcpy(D2H),
+ * which finalises the recording, runs the replay, and populates the
+ * shadow buffer before returning bytes to the host. */
 HAZE_API hazeError_t hazeSetTarget(const char *target) HAZE_NOEXCEPT;
-
-/* Trigger replay of the recorded operations.
- *
- * Finalises the current epoch's .fhetch trace and dispatches it
- * according to the configured target (see hazeSetTarget for the
- * two-tier table and resolution order). At a glance:
- *
- *   target == "local":   in-process simulator populates shadows.
- *   target == <other>:   HTTP transport to nbcc_fhetch_replay.
- *
- * Calling hazeReplay() with no recording in progress is a no-op
- * returning HAZE_SUCCESS. */
-HAZE_API hazeError_t hazeReplay(void) HAZE_NOEXCEPT;
 
 // Streams: lifecycle and ordering primitives. HAZE is a recording layer
 // that emits FHETCH IR; nothing executes until hazeMemcpy(D2H) flushes

--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -35,10 +35,11 @@
 //     hazeSetCiphertextModulus(kModIdx, picked);
 //
 //     // Per-input .bin / .ids and per-output .template files are written
-//     // automatically inside hazeReplay() via a post-recording hook the
-//     // bridge registers during InitCryptoContext. Tests just compute and
-//     // call hazeReplay().
-//     hazeReplay();   // in-process simulator or transport, both work
+//     // automatically inside the D2H-triggered replay via a post-recording
+//     // hook the bridge registers during InitCryptoContext. Tests just
+//     // compute and read back via hazeMemcpy(D2H).
+//     hazeMemcpy(host, dev, bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
+//     // Both in-process simulator and HTTP transport go through this path.
 
 #ifndef HAZE_REPLAY_BRIDGE_H
 #define HAZE_REPLAY_BRIDGE_H
@@ -64,14 +65,15 @@ extern "C" {
 /// previously serialized cryptocontext.dat is overwritten.
 ///
 /// niobium::compiler() must already be initialized (i.e. at least one haze
-/// compute call must have happened, or hazeConfigureDevice / hazeReplay
-/// must have been called) so the program directory resolves correctly.
+/// compute call must have happened, or hazeConfigureDevice must have been
+/// called) so the program directory resolves correctly.
 ///
 /// Must be called AFTER every hazeDeviceReset(): reset clears the post-
 /// recording hook this function registers, and without re-registration
-/// hazeReplay() ships an incomplete project (no .bin / .ids / .template
-/// files), which the compiler-side rejects. The setup_integration_compute_config
-/// helper enforces this ordering automatically.
+/// the next D2H-triggered replay ships an incomplete project (no .bin /
+/// .ids / .template files), which the compiler-side rejects. The
+/// setup_integration_compute_config helper enforces this ordering
+/// automatically.
 HAZE_API hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim, uint64_t desired_modulus,
                                                        uint64_t *picked_modulus) HAZE_NOEXCEPT;
 

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -303,7 +303,7 @@ void on_post_recording() {
     // path fills the first NativePoly with simulator output; templates
     // are otherwise empty. This removes the burden from test code of
     // having to call hazeReplayBridgeWriteTemplate per output — tests
-    // just call hazeReplay() and the bridge handles it.
+    // just D2H any output and the bridge handles it on the way through.
     niobium::detail::for_each_captured_output([&](const std::string &name) {
         try {
             auto ct = synthesize_haze_ciphertext({});

--- a/src/api/lifecycle.cpp
+++ b/src/api/lifecycle.cpp
@@ -56,10 +56,3 @@ extern "C" hazeError_t hazeDeviceReset(void) noexcept {
     g_last_error = HAZE_SUCCESS;
     return HAZE_SUCCESS;
 }
-
-extern "C" hazeError_t hazeReplay(void) noexcept {
-    auto result = haze::epoch().replay_and_populate();
-    if (!result)
-        return set_error(haze::to_public_error(result.error()));
-    return HAZE_SUCCESS;
-}

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -89,9 +89,9 @@ extern "C" hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
     }
 
     if (kind == HAZE_MEMCPY_DEVICE_TO_HOST) {
-        // Plain shadow read. To get post-compute values, the caller
-        // must invoke hazeReplay() before this — replay populates the
-        // shadow buffer with values from the compiler-side simulator.
+        // D2H finalises any in-flight recording (replay + shadow
+        // populate) before reading the shadow buffer. See
+        // haze::copy_to_host for the contract.
         return set_error(haze::copy_to_host(dst, haze::to_dev_addr(src), count));
     }
 

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -229,13 +229,16 @@ HazeMutex &EpochSession::init_then_get_mutex() noexcept {
 }
 
 hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept {
-    // D2H is a plain shadow read. Recording finalization + replay live
-    // in haze::epoch().replay_and_populate() (exposed as hazeReplay()),
-    // which the user must call explicitly before reading post-compute
-    // values back. This separation is intentional: replay incurs an
-    // HTTP transport round-trip to the compiler-side nbcc_fhetch_replay,
-    // which is a heavy operation that should be triggered explicitly,
-    // not as a side-effect of a memcpy.
+    // D2H is the sole flush trigger: finalise any active recording,
+    // dispatch replay (potentially an HTTP round-trip to nbcc_fhetch_replay
+    // for non-local targets), and populate shadow buffers before reading.
+    // replay_and_populate() is a no-op when no recording is in flight, so
+    // plain H2D-then-D2H round-trips elide the cost, and subsequent D2H
+    // calls within the same epoch are free (the first D2H clears
+    // recording_).
+    auto replay_result = epoch().replay_and_populate();
+    if (!replay_result)
+        return to_public_error(replay_result.error());
     return allocator().copy_to_host(dst, src, count);
 }
 

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -30,7 +30,9 @@ namespace haze {
 // Epoch state is the single point of contact between the compute API
 // and the niobium compiler's recording window. It tracks the active
 // polymap (DevAddr → fhetch::Polynomial), pending output names for the
-// next D2H, and the recording lifecycle flags.
+// next D2H, and the recording lifecycle flags. The next D2H drives
+// replay_and_populate(), which finalises the trace and writes every
+// pending output back into the shadow buffer.
 //
 // Mutex contract: most public methods take `mutex_` themselves; the
 // `_locked` variants assume the caller has already taken it via an
@@ -169,11 +171,13 @@ class HAZE_SCOPED_CAPABILITY EpochSession {
     HazeLockGuard guard_;
 };
 
-// D2H-side helper: copies bytes from the device shadow buffer to a host
-// destination. Plain shadow read — does NOT trigger any recording
-// finalization or replay. Callers that need post-compute values must
-// invoke hazeReplay() (haze::epoch().replay_and_populate()) first to
-// materialize results into the shadow buffer.
+// D2H-side helper: finalises any active recording via
+// replay_and_populate() (no-op when not recording), then copies bytes
+// from the device shadow buffer to a host destination. D2H is the
+// sole flush trigger; there is no separate explicit-replay entry point.
+// Returns a public hazeError_t (already translated via to_public_error);
+// the caller in src/api/ is responsible for routing the value through
+// set_error() so hazeGetLastError() reflects the failure.
 hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept;
 
 } // namespace haze

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -5,13 +5,12 @@
 //   2. Bridge auto-synthesizes a CryptoContext + per-input cereal-binary
 //      .bin files + per-output ciphertext templates at recording-finalize
 //      time (see haze_replay_bridge's post_recording_hook).
-//   3. Call hazeReplay() to dispatch the recorded project to a
-//      niobium-compiler-built nbcc_fhetch_replay over the FHETCH HTTP
-//      transport.
+//   3. The first hazeMemcpy(D2H) finalises the recording, dispatches the
+//      project to a niobium-compiler-built nbcc_fhetch_replay over the
+//      FHETCH HTTP transport, and reads the materialized values back.
 //   4. The simulator-computed values flow back as serialized_probes/*.ct,
 //      which fhetch::result reads and replay_and_populate writes into the
-//      haze shadow buffers.
-//   5. hazeMemcpy(D2H) returns the materialized values from shadow.
+//      haze shadow buffers; D2H then returns those values.
 //
 // Orchestration of the server + client-side forwarder lives in
 // scripts/test_haze_integration.sh.
@@ -44,9 +43,10 @@ namespace haze::test {
 // with the .ct round-trip, we feed the picked value back into
 // hazeSetCiphertextModulus before any compute.
 //
-// After this call returns, tests do compute + hazeReplay() + hazeMemcpy(D2H).
-// The bridge's post_recording_hook auto-writes the .bin / .ids / .template
-// artifacts during stop(); tests do not need to call WriteTemplate or
+// After this call returns, tests do compute + hazeMemcpy(D2H); the D2H
+// triggers replay before reading the shadow buffer. The bridge's
+// post_recording_hook auto-writes the .bin / .ids / .template artifacts
+// during stop(); tests do not need to call WriteTemplate or
 // WriteInputBin explicitly.
 inline uint64_t setup_integration_compute_config(uint64_t ring_dim = 4096,
                                                  uint64_t desired_modulus = 576460752303415297ULL,

--- a/test/test_basis_convert.cpp
+++ b/test/test_basis_convert.cpp
@@ -81,7 +81,7 @@ TEST_CASE("hazeBasisConvert rejects empty source base", "[unit]") {
 }
 
 // The [!mayfail] cases below are blocked on multi-residue support in the
-// replay bridge. Recording succeeds, but `hazeReplay()` returns
+// replay bridge. Recording succeeds, but the D2H-triggered replay returns
 // HAZE_ERROR_NOT_SUPPORTED because the bridge cannot synthesise an OpenFHE
 // CryptoContext for multi-modulus traces yet. They run and report assertion
 // failures, but Catch2 does not propagate those as suite failures. Remove the
@@ -120,7 +120,6 @@ TEST_CASE("hazeModDown rejects foreign modulus in rescale_base", "[integration][
     REQUIRE(hazeMemcpy(b, vb.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
     REQUIRE(hazeAdd(c, a, b, 0, nullptr) == HAZE_SUCCESS);
     std::vector<uint64_t> out(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out.data(), c, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     REQUIRE(out[0] == 3);
 
@@ -249,11 +248,8 @@ TEST_CASE("hazeBasisConvert: shared-modulus copies produce input values",
     std::vector<uint64_t> out0(kRingDim, 0);
     std::vector<uint64_t> out1(kRingDim, 0);
     std::vector<uint64_t> out2(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out0.data(), d0, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out1.data(), d1, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out2.data(), d2, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     // Same-modulus copies: dst residue == src residue, every coefficient.
@@ -295,9 +291,7 @@ TEST_CASE("hazeBasisConvert: zero input produces zero output", "[integration][!m
 
     std::vector<uint64_t> out0(kRingDim, 0xDEADBEEF);
     std::vector<uint64_t> out1(kRingDim, 0xDEADBEEF);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out0.data(), d0, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out1.data(), d1, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     // Catches both (a) a backend that writes garbage and (b) the
@@ -335,7 +329,6 @@ TEST_CASE("hazeBasisConvert: src/dst aliasing is safe (in-place 1->1)", "[integr
     REQUIRE(hazeBasisConvert(dst_polys, src_polys, &p, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> out(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out.data(), p0, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     REQUIRE(out[0] == 42);
 
@@ -385,9 +378,7 @@ TEST_CASE("hazeModDown: zero input rescales to zero output", "[integration][!may
     // Initialise to non-zero so a no-op D2H would surface as a failure.
     std::vector<uint64_t> out0(kRingDim, 0xDEADBEEF);
     std::vector<uint64_t> out1(kRingDim, 0xDEADBEEF);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out0.data(), d0, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(out1.data(), d1, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     for (uint64_t i = 0; i < kRingDim; ++i) {
         REQUIRE(out0[i] == 0);
@@ -448,7 +439,6 @@ TEST_CASE("hazeModUp: zero input produces zero output across both digits",
 
     // D2H every output and verify exact zero. Initialise the host
     // buffer to a sentinel so a skipped D2H is detectable.
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     for (size_t slot = 0; slot < 6; ++slot) {
         std::vector<uint64_t> out(kRingDim, 0xDEADBEEF);
         REQUIRE(hazeMemcpy(out.data(), dst_storage[slot], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) ==
@@ -762,7 +752,6 @@ static void check_against_reference(const std::vector<void *> &dst,
     REQUIRE(dst.size() == dst_base.size());
     for (size_t j = 0; j < dst.size(); ++j) {
         std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
-        REQUIRE(hazeReplay() == HAZE_SUCCESS);
         REQUIRE(hazeMemcpy(got.data(), dst[j], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
         for (uint64_t s = 0; s < kRingDim; ++s) {
             INFO("dst index " << j << " (mod " << dst_base[j] << ") slot " << s);

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -30,7 +30,6 @@ TEST_CASE("hazeAdd: pointwise sum retrieved after D2H", "[integration]") {
     REQUIRE(hazeAdd(d_dst, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -58,7 +57,6 @@ TEST_CASE("hazeSub: pointwise difference retrieved after D2H", "[integration]") 
     REQUIRE(hazeSub(d_dst, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -84,7 +82,6 @@ TEST_CASE("hazeMulScalar: pointwise scalar product retrieved after D2H", "[integ
     REQUIRE(hazeMulScalar(d_dst, d_a, 4, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -109,7 +106,6 @@ TEST_CASE("hazeAddScalar: pointwise scalar addition retrieved after D2H", "[inte
     REQUIRE(hazeAddScalar(d_dst, d_a, 3, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -140,7 +136,6 @@ TEST_CASE("NTT round-trip: INTT(NTT(x)) == x", "[integration]") {
     REQUIRE(hazeINTT(d_intt, d_ntt, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_intt, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -171,7 +166,6 @@ TEST_CASE("hazeAdd in-place (dst == src1) produces correct result", "[integratio
     REQUIRE(hazeAdd(d_a, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_a, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -197,7 +191,6 @@ TEST_CASE("hazeAdd in-place (dst == src2) produces correct result", "[integratio
     REQUIRE(hazeAdd(d_b, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_b, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -221,7 +214,6 @@ TEST_CASE("hazeAdd in-place squaring-style (dst == src1 == src2)", "[integration
     REQUIRE(hazeAdd(d_a, d_a, d_a, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_a, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -253,7 +245,6 @@ TEST_CASE("multi-operation chain: add then mulscalar in one recording", "[integr
     REQUIRE(hazeMulScalar(d_dst, d_t, 2, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -286,7 +277,6 @@ TEST_CASE("multiple materializations: two independent D2H cycles", "[integration
     REQUIRE(hazeAdd(d_dst1, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> r1(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(r1.data(), d_dst1, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -301,7 +291,6 @@ TEST_CASE("multiple materializations: two independent D2H cycles", "[integration
     REQUIRE(hazeAdd(d_dst2, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> r2(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(r2.data(), d_dst2, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     for (uint64_t i = 0; i < kRingDim; ++i) {
@@ -335,7 +324,6 @@ TEST_CASE("hazeDeviceSynchronize does not trigger materialization", "[integratio
     REQUIRE(hazeDeviceSynchronize() == HAZE_SUCCESS);
 
     std::vector<uint64_t> result(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(result.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     // If sync had flushed state, result would be stale/zero. Correct: 6.
@@ -429,7 +417,6 @@ TEST_CASE("H2D after compute invalidates the polymap binding", "[integration]") 
     REQUIRE(hazeAdd(d_dst2, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> r2(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(r2.data(), d_dst2, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     for (uint64_t i = 0; i < kRingDim; ++i) {
         REQUIRE(r2[i] == 23);
@@ -461,7 +448,6 @@ TEST_CASE("memset after compute invalidates the polymap binding", "[integration]
     REQUIRE(hazeAdd(d_dst2, d_a, d_b, kModIdx, nullptr) == HAZE_SUCCESS);
 
     std::vector<uint64_t> r2(kRingDim, 0);
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(r2.data(), d_dst2, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     for (uint64_t i = 0; i < kRingDim; ++i) {
         REQUIRE(r2[i] == 5);

--- a/test/test_ring_dim_consistency.cpp
+++ b/test/test_ring_dim_consistency.cpp
@@ -48,13 +48,13 @@ constexpr size_t kBytes = kN * sizeof(uint64_t);
 // Routes through haze_replay_bridge so the test runs end-to-end via
 // the FHETCH transport: bridge picks the actual tower modulus near
 // 2^bits(kQ), aligns haze's ciphertext modulus, sets target=FUNC_SIM
-// so hazeReplay() dispatches to nbcc_fhetch_replay rather than no-op'ing.
+// so the D2H-triggered replay dispatches to nbcc_fhetch_replay rather
+// than no-op'ing.
 void setup_4096() {
     haze::test::setup_integration_compute_config(kN, kQ, 0);
 }
 
 inline void d2h(std::vector<uint64_t> &dst, const void *dev) {
-    REQUIRE(hazeReplay() == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(dst.data(), dev, dst.size() * sizeof(uint64_t),
                        HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 }


### PR DESCRIPTION
Previously we had added the replay function to stop the fhetch tracing and export that to a client. However, this requires an additional step that is not normally done in CUDA. Especially if we later want people to be able to write programs that run on machines that do have device access, it would be convenient to execute only when a device to host (D2H) transfer happens.

This PR removes the replay feature and then automatically calls the equivalent when the user asks for a D2H. This better matches CUDA and the user doesn't need to know when they need to sync with the device, as it happens automatically for them.