### PR TITLE
style: clang-format pass on haze sources

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -2,9 +2,9 @@ name: clang-format
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main]
   push:
-    branches: [main, master]
+    branches: [main]
   # Manual re-run from the Actions tab. Useful after touching .clang-format
   # without bumping a code commit.
   workflow_dispatch:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,48 @@
+name: clang-format
+
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+  # Manual re-run from the Actions tab. Useful after touching .clang-format
+  # without bumping a code commit.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clang-format-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-format:
+    name: Check clang-format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Install clang-format-19
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-19
+          sudo update-alternatives --install /usr/bin/clang-format \
+            clang-format /usr/bin/clang-format-19 100
+
+      - name: Verify clang-format version
+        run: clang-format --version
+
+      - name: Run clang-format --dry-run -Werror
+        # First-party C/C++ trees only. vendor/ is third-party / submodule
+        # territory and uses upstream's own formatting. The .clang-format at
+        # repo root governs every match here.
+        # --dry-run -Werror prints diffs and exits non-zero if any file
+        # needs reformatting.
+        run: |
+          find src include replay_bridge test \
+            \( -name '*.cpp' -o -name '*.hpp' -o -name '*.h' -o -name '*.c' \) \
+            -print0 | xargs -0 clang-format --dry-run -Werror

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -14,7 +14,6 @@
 #define HAZE_H
 
 #include <haze/haze_types.h>
-
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -33,14 +32,14 @@ extern "C" {
 // epoch, compiler backend, configuration, streams, events, active
 // device) AND the thread-local last-error flag. Mirrors cudaDeviceReset.
 
-HAZE_API hazeError_t hazeGetDeviceCount(int* count) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeGetDeviceCount(int *count) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeSetDevice(int device) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeGetDevice(int* device) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeGetDeviceProperties(hazeDeviceProp* prop, int device) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeGetDevice(int *device) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeGetDeviceProperties(hazeDeviceProp *prop, int device) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeDeviceSynchronize(void) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeDeviceReset(void) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeDeviceEnablePeerAccess(int peer, unsigned int flags) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeDeviceCanAccessPeer(int* can_access, int device, int peer) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeDeviceCanAccessPeer(int *can_access, int device, int peer) HAZE_NOEXCEPT;
 
 // Device memory: allocation, free, host-pinned buffers, pointer attributes.
 //
@@ -66,27 +65,26 @@ HAZE_API hazeError_t hazeDeviceCanAccessPeer(int* can_access, int device, int pe
 // allocator, etc.) reports HAZE_MEMORY_TYPE_UNREGISTERED — matches
 // cudaPointerGetAttributes' behaviour from CUDA 11 onward.
 
-HAZE_API hazeError_t hazeMalloc(void** ptr, size_t size) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeFree(void* ptr) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeMallocAsync(void** ptr, size_t size, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeFreeAsync(void* ptr, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeHostAlloc(void** ptr, size_t size, unsigned int flags) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeFreeHost(void* ptr) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazePointerGetAttributes(hazePointerAttributes* attrs,
-                                               const void* ptr) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMalloc(void **ptr, size_t size) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeFree(void *ptr) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMallocAsync(void **ptr, size_t size, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeFreeAsync(void *ptr, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeHostAlloc(void **ptr, size_t size, unsigned int flags) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeFreeHost(void *ptr) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazePointerGetAttributes(hazePointerAttributes *attrs,
+                                              const void *ptr) HAZE_NOEXCEPT;
 
 // Data transfer: H2D, D2H, D2D, memset, peer copies.
 
-HAZE_API hazeError_t hazeMemcpy(void* dst, const void* src, size_t count,
-                                 hazeMemcpyKind kind) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeMemcpyAsync(void* dst, const void* src, size_t count,
-                                      hazeMemcpyKind kind, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeMemset(void* dev_ptr, int value, size_t count) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeMemsetAsync(void* dev_ptr, int value, size_t count,
-                                      hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeMemcpyPeerAsync(void* dst, int dst_device,
-                                          const void* src, int src_device,
-                                          size_t count, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
+                                hazeMemcpyKind kind) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMemcpyAsync(void *dst, const void *src, size_t count, hazeMemcpyKind kind,
+                                     hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMemset(void *dev_ptr, int value, size_t count) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMemsetAsync(void *dev_ptr, int value, size_t count,
+                                     hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMemcpyPeerAsync(void *dst, int dst_device, const void *src, int src_device,
+                                         size_t count, hazeStream_t stream) HAZE_NOEXCEPT;
 
 // Device configuration: ring dimension, ciphertext moduli, twiddle factors,
 // program metadata, target selection, lifecycle reset.
@@ -99,8 +97,8 @@ HAZE_API hazeError_t hazeConfigureDevice(void) HAZE_NOEXCEPT;
 /* Set program metadata recorded in the FHETCH trace produced by HAZE.
  * Defaults: name="haze", version="0.1", description="HAZE runtime".
  * Must be called before the first compute call to take effect. */
-HAZE_API hazeError_t hazeSetProgramInfo(const char* name, const char* version,
-                                          const char* description) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeSetProgramInfo(const char *name, const char *version,
+                                        const char *description) HAZE_NOEXCEPT;
 
 /* Select the niobium-compiler target for replay.
  *
@@ -133,7 +131,7 @@ HAZE_API hazeError_t hazeSetProgramInfo(const char* name, const char* version,
  *   3. "local"                - default if both above are unset.
  *
  * See hazeReplay() for behaviour-by-target dispatch. */
-HAZE_API hazeError_t hazeSetTarget(const char* target) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeSetTarget(const char *target) HAZE_NOEXCEPT;
 
 /* Trigger replay of the recorded operations.
  *
@@ -155,54 +153,52 @@ HAZE_API hazeError_t hazeReplay(void) HAZE_NOEXCEPT;
 // HAZE_SUCCESS. The handle and signature surface is preserved for
 // CUDA-shape porting parity.
 
-HAZE_API hazeError_t hazeStreamCreate(hazeStream_t* stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeStreamCreateWithPriority(hazeStream_t* stream,
-                                                   unsigned int flags,
-                                                   int priority) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeStreamCreate(hazeStream_t *stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeStreamCreateWithPriority(hazeStream_t *stream, unsigned int flags,
+                                                  int priority) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeStreamDestroy(hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeStreamSynchronize(hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeStreamWaitEvent(hazeStream_t stream, hazeEvent_t event,
-                                          unsigned int flags) HAZE_NOEXCEPT;
+                                         unsigned int flags) HAZE_NOEXCEPT;
 
 // Events: same shape as streams; no-op semantics today.
 
-HAZE_API hazeError_t hazeEventCreate(hazeEvent_t* event) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeEventCreateWithFlags(hazeEvent_t* event,
-                                               unsigned int flags) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeEventCreate(hazeEvent_t *event) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeEventCreateWithFlags(hazeEvent_t *event, unsigned int flags) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeEventDestroy(hazeEvent_t event) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeEventRecord(hazeEvent_t event, hazeStream_t stream) HAZE_NOEXCEPT;
 
 // Error handling. Mirrors CUDA's last-error pattern.
 
-HAZE_API hazeError_t                  hazeGetLastError(void) HAZE_NOEXCEPT;
-HAZE_NODISCARD HAZE_API const char*   hazeGetErrorString(hazeError_t error) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeGetLastError(void) HAZE_NOEXCEPT;
+HAZE_NODISCARD HAZE_API const char *hazeGetErrorString(hazeError_t error) HAZE_NOEXCEPT;
 
 // Point-wise polynomial arithmetic and scalar variants.
 
-HAZE_API hazeError_t hazeAdd(void* dst, const void* src1, const void* src2,
-                              int mod_idx, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeSub(void* dst, const void* src1, const void* src2,
-                              int mod_idx, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeMul(void* dst, const void* src1, const void* src2,
-                              int mod_idx, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeAddScalar(void* dst, const void* src, uint64_t scalar,
-                                    int mod_idx, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeSubScalar(void* dst, const void* src, uint64_t scalar,
-                                    int mod_idx, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeMulScalar(void* dst, const void* src, uint64_t scalar,
-                                    int mod_idx, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeAdd(void *dst, const void *src1, const void *src2, int mod_idx,
+                             hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeSub(void *dst, const void *src1, const void *src2, int mod_idx,
+                             hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMul(void *dst, const void *src1, const void *src2, int mod_idx,
+                             hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeAddScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
+                                   hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeSubScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
+                                   hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeMulScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
+                                   hazeStream_t stream) HAZE_NOEXCEPT;
 
 // Number-theoretic transform (NTT) and its inverse.
 
-HAZE_API hazeError_t hazeNTT(void* dst, const void* src,
-                               int mod_idx, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeINTT(void* dst, const void* src,
-                                int mod_idx, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeNTT(void *dst, const void *src, int mod_idx,
+                             hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeINTT(void *dst, const void *src, int mod_idx,
+                              hazeStream_t stream) HAZE_NOEXCEPT;
 
 // Automorphism / rotation.
 
-HAZE_API hazeError_t hazeAutomorph(void* dst, const void* src, uint64_t index,
-                                    hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeAutomorph(void *dst, const void *src, uint64_t index,
+                                   hazeStream_t stream) HAZE_NOEXCEPT;
 
 // CRT basis conversion (composite operations: ModUp, ModDown,
 // generalised basis convert).
@@ -215,20 +211,20 @@ HAZE_API hazeError_t hazeAutomorph(void* dst, const void* src, uint64_t index,
 // doc). `params` carries the moduli bases and other scalar metadata
 // only — never polynomial pointers.
 
-HAZE_API hazeError_t hazeBasisConvert(void* const* dst, const void* const* src,
-                                       const void* params, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeModDown(void* const* dst, const void* const* src,
-                                  const void* params, hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeModUp(void* const* dst, const void* const* src,
-                                const void* params, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeBasisConvert(void *const *dst, const void *const *src, const void *params,
+                                      hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeModDown(void *const *dst, const void *const *src, const void *params,
+                                 hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeModUp(void *const *dst, const void *const *src, const void *params,
+                               hazeStream_t stream) HAZE_NOEXCEPT;
 
 // Graph recording and execution. Names mirror CUDA's graph API. All
 // entries currently return HAZE_ERROR_NOT_SUPPORTED — graph capture is
 // a future task.
 
 HAZE_API hazeError_t hazeStreamBeginCapture(hazeStream_t stream) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeStreamEndCapture(hazeStream_t stream, hazeGraph_t* graph) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeGraphInstantiate(hazeGraphExec_t* exec, hazeGraph_t graph) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeStreamEndCapture(hazeStream_t stream, hazeGraph_t *graph) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeGraphInstantiate(hazeGraphExec_t *exec, hazeGraph_t graph) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeGraphLaunch(hazeGraphExec_t exec, hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeGraphExecUpdate(hazeGraphExec_t exec, hazeGraph_t graph) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeGraphExecDestroy(hazeGraphExec_t exec) HAZE_NOEXCEPT;
@@ -236,7 +232,7 @@ HAZE_API hazeError_t hazeGraphDestroy(hazeGraph_t graph) HAZE_NOEXCEPT;
 
 // Profiling / multi-device stubs.
 
-HAZE_API hazeError_t hazeGetPerformanceCounters(void* counters) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeGetPerformanceCounters(void *counters) HAZE_NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/include/haze/haze_types.h
+++ b/include/haze/haze_types.h
@@ -155,9 +155,9 @@ typedef struct {
 //   dst: array of dst_base_len output poly pointers.
 typedef struct {
     const uint64_t *src_base;
-    size_t          src_base_len;
+    size_t src_base_len;
     const uint64_t *dst_base;
-    size_t          dst_base_len;
+    size_t dst_base_len;
 } hazeBasisConvertParams;
 
 // hazeModDown: rescale by removing rescale_base from src_base.
@@ -167,9 +167,9 @@ typedef struct {
 //   rescale_base: a proper subset of src_base.
 typedef struct {
     const uint64_t *src_base;
-    size_t          src_base_len;
+    size_t src_base_len;
     const uint64_t *rescale_base;
-    size_t          rescale_base_len;
+    size_t rescale_base_len;
 } hazeModDownParams;
 
 // hazeModUp: digit decomposition for hybrid key switching.
@@ -184,13 +184,13 @@ typedef struct {
 //   p_base: auxiliary primes appended to every digit's output base.
 typedef struct {
     const uint64_t *src_base;
-    size_t          src_base_len;
+    size_t src_base_len;
     const uint64_t *digit_bases;
-    size_t          digit_bases_total_len;
-    const size_t   *digit_base_lens;
-    size_t          digit_count;
+    size_t digit_bases_total_len;
+    const size_t *digit_base_lens;
+    size_t digit_count;
     const uint64_t *p_base;
-    size_t          p_base_len;
+    size_t p_base_len;
 } hazeModUpParams;
 
 #endif /* HAZE_TYPES_H */

--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -44,7 +44,6 @@
 #define HAZE_REPLAY_BRIDGE_H
 
 #include <haze/haze_types.h>
-
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -73,13 +72,11 @@ extern "C" {
 /// hazeReplay() ships an incomplete project (no .bin / .ids / .template
 /// files), which the compiler-side rejects. The setup_integration_compute_config
 /// helper enforces this ordering automatically.
-HAZE_API hazeError_t hazeReplayBridgeInitCryptoContext(
-    uint64_t  ring_dim,
-    uint64_t  desired_modulus,
-    uint64_t* picked_modulus) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim, uint64_t desired_modulus,
+                                                       uint64_t *picked_modulus) HAZE_NOEXCEPT;
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // HAZE_REPLAY_BRIDGE_H
+#endif // HAZE_REPLAY_BRIDGE_H

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -15,18 +15,12 @@
 // catch2 runner). Bridge state is therefore implicitly serialized; no
 // internal lock needed.
 
-#include <haze/replay_bridge.h>
-
-#include "openfhe.h"
 #include "ciphertext-ser.h"
+#include "common/log.hpp"
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
+#include "openfhe.h"
 #include "scheme/ckksrns/ckksrns-ser.h"
-
-#include "common/log.hpp"
-
-#include <niobium/compiler.h>
-#include <niobium/fhetch_api.h>
 
 #include <bit>
 #include <cassert>
@@ -34,7 +28,10 @@
 #include <expected>
 #include <filesystem>
 #include <functional>
+#include <haze/replay_bridge.h>
 #include <map>
+#include <niobium/compiler.h>
+#include <niobium/fhetch_api.h>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -58,31 +55,27 @@ namespace niobium::detail {
 // (in-process simulator or transport) deserializes this template,
 // fills its first NativePoly with computed values, and re-serializes
 // it as serialized_probes/<name>.ct.
-bool write_ciphertext_template(
-    const std::string& name,
-    const lbcrypto::Ciphertext<lbcrypto::DCRTPoly>& ct);
+bool write_ciphertext_template(const std::string &name,
+                               const lbcrypto::Ciphertext<lbcrypto::DCRTPoly> &ct);
 
 // Serialize a populated Ciphertext<DCRTPoly> as the cereal-binary
 // {.bin, .ids} pair the compiler-side fhetch_driver expects for an
 // input named `name`.
-bool write_ciphertext_input_bin(
-    const std::string& name,
-    const lbcrypto::Ciphertext<lbcrypto::DCRTPoly>& ct,
-    const std::vector<uint64_t>& addr_ids);
+bool write_ciphertext_input_bin(const std::string &name,
+                                const lbcrypto::Ciphertext<lbcrypto::DCRTPoly> &ct,
+                                const std::vector<uint64_t> &addr_ids);
 
 // Iterate every captured input recorded via fhetch::tag_input. The
 // callback receives (name, addr_id, modulus, values) for each per-name
 // element so the bridge can fan-out a single ciphertext per name.
-void for_each_captured_input(
-    const std::function<void(const std::string&, uint64_t, uint64_t,
-                              const std::vector<uint64_t>&)>& cb);
+void for_each_captured_input(const std::function<void(const std::string &, uint64_t, uint64_t,
+                                                      const std::vector<uint64_t> &)> &cb);
 
 // Iterate every captured output name recorded via fhetch::tag_output.
 // Callback fires once per output name.
-void for_each_captured_output(
-    const std::function<void(const std::string&)>& cb);
+void for_each_captured_output(const std::function<void(const std::string &)> &cb);
 
-}  // namespace niobium::detail
+} // namespace niobium::detail
 
 namespace {
 
@@ -134,8 +127,8 @@ uint32_t bit_width_for_modulus(uint64_t modulus) {
 // correct shape) or after a successful rebuild; returns a structured
 // BridgeError otherwise so the caller can map to the matching
 // hazeError_t.
-std::expected<void, BridgeError>
-rebuild_context_locked(uint64_t ring_dim, uint64_t desired_modulus) {
+std::expected<void, BridgeError> rebuild_context_locked(uint64_t ring_dim,
+                                                        uint64_t desired_modulus) {
     using namespace lbcrypto;
     // Sanity gate: 0 or 1 are trivially malformed. Real CKKS NTT-
     // friendly primes are ~60-bit; OpenFHE will reject other invalid
@@ -145,13 +138,12 @@ rebuild_context_locked(uint64_t ring_dim, uint64_t desired_modulus) {
     if (desired_modulus < 2)
         return std::unexpected(BridgeError::InvalidModulus);
 
-    if (g_ctx.cc && g_ctx.ring_dim == ring_dim &&
-        g_ctx.desired_modulus == desired_modulus) {
-        return {};  // cache hit
+    if (g_ctx.cc && g_ctx.ring_dim == ring_dim && g_ctx.desired_modulus == desired_modulus) {
+        return {}; // cache hit
     }
 
     CCParams<CryptoContextCKKSRNS> p;
-    p.SetSecurityLevel(HEStd_NotSet);  // toy: ring_dim is user-chosen
+    p.SetSecurityLevel(HEStd_NotSet); // toy: ring_dim is user-chosen
     p.SetRingDim(ring_dim);
     // TODO(haze:multi-residue): SetMultiplicativeDepth(0) produces a
     // single-tower DCRTPoly chain. Multi-residue paths (hazeModUp,
@@ -205,12 +197,12 @@ rebuild_context_locked(uint64_t ring_dim, uint64_t desired_modulus) {
 // coarser.
 hazeError_t to_haze_error(BridgeError e) {
     switch (e) {
-        case BridgeError::InvalidRingDim:
-        case BridgeError::InvalidModulus:
-            return HAZE_ERROR_INVALID_VALUE;
-        case BridgeError::KeygenFailed:
-        case BridgeError::OpenFheUnavailable:
-            return HAZE_ERROR_LAUNCH_FAILURE;
+    case BridgeError::InvalidRingDim:
+    case BridgeError::InvalidModulus:
+        return HAZE_ERROR_INVALID_VALUE;
+    case BridgeError::KeygenFailed:
+    case BridgeError::OpenFheUnavailable:
+        return HAZE_ERROR_LAUNCH_FAILURE;
     }
     return HAZE_ERROR_LAUNCH_FAILURE;
 }
@@ -221,8 +213,7 @@ hazeError_t to_haze_error(BridgeError e) {
 // TODO(haze:no-keygen): bypass Encrypt + element[1] trim with a direct
 // public-API no-key construction once OpenFHE exposes one. See the
 // rebuild_context_locked TODO.
-lbcrypto::Ciphertext<DCRTPoly>
-synthesize_haze_ciphertext(const std::vector<uint64_t>& values) {
+lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_ciphertext(const std::vector<uint64_t> &values) {
     std::vector<double> zeros(g_ctx.ring_dim / 2, 0.0);
     auto pt = g_ctx.cc->MakeCKKSPackedPlaintext(zeros);
     auto ct = g_ctx.cc->Encrypt(g_ctx.keys.publicKey, pt);
@@ -234,15 +225,16 @@ synthesize_haze_ciphertext(const std::vector<uint64_t>& values) {
     // compiler-side reads NativePoly values positionally, not via the
     // CKKS API.
     {
-        auto& els = ct->GetElements();
-        if (els.size() > 1) els.resize(1);
+        auto &els = ct->GetElements();
+        if (els.size() > 1)
+            els.resize(1);
     }
     if (values.empty()) {
         // Output template path: caller wants an empty shell, no fill.
         return ct;
     }
-    auto& dcrt = ct->GetElements()[0];
-    auto& np = dcrt.GetAllElements()[0];
+    auto &dcrt = ct->GetElements()[0];
+    auto &np = dcrt.GetAllElements()[0];
     size_t n = np.GetParams()->GetRingDimension();
     if (values.size() != n) {
         std::ostringstream body;
@@ -274,37 +266,35 @@ void on_post_recording() {
 
     // ---- Inputs ----
     struct InputAccum {
-        std::vector<uint64_t> values;  // first element's values
+        std::vector<uint64_t> values; // first element's values
         std::vector<uint64_t> addr_ids;
         bool seen_first = false;
     };
     std::map<std::string, InputAccum> inputs_by_name;
 
-    niobium::detail::for_each_captured_input(
-        [&](const std::string& name, uint64_t addr_id, uint64_t /*mod*/,
-            const std::vector<uint64_t>& values) {
-            if (name == "evalmult_key" || name == "automorphism_key") return;
-            auto& acc = inputs_by_name[name];
-            acc.addr_ids.push_back(addr_id);
-            if (!acc.seen_first) {
-                acc.values = values;
-                acc.seen_first = true;
-            }
-        });
+    niobium::detail::for_each_captured_input([&](const std::string &name, uint64_t addr_id,
+                                                 uint64_t /*mod*/,
+                                                 const std::vector<uint64_t> &values) {
+        if (name == "evalmult_key" || name == "automorphism_key")
+            return;
+        auto &acc = inputs_by_name[name];
+        acc.addr_ids.push_back(addr_id);
+        if (!acc.seen_first) {
+            acc.values = values;
+            acc.seen_first = true;
+        }
+    });
 
-    for (auto& [name, acc] : inputs_by_name) {
+    for (auto &[name, acc] : inputs_by_name) {
         try {
             auto ct = synthesize_haze_ciphertext(acc.values);
-            if (!niobium::detail::write_ciphertext_input_bin(
-                    name, ct, acc.addr_ids)) {
-                haze::log_error(
-                    "replay_bridge",
-                    "write_ciphertext_input_bin failed for '" + name + "'");
+            if (!niobium::detail::write_ciphertext_input_bin(name, ct, acc.addr_ids)) {
+                haze::log_error("replay_bridge",
+                                "write_ciphertext_input_bin failed for '" + name + "'");
             }
-        } catch (const std::exception& e) {
-            haze::log_error(
-                "replay_bridge",
-                "input bin synthesis for '" + name + "' threw: " + e.what());
+        } catch (const std::exception &e) {
+            haze::log_error("replay_bridge",
+                            "input bin synthesis for '" + name + "' threw: " + e.what());
         }
     }
 
@@ -314,21 +304,18 @@ void on_post_recording() {
     // are otherwise empty. This removes the burden from test code of
     // having to call hazeReplayBridgeWriteTemplate per output — tests
     // just call hazeReplay() and the bridge handles it.
-    niobium::detail::for_each_captured_output(
-        [&](const std::string& name) {
-            try {
-                auto ct = synthesize_haze_ciphertext({});
-                if (!niobium::detail::write_ciphertext_template(name, ct)) {
-                    haze::log_error(
-                        "replay_bridge",
-                        "write_ciphertext_template failed for '" + name + "'");
-                }
-            } catch (const std::exception& e) {
-                haze::log_error(
-                    "replay_bridge",
-                    "template synthesis for '" + name + "' threw: " + e.what());
+    niobium::detail::for_each_captured_output([&](const std::string &name) {
+        try {
+            auto ct = synthesize_haze_ciphertext({});
+            if (!niobium::detail::write_ciphertext_template(name, ct)) {
+                haze::log_error("replay_bridge",
+                                "write_ciphertext_template failed for '" + name + "'");
             }
-        });
+        } catch (const std::exception &e) {
+            haze::log_error("replay_bridge",
+                            "template synthesis for '" + name + "' threw: " + e.what());
+        }
+    });
 }
 
 // Push the bridge's CryptoContext into niobium::compiler() (libnbfhetch's
@@ -355,17 +342,18 @@ void push_crypto_to_compiler() {
     niobium::compiler().set_post_recording_hook(&on_post_recording);
 }
 
-}  // namespace
+} // namespace
 
-extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(
-    uint64_t  ring_dim,
-    uint64_t  desired_modulus,
-    uint64_t* picked_modulus) noexcept {
-    if (picked_modulus == nullptr) return HAZE_ERROR_INVALID_VALUE;
+extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
+                                                         uint64_t desired_modulus,
+                                                         uint64_t *picked_modulus) noexcept {
+    if (picked_modulus == nullptr)
+        return HAZE_ERROR_INVALID_VALUE;
 
     try {
         auto rebuild = rebuild_context_locked(ring_dim, desired_modulus);
-        if (!rebuild) return to_haze_error(rebuild.error());
+        if (!rebuild)
+            return to_haze_error(rebuild.error());
 
         // capture_crypto_context populates ring dimension + modulus
         // chain AND serializes <program_dir>/cryptocontext.dat from
@@ -378,9 +366,8 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(
 
         *picked_modulus = g_ctx.picked_modulus;
         return HAZE_SUCCESS;
-    } catch (const std::exception& e) {
-        haze::log_error("replay_bridge",
-                        std::string{"init threw: "} + e.what());
+    } catch (const std::exception &e) {
+        haze::log_error("replay_bridge", std::string{"init threw: "} + e.what());
         return HAZE_ERROR_LAUNCH_FAILURE;
     } catch (...) {
         return HAZE_ERROR_LAUNCH_FAILURE;
@@ -408,19 +395,16 @@ inline Format openfhe_to_fhetch_format(::Format fmt) {
 
 // Load <program_dir>/serialized_probes/<name>.ct as a Ciphertext<DCRTPoly>.
 // Returns nullptr on any I/O / parse error.
-lbcrypto::Ciphertext<DCRTPoly> load_serialized_probe(const std::string& name) {
+lbcrypto::Ciphertext<DCRTPoly> load_serialized_probe(const std::string &name) {
     auto dir = niobium::compiler().get_program_directory();
     auto ct_path = dir / "serialized_probes" / (name + ".ct");
     if (!std::filesystem::exists(ct_path)) {
-        haze::log_error("fhetch::result",
-                        "'" + name + "' not found at " + ct_path.string());
+        haze::log_error("fhetch::result", "'" + name + "' not found at " + ct_path.string());
         return nullptr;
     }
     lbcrypto::Ciphertext<DCRTPoly> ct;
-    if (!lbcrypto::Serial::DeserializeFromFile(ct_path.string(), ct,
-                                               lbcrypto::SerType::BINARY)) {
-        haze::log_error("fhetch::result",
-                        "failed to deserialize " + ct_path.string());
+    if (!lbcrypto::Serial::DeserializeFromFile(ct_path.string(), ct, lbcrypto::SerType::BINARY)) {
+        haze::log_error("fhetch::result", "failed to deserialize " + ct_path.string());
         return nullptr;
     }
     return ct;
@@ -428,8 +412,8 @@ lbcrypto::Ciphertext<DCRTPoly> load_serialized_probe(const std::string& name) {
 
 // Pull a single residue's coefficients out of a NativePoly as
 // std::vector<uint64_t>.
-std::vector<uint64_t> native_poly_values(const lbcrypto::NativePoly& np) {
-    const auto& vals = np.GetValues();
+std::vector<uint64_t> native_poly_values(const lbcrypto::NativePoly &np) {
+    const auto &vals = np.GetValues();
     const size_t n = vals.GetLength();
     std::vector<uint64_t> out;
     out.reserve(n);
@@ -439,48 +423,49 @@ std::vector<uint64_t> native_poly_values(const lbcrypto::NativePoly& np) {
     return out;
 }
 
-}  // namespace
+} // namespace
 
 NIOBIUM_FHETCH_RESULT_API
-bool result(const std::string& name, Polynomial& p) {
+bool result(const std::string &name, Polynomial &p) {
     auto ct = load_serialized_probe(name);
-    if (!ct) return false;
+    if (!ct)
+        return false;
 
-    const auto& elements = ct->GetElements();
+    const auto &elements = ct->GetElements();
     if (elements.empty()) {
-        haze::log_error("fhetch::result",
-                        "'" + name + "' has no DCRTPoly elements");
+        haze::log_error("fhetch::result", "'" + name + "' has no DCRTPoly elements");
         return false;
     }
-    const auto& towers = elements[0].GetAllElements();
+    const auto &towers = elements[0].GetAllElements();
     if (towers.empty()) {
-        haze::log_error("fhetch::result",
-                        "'" + name + "' has no NativePoly towers");
+        haze::log_error("fhetch::result", "'" + name + "' has no NativePoly towers");
         return false;
     }
-    const auto& np = towers[0];
+    const auto &np = towers[0];
     auto values = native_poly_values(np);
-    p = Polynomial::from_data(values, values.size(),
-                              openfhe_to_fhetch_format(np.GetFormat()));
+    p = Polynomial::from_data(values, values.size(), openfhe_to_fhetch_format(np.GetFormat()));
     return true;
 }
 
 NIOBIUM_FHETCH_RESULT_API
-bool result(const std::string& name, MRP& m) {
+bool result(const std::string &name, MRP &m) {
     auto ct = load_serialized_probe(name);
-    if (!ct) return false;
+    if (!ct)
+        return false;
 
-    const auto& elements = ct->GetElements();
-    if (elements.empty()) return false;
-    const auto& towers = elements[0].GetAllElements();
-    if (towers.empty()) return false;
+    const auto &elements = ct->GetElements();
+    if (elements.empty())
+        return false;
+    const auto &towers = elements[0].GetAllElements();
+    if (towers.empty())
+        return false;
 
     std::vector<std::pair<Polynomial, uint64_t>> pairs;
     pairs.reserve(towers.size());
-    for (const auto& np : towers) {
+    for (const auto &np : towers) {
         auto values = native_poly_values(np);
-        auto poly = Polynomial::from_data(values, values.size(),
-                                          openfhe_to_fhetch_format(np.GetFormat()));
+        auto poly =
+            Polynomial::from_data(values, values.size(), openfhe_to_fhetch_format(np.GetFormat()));
         pairs.emplace_back(std::move(poly), np.GetModulus().ConvertToInt());
     }
     m = MRP::from_pairs(pairs);
@@ -488,18 +473,19 @@ bool result(const std::string& name, MRP& m) {
 }
 
 NIOBIUM_FHETCH_RESULT_API
-bool result(const std::string& name, MRPArray& arr) {
+bool result(const std::string &name, MRPArray &arr) {
     auto ct = load_serialized_probe(name);
-    if (!ct) return false;
+    if (!ct)
+        return false;
 
-    const auto& elements = ct->GetElements();
+    const auto &elements = ct->GetElements();
     MRPArray out(elements.size());
     for (size_t i = 0; i < elements.size(); ++i) {
-        const auto& dcrt = elements[i];
-        const auto& towers = dcrt.GetAllElements();
+        const auto &dcrt = elements[i];
+        const auto &towers = dcrt.GetAllElements();
         std::vector<std::pair<Polynomial, uint64_t>> pairs;
         pairs.reserve(towers.size());
-        for (const auto& np : towers) {
+        for (const auto &np : towers) {
             auto values = native_poly_values(np);
             auto poly = Polynomial::from_data(values, values.size(),
                                               openfhe_to_fhetch_format(np.GetFormat()));
@@ -511,4 +497,4 @@ bool result(const std::string& name, MRPArray& arr) {
     return true;
 }
 
-}  // namespace niobium::fhetch
+} // namespace niobium::fhetch

--- a/src/api/basis_convert.cpp
+++ b/src/api/basis_convert.cpp
@@ -12,6 +12,7 @@
 // from the Product.
 
 #include "core/basis_convert.hpp"
+
 #include "common/errors.hpp"
 
 #include <haze/haze.h>

--- a/src/api/compute.cpp
+++ b/src/api/compute.cpp
@@ -16,15 +16,14 @@
 // DevAddr, and selects the matching FHETCH operation.
 
 #include "core/compute.hpp"
-#include "common/handle.hpp"
+
 #include "common/errors.hpp"
-
-#include <haze/haze.h>
-#include <haze/haze_types.h>
-
-#include <niobium/fhetch_api.h>
+#include "common/handle.hpp"
 
 #include <cstdint>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <niobium/fhetch_api.h>
 
 namespace fhetch = niobium::fhetch;
 
@@ -32,75 +31,72 @@ extern "C" hazeError_t hazeAdd(void *dst, const void *src1, const void *src2, in
                                hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op<fhetch::sr_addp>(haze::to_dev_addr(dst),
-                                                       haze::to_dev_addr(src1),
-                                                       haze::to_dev_addr(src2), mod_idx);
+    return haze::binary_pp_op<fhetch::sr_addp>(haze::to_dev_addr(dst), haze::to_dev_addr(src1),
+                                               haze::to_dev_addr(src2), mod_idx);
 }
 
 extern "C" hazeError_t hazeSub(void *dst, const void *src1, const void *src2, int mod_idx,
                                hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op<fhetch::sr_subp>(haze::to_dev_addr(dst),
-                                                       haze::to_dev_addr(src1),
-                                                       haze::to_dev_addr(src2), mod_idx);
+    return haze::binary_pp_op<fhetch::sr_subp>(haze::to_dev_addr(dst), haze::to_dev_addr(src1),
+                                               haze::to_dev_addr(src2), mod_idx);
 }
 
 extern "C" hazeError_t hazeMul(void *dst, const void *src1, const void *src2, int mod_idx,
                                hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op<fhetch::sr_mulp>(haze::to_dev_addr(dst),
-                                                       haze::to_dev_addr(src1),
-                                                       haze::to_dev_addr(src2), mod_idx);
+    return haze::binary_pp_op<fhetch::sr_mulp>(haze::to_dev_addr(dst), haze::to_dev_addr(src1),
+                                               haze::to_dev_addr(src2), mod_idx);
 }
 
 extern "C" hazeError_t hazeAddScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
                                      hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op<fhetch::sr_addps>(
-        haze::to_dev_addr(dst), haze::to_dev_addr(src), scalar, mod_idx);
+    return haze::binary_ps_op<fhetch::sr_addps>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
+                                                scalar, mod_idx);
 }
 
 extern "C" hazeError_t hazeSubScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
                                      hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op<fhetch::sr_subps>(
-        haze::to_dev_addr(dst), haze::to_dev_addr(src), scalar, mod_idx);
+    return haze::binary_ps_op<fhetch::sr_subps>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
+                                                scalar, mod_idx);
 }
 
 extern "C" hazeError_t hazeMulScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
                                      hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op<fhetch::sr_mulps>(
-        haze::to_dev_addr(dst), haze::to_dev_addr(src), scalar, mod_idx);
+    return haze::binary_ps_op<fhetch::sr_mulps>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
+                                                scalar, mod_idx);
 }
 
 extern "C" hazeError_t hazeNTT(void *dst, const void *src, int mod_idx,
                                hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_pq_op<fhetch::sr_ntt>(haze::to_dev_addr(dst),
-                                                     haze::to_dev_addr(src), mod_idx);
+    return haze::unary_pq_op<fhetch::sr_ntt>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
+                                             mod_idx);
 }
 
 extern "C" hazeError_t hazeINTT(void *dst, const void *src, int mod_idx,
                                 hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_pq_op<fhetch::sr_intt>(haze::to_dev_addr(dst),
-                                                      haze::to_dev_addr(src), mod_idx);
+    return haze::unary_pq_op<fhetch::sr_intt>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
+                                              mod_idx);
 }
 
 extern "C" hazeError_t hazeAutomorph(void *dst, const void *src, uint64_t index,
                                      hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_pi_op<fhetch::sr_automorph_eval>(
-        haze::to_dev_addr(dst), haze::to_dev_addr(src), index);
+    return haze::unary_pi_op<fhetch::sr_automorph_eval>(haze::to_dev_addr(dst),
+                                                        haze::to_dev_addr(src), index);
 }
 
 // CRT basis conversion (hazeBasisConvert / hazeModDown / hazeModUp) is
@@ -112,22 +108,19 @@ extern "C" hazeError_t hazeStreamBeginCapture(hazeStream_t /*stream*/) noexcept 
     return set_error(HAZE_ERROR_NOT_SUPPORTED);
 }
 
-extern "C" hazeError_t hazeStreamEndCapture(hazeStream_t /*stream*/,
-                                            hazeGraph_t *graph) noexcept {
+extern "C" hazeError_t hazeStreamEndCapture(hazeStream_t /*stream*/, hazeGraph_t *graph) noexcept {
     if (graph != nullptr)
         *graph = nullptr;
     return set_error(HAZE_ERROR_NOT_SUPPORTED);
 }
 
-extern "C" hazeError_t hazeGraphInstantiate(hazeGraphExec_t *exec,
-                                            hazeGraph_t /*graph*/) noexcept {
+extern "C" hazeError_t hazeGraphInstantiate(hazeGraphExec_t *exec, hazeGraph_t /*graph*/) noexcept {
     if (exec != nullptr)
         *exec = nullptr;
     return set_error(HAZE_ERROR_NOT_SUPPORTED);
 }
 
-extern "C" hazeError_t hazeGraphLaunch(hazeGraphExec_t /*exec*/,
-                                       hazeStream_t /*stream*/) noexcept {
+extern "C" hazeError_t hazeGraphLaunch(hazeGraphExec_t /*exec*/, hazeStream_t /*stream*/) noexcept {
     return set_error(HAZE_ERROR_NOT_SUPPORTED);
 }
 

--- a/src/api/config.cpp
+++ b/src/api/config.cpp
@@ -11,12 +11,12 @@
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
 #include "core/config.hpp"
+
 #include "common/errors.hpp"
 
+#include <cstdint>
 #include <haze/haze.h>
 #include <haze/haze_types.h>
-
-#include <cstdint>
 
 extern "C" hazeError_t hazeSetRingDimension(uint64_t n) noexcept {
     return set_error(haze::config().set_ring_dimension(n));

--- a/src/api/device.cpp
+++ b/src/api/device.cpp
@@ -11,6 +11,7 @@
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
 #include "core/device.hpp"
+
 #include "common/errors.hpp"
 
 #include <haze/haze.h>
@@ -38,7 +39,9 @@ extern "C" hazeError_t hazeGetDeviceProperties(hazeDeviceProp *prop, int device)
     return set_error(haze::device_fill_properties(prop, device));
 }
 
-extern "C" hazeError_t hazeDeviceSynchronize() noexcept { return HAZE_SUCCESS; }
+extern "C" hazeError_t hazeDeviceSynchronize() noexcept {
+    return HAZE_SUCCESS;
+}
 
 extern "C" hazeError_t hazeDeviceEnablePeerAccess(int /*peer*/, unsigned int /*flags*/) noexcept {
     return set_error(HAZE_ERROR_NOT_SUPPORTED);

--- a/src/api/error.cpp
+++ b/src/api/error.cpp
@@ -23,20 +23,33 @@ extern "C" hazeError_t hazeGetLastError() noexcept {
     return err;
 }
 
-extern "C" const char* hazeGetErrorString(hazeError_t error) noexcept {
+extern "C" const char *hazeGetErrorString(hazeError_t error) noexcept {
     switch (error) {
-        case HAZE_SUCCESS:              return "no error";
-        case HAZE_ERROR_INVALID_HANDLE: return "invalid handle";
-        case HAZE_ERROR_INVALID_VALUE:  return "invalid value";
-        case HAZE_ERROR_OUT_OF_MEMORY:  return "out of memory";
-        case HAZE_ERROR_NOT_SUPPORTED:  return "not supported";
-        case HAZE_ERROR_NOT_READY:      return "device not ready";
-        case HAZE_ERROR_LAUNCH_FAILURE: return "compilation or execution failure";
-        case HAZE_ERROR_DMEMERR:        return "data memory error";
-        case HAZE_ERROR_IMEMERR:        return "instruction memory error";
-        case HAZE_ERROR_INSTRERR:       return "instruction error";
-        case HAZE_ERROR_CONFIGERR:      return "configuration error";
-        case HAZE_ERROR_ISEQERR:        return "instruction sequence error";
-        default:                        return "unknown error";
+    case HAZE_SUCCESS:
+        return "no error";
+    case HAZE_ERROR_INVALID_HANDLE:
+        return "invalid handle";
+    case HAZE_ERROR_INVALID_VALUE:
+        return "invalid value";
+    case HAZE_ERROR_OUT_OF_MEMORY:
+        return "out of memory";
+    case HAZE_ERROR_NOT_SUPPORTED:
+        return "not supported";
+    case HAZE_ERROR_NOT_READY:
+        return "device not ready";
+    case HAZE_ERROR_LAUNCH_FAILURE:
+        return "compilation or execution failure";
+    case HAZE_ERROR_DMEMERR:
+        return "data memory error";
+    case HAZE_ERROR_IMEMERR:
+        return "instruction memory error";
+    case HAZE_ERROR_INSTRERR:
+        return "instruction error";
+    case HAZE_ERROR_CONFIGERR:
+        return "configuration error";
+    case HAZE_ERROR_ISEQERR:
+        return "instruction sequence error";
+    default:
+        return "unknown error";
     }
 }

--- a/src/api/lifecycle.cpp
+++ b/src/api/lifecycle.cpp
@@ -16,12 +16,12 @@
 // pending compute is dropped before the backend / allocator state is
 // torn down).
 
+#include "common/errors.hpp"
 #include "core/allocator.hpp"
 #include "core/backend.hpp"
 #include "core/config.hpp"
 #include "core/device.hpp"
 #include "core/epoch.hpp"
-#include "common/errors.hpp"
 #include "core/stream.hpp"
 
 #include <haze/haze.h>

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -10,17 +10,16 @@
 // available the Product; (iii) reverse engineer, disassemble, decompile,
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
-#include "core/allocator.hpp"
-#include "core/epoch.hpp"
 #include "common/errors.hpp"
 #include "common/handle.hpp"
-
-#include <haze/haze.h>
-#include <haze/haze_types.h>
+#include "core/allocator.hpp"
+#include "core/epoch.hpp"
 
 #include <cstdint>
 #include <cstdlib>
 #include <expected>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
 #include <unistd.h>
 
 extern "C" hazeError_t hazeMalloc(void **ptr, size_t size) noexcept {
@@ -53,8 +52,7 @@ extern "C" hazeError_t hazeHostAlloc(void **ptr, size_t size, unsigned int /*fla
     // Page-aligned allocation for DMA / O_DIRECT compatibility on
     // pinned-host buffers. Apple Silicon uses 16K pages, Linux x86_64
     // uses 4K — sysconf returns the right value either way.
-    static const size_t kHostAllocAlignment =
-        static_cast<size_t>(sysconf(_SC_PAGESIZE));
+    static const size_t kHostAllocAlignment = static_cast<size_t>(sysconf(_SC_PAGESIZE));
     void *p = nullptr;
     if (posix_memalign(&p, kHostAllocAlignment, size) != 0)
         return set_error(HAZE_ERROR_OUT_OF_MEMORY);
@@ -94,8 +92,7 @@ extern "C" hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
         // Plain shadow read. To get post-compute values, the caller
         // must invoke hazeReplay() before this — replay populates the
         // shadow buffer with values from the compiler-side simulator.
-        return set_error(
-            haze::copy_to_host(dst, haze::to_dev_addr(src), count));
+        return set_error(haze::copy_to_host(dst, haze::to_dev_addr(src), count));
     }
 
     if (kind == HAZE_MEMCPY_DEVICE_TO_DEVICE) {

--- a/src/api/stream.cpp
+++ b/src/api/stream.cpp
@@ -10,8 +10,9 @@
 // available the Product; (iii) reverse engineer, disassemble, decompile,
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
-#include "common/errors.hpp"
 #include "core/stream.hpp"
+
+#include "common/errors.hpp"
 
 #include <haze/haze.h>
 #include <haze/haze_types.h>
@@ -25,8 +26,7 @@ extern "C" hazeError_t hazeStreamCreate(hazeStream_t *stream) noexcept {
     return HAZE_SUCCESS;
 }
 
-extern "C" hazeError_t hazeStreamCreateWithPriority(hazeStream_t *stream,
-                                                    unsigned int /*flags*/,
+extern "C" hazeError_t hazeStreamCreateWithPriority(hazeStream_t *stream, unsigned int /*flags*/,
                                                     int /*priority*/) noexcept {
     return hazeStreamCreate(stream);
 }

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -30,13 +30,12 @@
 
 #include "core/backend.hpp"
 
-#include "core/config.hpp"
 #include "common/errors.hpp"
-
-#include <niobium/compiler.h>
+#include "core/config.hpp"
 
 #include <atomic>
 #include <mutex>
+#include <niobium/compiler.h>
 #include <string>
 
 namespace haze {
@@ -86,9 +85,7 @@ bool CompilerBackend::ensure_initialized() noexcept {
         // these strings on the singleton.
         std::string prog_storage = program_name;
         std::string target_arg_storage = "--target=" + target;
-        char* argv[3] = {prog_storage.data(),
-                         target_arg_storage.data(),
-                         nullptr};
+        char *argv[3] = {prog_storage.data(), target_arg_storage.data(), nullptr};
         // argc is 2 — the trailing nullptr is the C-standard argv
         // terminator, not a counted argument.
         int argc = 2;
@@ -108,9 +105,13 @@ bool CompilerBackend::is_initialized() const noexcept {
     return initialized_.load(std::memory_order_acquire);
 }
 
-void CompilerBackend::start_recording() noexcept { niobium::compiler().start(); }
+void CompilerBackend::start_recording() noexcept {
+    niobium::compiler().start();
+}
 
-void CompilerBackend::start_epoch() noexcept { niobium::compiler().start_epoch(); }
+void CompilerBackend::start_epoch() noexcept {
+    niobium::compiler().start_epoch();
+}
 
 bool CompilerBackend::stop_epoch() noexcept {
     // Use the canonical stop() rather than stop_epoch(). stop() writes
@@ -134,8 +135,7 @@ bool CompilerBackend::replay() noexcept {
     try {
         return niobium::compiler().replay();
     } catch (...) {
-        record_internal_error(HazeInternalError::BackendError,
-                              "CompilerBackend::replay");
+        record_internal_error(HazeInternalError::BackendError, "CompilerBackend::replay");
         return false;
     }
 }

--- a/src/core/backend.hpp
+++ b/src/core/backend.hpp
@@ -77,6 +77,8 @@ class CompilerBackend {
     std::mutex init_mutex_;
 };
 
-inline CompilerBackend &backend() noexcept { return CompilerBackend::instance(); }
+inline CompilerBackend &backend() noexcept {
+    return CompilerBackend::instance();
+}
 
 } // namespace haze

--- a/src/core/basis_convert.cpp
+++ b/src/core/basis_convert.cpp
@@ -13,10 +13,10 @@
 
 #include "core/basis_convert.hpp"
 
-#include "core/epoch.hpp"
 #include "common/errors.hpp"
 #include "common/handle.hpp"
 #include "common/thread_safety.hpp"
+#include "core/epoch.hpp"
 
 #include <cstdint>
 #include <expected>

--- a/src/core/compute.hpp
+++ b/src/core/compute.hpp
@@ -12,17 +12,15 @@
 // from the Product.
 #pragma once
 
-#include "core/config.hpp"
-#include "core/epoch.hpp"
 #include "common/errors.hpp"
 #include "common/handle.hpp"
-
-#include <haze/haze_types.h>
-
-#include <niobium/fhetch_api.h>
+#include "core/config.hpp"
+#include "core/epoch.hpp"
 
 #include <cstdint>
 #include <expected>
+#include <haze/haze_types.h>
+#include <niobium/fhetch_api.h>
 
 namespace haze {
 
@@ -60,13 +58,13 @@ hazeError_t binary_ps_op(DevAddr dst, DevAddr src, uint64_t scalar, int mod_idx)
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
         return set_error(to_public_error(p.error()));
-    epoch().store_compute_result_locked(dst, OpFn(*p, niobium::fhetch::Scalar::from_int(scalar), q));
+    epoch().store_compute_result_locked(dst,
+                                        OpFn(*p, niobium::fhetch::Scalar::from_int(scalar), q));
     return HAZE_SUCCESS;
 }
 
 // Polynomial-modulus. Used by hazeNTT, hazeINTT.
-template <auto OpFn>
-hazeError_t unary_pq_op(DevAddr dst, DevAddr src, int mod_idx) noexcept {
+template <auto OpFn> hazeError_t unary_pq_op(DevAddr dst, DevAddr src, int mod_idx) noexcept {
     EpochSession session;
     const uint64_t q = config().modulus(mod_idx);
     if (q == 0)
@@ -79,8 +77,7 @@ hazeError_t unary_pq_op(DevAddr dst, DevAddr src, int mod_idx) noexcept {
 }
 
 // Polynomial-index. Used by hazeAutomorph.
-template <auto OpFn>
-hazeError_t unary_pi_op(DevAddr dst, DevAddr src, uint64_t index) noexcept {
+template <auto OpFn> hazeError_t unary_pi_op(DevAddr dst, DevAddr src, uint64_t index) noexcept {
     EpochSession session;
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -14,10 +14,9 @@
 
 #include "core/allocator.hpp"
 
-#include <haze/haze_types.h>
-
 #include <cstdint>
 #include <cstdlib>
+#include <haze/haze_types.h>
 #include <mutex>
 #include <string>
 #include <vector>

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -12,9 +12,8 @@
 // from the Product.
 #pragma once
 
-#include <haze/haze_types.h>
-
 #include <cstdint>
+#include <haze/haze_types.h>
 #include <mutex>
 #include <string>
 #include <string_view>
@@ -91,6 +90,8 @@ class Config {
     bool target_set_ = false;
 };
 
-inline Config &config() noexcept { return Config::instance(); }
+inline Config &config() noexcept {
+    return Config::instance();
+}
 
 } // namespace haze

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -12,10 +12,9 @@
 // from the Product.
 #include "core/device.hpp"
 
-#include <haze/haze_types.h>
-
 #include <cstddef>
 #include <cstring>
+#include <haze/haze_types.h>
 
 namespace haze {
 
@@ -34,9 +33,13 @@ inline constexpr int kNumSupportedRingDims =
 int g_active_device = 0;
 } // namespace
 
-int device_count() noexcept { return kDeviceCount; }
+int device_count() noexcept {
+    return kDeviceCount;
+}
 
-int device_active() noexcept { return g_active_device; }
+int device_active() noexcept {
+    return g_active_device;
+}
 
 hazeError_t device_set_active(int device) noexcept {
     if (device != 0)
@@ -67,6 +70,8 @@ hazeError_t device_fill_properties(hazeDeviceProp *prop, int device) noexcept {
     return HAZE_SUCCESS;
 }
 
-void device_reset() noexcept { g_active_device = 0; }
+void device_reset() noexcept {
+    g_active_device = 0;
+}
 
 } // namespace haze

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -107,8 +107,8 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
     return poly;
 }
 
-void EpochState::store_compute_result_locked(
-    DevAddr addr, niobium::fhetch::Polynomial poly) noexcept {
+void EpochState::store_compute_result_locked(DevAddr addr,
+                                             niobium::fhetch::Polynomial poly) noexcept {
     poly_map_.insert_or_assign(addr, std::move(poly));
     // Authoritative output registration: every compute store gets a
     // pending output name on first store. Re-stores at the same addr
@@ -118,8 +118,7 @@ void EpochState::store_compute_result_locked(
     // lookup_or_create_locked never reach this path, so they are
     // never tagged as fhetch outputs.
     if (pending_outputs_.find(addr) == pending_outputs_.end()) {
-        pending_outputs_.emplace(addr,
-            "haze_out_" + std::to_string(output_counter_++));
+        pending_outputs_.emplace(addr, "haze_out_" + std::to_string(output_counter_++));
     }
 }
 
@@ -175,16 +174,16 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         fhetch::Polynomial result_poly;
         if (!fhetch::result(name, result_poly)) {
             std::ostringstream body;
-            body << "result('" << name << "') unavailable; shadow at addr 0x"
-                 << std::hex << to_uintptr(addr) << std::dec << " is stale";
+            body << "result('" << name << "') unavailable; shadow at addr 0x" << std::hex
+                 << to_uintptr(addr) << std::dec << " is stale";
             log_error("epoch", body.str());
             continue;
         }
         std::vector<uint64_t> values;
         if (!extract_polynomial_values(result_poly, name, values)) {
             std::ostringstream body;
-            body << "failed to extract values for output '" << name
-                 << "' at addr 0x" << std::hex << to_uintptr(addr) << std::dec;
+            body << "failed to extract values for output '" << name << "' at addr 0x" << std::hex
+                 << to_uintptr(addr) << std::dec;
             log_error("epoch", body.str());
             continue;
         }
@@ -193,7 +192,7 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         allocator().update_shadow(addr, bytes);
     }
 
-    clear_state_locked();   // also clears captured inputs/outputs (E7).
+    clear_state_locked(); // also clears captured inputs/outputs (E7).
     return {};
 }
 

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -72,8 +72,7 @@ class EpochState {
     // After this call returns, hazeMemcpy(D2H) on any bound output
     // address reads the materialized value from the shadow buffer.
     // No-op when not recording.
-    std::expected<void, HazeInternalError> replay_and_populate() noexcept
-        HAZE_EXCLUDES(mutex_);
+    std::expected<void, HazeInternalError> replay_and_populate() noexcept HAZE_EXCLUDES(mutex_);
 
     void reset() noexcept HAZE_EXCLUDES(mutex_);
 
@@ -96,8 +95,7 @@ class EpochState {
     // addr keep their original name (insert-no-overwrite); an
     // intervening invalidate() wipes pending_outputs_, so a fresh store
     // after H2D / memset gets a new name.
-    void store_compute_result_locked(DevAddr addr,
-                                     niobium::fhetch::Polynomial poly) noexcept
+    void store_compute_result_locked(DevAddr addr, niobium::fhetch::Polynomial poly) noexcept
         HAZE_REQUIRES(mutex_);
 
   private:

--- a/src/core/polynomial_io.cpp
+++ b/src/core/polynomial_io.cpp
@@ -12,12 +12,11 @@
 // from the Product.
 #include "core/polynomial_io.hpp"
 
-#include <niobium/fhetch_api.h>
-#include <nlohmann/json.hpp>
-
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <niobium/fhetch_api.h>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/src/core/polynomial_io.hpp
+++ b/src/core/polynomial_io.hpp
@@ -12,9 +12,8 @@
 // from the Product.
 #pragma once
 
-#include <niobium/fhetch_api.h>
-
 #include <cstdint>
+#include <niobium/fhetch_api.h>
 #include <string_view>
 #include <vector>
 

--- a/src/core/stream.cpp
+++ b/src/core/stream.cpp
@@ -57,13 +57,17 @@ hazeEvent_t event_create() noexcept {
         haze_event_s{g_next_event_id.fetch_add(1, std::memory_order_relaxed), false};
 }
 
-void event_destroy(hazeEvent_t e) noexcept { delete e; }
+void event_destroy(hazeEvent_t e) noexcept {
+    delete e;
+}
 
 void event_record(hazeEvent_t e) noexcept {
     if (e != nullptr)
         e->recorded = true;
 }
 
-void events_reset() noexcept { g_next_event_id.store(1, std::memory_order_relaxed); }
+void events_reset() noexcept {
+    g_next_event_id.store(1, std::memory_order_relaxed);
+}
 
 } // namespace haze

--- a/src/core/stream.hpp
+++ b/src/core/stream.hpp
@@ -12,9 +12,8 @@
 // from the Product.
 #pragma once
 
-#include <haze/haze_types.h>
-
 #include <cstdint>
+#include <haze/haze_types.h>
 
 // Opaque-handle struct definitions. These match the forward-declared C
 // handles in haze_types.h. Allocated via raw new/delete at the C ABI
@@ -35,7 +34,7 @@ namespace haze {
 // counters and a default-stream singleton, not enough invariants to
 // justify the wrapper. Default stream id=0 mirrors CUDA stream-0.
 
-hazeStream_t stream_create() noexcept;       // new haze_stream_s, caller owns
+hazeStream_t stream_create() noexcept;        // new haze_stream_s, caller owns
 void stream_destroy(hazeStream_t s) noexcept; // delete unless is_default
 hazeStream_t stream_default() noexcept;       // lazy-init singleton
 void streams_reset() noexcept;

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -19,12 +19,11 @@
 #pragma once
 
 #include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <cstdlib>
 #include <haze/haze.h>
 #include <haze/haze_types.h>
 #include <haze/replay_bridge.h>
-
-#include <cstdint>
-#include <cstdlib>
 
 namespace haze::test {
 
@@ -49,19 +48,17 @@ namespace haze::test {
 // The bridge's post_recording_hook auto-writes the .bin / .ids / .template
 // artifacts during stop(); tests do not need to call WriteTemplate or
 // WriteInputBin explicitly.
-inline uint64_t setup_integration_compute_config(
-    uint64_t ring_dim = 4096,
-    uint64_t desired_modulus = 576460752303415297ULL,
-    int mod_idx = 0) {
+inline uint64_t setup_integration_compute_config(uint64_t ring_dim = 4096,
+                                                 uint64_t desired_modulus = 576460752303415297ULL,
+                                                 int mod_idx = 0) {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
-    if (const char* env_target = std::getenv("HAZE_TARGET");
+    if (const char *env_target = std::getenv("HAZE_TARGET");
         env_target != nullptr && *env_target != '\0') {
         REQUIRE(hazeSetTarget(env_target) == HAZE_SUCCESS);
     }
     uint64_t picked = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, desired_modulus,
-                                              &picked) == HAZE_SUCCESS);
+    REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, desired_modulus, &picked) == HAZE_SUCCESS);
     REQUIRE(picked != 0);
     REQUIRE(hazeSetCiphertextModulus(mod_idx, picked) == HAZE_SUCCESS);
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);

--- a/test/test_basis_convert.cpp
+++ b/test/test_basis_convert.cpp
@@ -86,8 +86,7 @@ TEST_CASE("hazeBasisConvert rejects empty source base", "[unit]") {
 // CryptoContext for multi-modulus traces yet. They run and report assertion
 // failures, but Catch2 does not propagate those as suite failures. Remove the
 // tag from each marked TEST_CASE once the bridge gains MRP support.
-TEST_CASE("hazeModDown rejects foreign modulus in rescale_base",
-          "[integration][!mayfail]") {
+TEST_CASE("hazeModDown rejects foreign modulus in rescale_base", "[integration][!mayfail]") {
     // rescale_base contains a prime not present in src_base. The HAZE
     // layer must reject this BEFORE opening an EpochSession — otherwise
     // the next D2H would replay a dirty recording and crash.
@@ -264,8 +263,7 @@ TEST_CASE("hazeBasisConvert: shared-modulus copies produce input values",
     }
 }
 
-TEST_CASE("hazeBasisConvert: zero input produces zero output",
-          "[integration][!mayfail]") {
+TEST_CASE("hazeBasisConvert: zero input produces zero output", "[integration][!mayfail]") {
     // FBC of zero polynomials is zero on every target modulus, so we
     // can verify the non-trivial dst residues without computing FBC.
     configure_three_moduli();
@@ -312,8 +310,7 @@ TEST_CASE("hazeBasisConvert: zero input produces zero output",
     }
 }
 
-TEST_CASE("hazeBasisConvert: src/dst aliasing is safe (in-place 1->1)",
-          "[integration][!mayfail]") {
+TEST_CASE("hazeBasisConvert: src/dst aliasing is safe (in-place 1->1)", "[integration][!mayfail]") {
     // Aliasing src[i] == dst[j] for any (i,j) is documented as safe in
     // core/basis_convert.cpp because all reads complete before any
     // store. Test the simplest case: same-modulus 1->1 convert with
@@ -345,8 +342,7 @@ TEST_CASE("hazeBasisConvert: src/dst aliasing is safe (in-place 1->1)",
     REQUIRE(hazeFree(p0) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeModDown: zero input rescales to zero output",
-          "[integration][!mayfail]") {
+TEST_CASE("hazeModDown: zero input rescales to zero output", "[integration][!mayfail]") {
     // ApproxModDown is rescale_fbc(x, rescale_base): CRT-divide x by
     // P=prod(rescale_base) with rounding. For x identically zero on
     // every residue, every output is also zero — we can assert exact
@@ -812,8 +808,7 @@ TEST_CASE("hazeBasisConvert: 12-limb fast base convert matches reference",
     free_all(dst_ptrs);
 }
 
-TEST_CASE("hazeModDown: 12-limb rescale matches reference",
-          "[integration][!mayfail]") {
+TEST_CASE("hazeModDown: 12-limb rescale matches reference", "[integration][!mayfail]") {
     configure_sixteen_moduli();
 
     const std::vector<uint64_t> src_base(kBigBase, kBigBase + kSrcLimbs);
@@ -850,8 +845,7 @@ TEST_CASE("hazeModDown: 12-limb rescale matches reference",
     free_all(dst_ptrs);
 }
 
-TEST_CASE("hazeModUp: 12-limb digit-decomp matches reference",
-          "[integration][!mayfail]") {
+TEST_CASE("hazeModUp: 12-limb digit-decomp matches reference", "[integration][!mayfail]") {
     configure_sixteen_moduli();
 
     const std::vector<uint64_t> src_base(kBigBase, kBigBase + kSrcLimbs);

--- a/test/test_build.cpp
+++ b/test/test_build.cpp
@@ -11,11 +11,9 @@
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
 #include <catch2/catch_test_macros.hpp>
-
-#include <haze/haze.h>        // IWYU pragma: keep
-#include <haze/haze_types.h>  // IWYU pragma: keep
-
 #include <cstring>
+#include <haze/haze.h>       // IWYU pragma: keep
+#include <haze/haze_types.h> // IWYU pragma: keep
 #include <string_view>
 #include <thread>
 
@@ -58,11 +56,11 @@ TEST_CASE("hazeGetDeviceCount compiles and links", "[unit]") {
 // error surfaces the missing feature immediately.
 TEST_CASE("graph API returns HAZE_ERROR_NOT_SUPPORTED", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeStreamBeginCapture(nullptr)          == HAZE_ERROR_NOT_SUPPORTED);
+    REQUIRE(hazeStreamBeginCapture(nullptr) == HAZE_ERROR_NOT_SUPPORTED);
     hazeGetLastError();
-    REQUIRE(hazeStreamEndCapture(nullptr, nullptr)   == HAZE_ERROR_NOT_SUPPORTED);
+    REQUIRE(hazeStreamEndCapture(nullptr, nullptr) == HAZE_ERROR_NOT_SUPPORTED);
     hazeGetLastError();
-    REQUIRE(hazeGraphDestroy(nullptr)          == HAZE_ERROR_NOT_SUPPORTED);
+    REQUIRE(hazeGraphDestroy(nullptr) == HAZE_ERROR_NOT_SUPPORTED);
     hazeGetLastError();
 }
 
@@ -79,10 +77,10 @@ TEST_CASE("successful stubs do not pollute error state", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Ensure a sequence of successful calls leaves hazeGetLastError as HAZE_SUCCESS.
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    void* ptr = nullptr;
+    void *ptr = nullptr;
     REQUIRE(hazeMalloc(&ptr, 32768) == HAZE_SUCCESS);
-    REQUIRE(hazeFree(ptr)           == HAZE_SUCCESS);
-    REQUIRE(hazeGetLastError()      == HAZE_SUCCESS);
+    REQUIRE(hazeFree(ptr) == HAZE_SUCCESS);
+    REQUIRE(hazeGetLastError() == HAZE_SUCCESS);
 }
 
 // CUDA exposes a thread-local error state via cudaGetLastError with

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -1,4 +1,6 @@
 // Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+#include "integration_helpers.hpp"
+
 #include <catch2/catch_test_macros.hpp>
 #include <cstddef>
 #include <cstdint>
@@ -6,8 +8,6 @@
 #include <haze/haze.h>
 #include <haze/haze_types.h>
 #include <vector>
-
-#include "integration_helpers.hpp"
 
 static constexpr uint64_t kRingDim = 4096;
 static constexpr size_t kBytes = kRingDim * sizeof(uint64_t);

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -1,12 +1,10 @@
 // Copyright (C) 2026, All rights reserved by Niobium Microsystems.
-#include <catch2/catch_test_macros.hpp>
-
-#include <haze/haze.h>        // IWYU pragma: keep
-#include <haze/haze_types.h>  // IWYU pragma: keep
-
 #include <algorithm>
+#include <catch2/catch_test_macros.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <haze/haze.h>       // IWYU pragma: keep
+#include <haze/haze_types.h> // IWYU pragma: keep
 #include <vector>
 
 // HAZE's device allocator is single-size: every allocation is one
@@ -17,7 +15,7 @@
 TEST_CASE("hazeMalloc returns non-null pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    void* p = nullptr;
+    void *p = nullptr;
     REQUIRE(hazeMalloc(&p, 32768) == HAZE_SUCCESS);
     REQUIRE(p != nullptr);
     REQUIRE(hazeFree(p) == HAZE_SUCCESS);
@@ -31,7 +29,7 @@ TEST_CASE("hazeMalloc null ptr arg returns error", "[unit]") {
 
 TEST_CASE("hazeMalloc before hazeSetRingDimension is rejected", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS); // ensure ring_dim cleared
-    void* p = nullptr;
+    void *p = nullptr;
     REQUIRE(hazeMalloc(&p, 32768) == HAZE_ERROR_CONFIGERR);
     hazeGetLastError();
 }
@@ -39,7 +37,7 @@ TEST_CASE("hazeMalloc before hazeSetRingDimension is rejected", "[unit]") {
 TEST_CASE("hazeMalloc with size != polynomial bytes is rejected", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    void* p = nullptr;
+    void *p = nullptr;
     // ring_dim=4096 → polynomial bytes = 32768; 8KB request fails.
     REQUIRE(hazeMalloc(&p, 8192) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
@@ -48,8 +46,8 @@ TEST_CASE("hazeMalloc with size != polynomial bytes is rejected", "[unit]") {
 TEST_CASE("distinct allocations produce non-overlapping addresses", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    void* p1 = nullptr;
-    void* p2 = nullptr;
+    void *p1 = nullptr;
+    void *p2 = nullptr;
     REQUIRE(hazeMalloc(&p1, 32768) == HAZE_SUCCESS);
     REQUIRE(hazeMalloc(&p2, 32768) == HAZE_SUCCESS);
     REQUIRE(p1 != p2);
@@ -61,11 +59,11 @@ TEST_CASE("free then re-allocate recycles pooled address", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
 
-    void* p1 = nullptr;
+    void *p1 = nullptr;
     REQUIRE(hazeMalloc(&p1, 32768) == HAZE_SUCCESS);
     REQUIRE(hazeFree(p1) == HAZE_SUCCESS);
 
-    void* p2 = nullptr;
+    void *p2 = nullptr;
     REQUIRE(hazeMalloc(&p2, 32768) == HAZE_SUCCESS);
     REQUIRE(p1 == p2);
     REQUIRE(hazeFree(p2) == HAZE_SUCCESS);
@@ -77,18 +75,17 @@ TEST_CASE("H2D then D2H round-trip preserves data", "[unit]") {
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(kN) == HAZE_SUCCESS);
-    void* dev = nullptr;
+    void *dev = nullptr;
     REQUIRE(hazeMalloc(&dev, kBytes) == HAZE_SUCCESS);
 
     std::vector<uint64_t> src(kN);
-    for (size_t i = 0; i < kN; ++i) src[i] = static_cast<uint64_t>(i + 1);
+    for (size_t i = 0; i < kN; ++i)
+        src[i] = static_cast<uint64_t>(i + 1);
 
-    REQUIRE(hazeMemcpy(dev, src.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE)
-            == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(dev, src.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
 
     std::vector<uint64_t> dst(kN, 0);
-    REQUIRE(hazeMemcpy(dst.data(), dev, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST)
-            == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(dst.data(), dev, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     REQUIRE(dst == src);
     REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
@@ -98,22 +95,21 @@ TEST_CASE("D2D memcpy copies shadow buffer", "[unit]") {
     constexpr size_t kBytes = 32768;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    void* src_dev = nullptr;
-    void* dst_dev = nullptr;
+    void *src_dev = nullptr;
+    void *dst_dev = nullptr;
     REQUIRE(hazeMalloc(&src_dev, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeMalloc(&dst_dev, kBytes) == HAZE_SUCCESS);
 
     std::vector<uint8_t> pattern(kBytes);
-    for (size_t i = 0; i < kBytes; ++i) pattern[i] = static_cast<uint8_t>(i & 0xFF);
+    for (size_t i = 0; i < kBytes; ++i)
+        pattern[i] = static_cast<uint8_t>(i & 0xFF);
 
-    REQUIRE(hazeMemcpy(src_dev, pattern.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE)
-            == HAZE_SUCCESS);
-    REQUIRE(hazeMemcpy(dst_dev, src_dev, kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE)
-            == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(src_dev, pattern.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
+            HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(dst_dev, src_dev, kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE) == HAZE_SUCCESS);
 
     std::vector<uint8_t> result(kBytes, 0);
-    REQUIRE(hazeMemcpy(result.data(), dst_dev, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST)
-            == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(result.data(), dst_dev, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
     REQUIRE(result == pattern);
     REQUIRE(hazeFree(src_dev) == HAZE_SUCCESS);
@@ -124,22 +120,20 @@ TEST_CASE("hazeMemset fills shadow buffer", "[unit]") {
     constexpr size_t kBytes = 32768;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    void* dev = nullptr;
+    void *dev = nullptr;
     REQUIRE(hazeMalloc(&dev, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeMemset(dev, 0xAB, kBytes) == HAZE_SUCCESS);
 
     std::vector<uint8_t> result(kBytes, 0);
-    REQUIRE(hazeMemcpy(result.data(), dev, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST)
-            == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(result.data(), dev, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
 
-    REQUIRE(std::all_of(result.begin(), result.end(),
-                        [](uint8_t b) { return b == 0xAB; }));
+    REQUIRE(std::all_of(result.begin(), result.end(), [](uint8_t b) { return b == 0xAB; }));
     REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
 }
 
 TEST_CASE("hazeHostAlloc/Free round-trip", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    void* p = nullptr;
+    void *p = nullptr;
     REQUIRE(hazeHostAlloc(&p, 4096, 0) == HAZE_SUCCESS);
     REQUIRE(p != nullptr);
     hazeFreeHost(p);
@@ -151,7 +145,7 @@ TEST_CASE("hazeMallocAsync/FreeAsync behave like sync versions", "[unit]") {
     hazeStream_t stream = nullptr;
     REQUIRE(hazeStreamCreate(&stream) == HAZE_SUCCESS);
 
-    void* p = nullptr;
+    void *p = nullptr;
     REQUIRE(hazeMallocAsync(&p, 32768, stream) == HAZE_SUCCESS);
     REQUIRE(p != nullptr);
     REQUIRE(hazeFreeAsync(p, stream) == HAZE_SUCCESS);
@@ -206,7 +200,10 @@ TEST_CASE("hazeGetDeviceProperties returns FPGA values", "[unit]") {
     // N=4096 corresponds to exponent 12
     bool found_12 = false;
     for (int i = 0; i < prop.numSupportedRingDims; ++i) {
-        if (prop.supportedRingDimExponents[i] == 12) { found_12 = true; break; }
+        if (prop.supportedRingDimExponents[i] == 12) {
+            found_12 = true;
+            break;
+        }
     }
     REQUIRE(found_12);
 }
@@ -231,7 +228,7 @@ TEST_CASE("NULL stream argument uses default stream", "[unit]") {
 TEST_CASE("hazePointerGetAttributes reports device type for hazeMalloc'd pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    void* dev = nullptr;
+    void *dev = nullptr;
     REQUIRE(hazeMalloc(&dev, 32768) == HAZE_SUCCESS);
 
     hazePointerAttributes attrs{};
@@ -253,7 +250,7 @@ TEST_CASE("hazePointerGetAttributes reports unregistered for foreign pointers", 
 
 TEST_CASE("hazePointerGetAttributes reports host type for hazeHostAlloc'd pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    void* p = nullptr;
+    void *p = nullptr;
     REQUIRE(hazeHostAlloc(&p, 4096, 0) == HAZE_SUCCESS);
     hazePointerAttributes attrs{};
     REQUIRE(hazePointerGetAttributes(&attrs, p) == HAZE_SUCCESS);
@@ -267,4 +264,3 @@ TEST_CASE("hazePointerGetAttributes rejects null attrs out-pointer", "[unit]") {
     REQUIRE(hazePointerGetAttributes(nullptr, &stack_local) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 }
-

--- a/test/test_ring_dim_consistency.cpp
+++ b/test/test_ring_dim_consistency.cpp
@@ -25,22 +25,20 @@
 // They serve as positive regression coverage; they will not catch the
 // niobium-side leak that remains under investigation.
 
+#include "integration_helpers.hpp"
+
 #include <catch2/catch_test_macros.hpp>
-
-#include <haze/haze.h>        // IWYU pragma: keep
-#include <haze/haze_types.h>  // IWYU pragma: keep
-
 #include <cstddef>
 #include <cstdint>
+#include <haze/haze.h>       // IWYU pragma: keep
+#include <haze/haze_types.h> // IWYU pragma: keep
 #include <vector>
-
-#include "integration_helpers.hpp"
 
 namespace {
 
-constexpr uint64_t kQ = 576460752303415297ULL;       // standard CKKS test prime
+constexpr uint64_t kQ = 576460752303415297ULL; // standard CKKS test prime
 constexpr uint64_t kN = 4096;
-constexpr size_t   kBytes = kN * sizeof(uint64_t);
+constexpr size_t kBytes = kN * sizeof(uint64_t);
 
 // Setup with the canonical test ring dim. Resets HAZE state first so
 // each test sees a clean Config / EpochState / DeviceAllocator. The
@@ -91,7 +89,8 @@ TEST_CASE("ring_dim consistency: H2D->Add->D2H round-trip at N=4096", "[integrat
 
     std::vector<uint64_t> out(kN, 0);
     d2h(out, d_dst);
-    for (uint64_t i = 0; i < kN; ++i) REQUIRE(out[i] == 18);
+    for (uint64_t i = 0; i < kN; ++i)
+        REQUIRE(out[i] == 18);
 
     REQUIRE(hazeFree(d_a) == HAZE_SUCCESS);
     REQUIRE(hazeFree(d_b) == HAZE_SUCCESS);
@@ -104,7 +103,8 @@ TEST_CASE("ring_dim consistency: H2D->Add->D2H round-trip at N=4096", "[integrat
 // operation reuses the first op's output (compute_results_ entry)
 // as input. If poly_map_ ever served a Polynomial with a stale
 // ring_dim, this is the path that would expose it.
-TEST_CASE("ring_dim consistency: chained ops within one epoch reuse poly_map_ entries", "[integration]") {
+TEST_CASE("ring_dim consistency: chained ops within one epoch reuse poly_map_ entries",
+          "[integration]") {
     setup_4096();
 
     void *d_a = nullptr, *d_b = nullptr, *d_c = nullptr, *d_t = nullptr;
@@ -127,7 +127,8 @@ TEST_CASE("ring_dim consistency: chained ops within one epoch reuse poly_map_ en
 
     std::vector<uint64_t> out(kN, 0);
     d2h(out, d_t);
-    for (uint64_t i = 0; i < kN; ++i) REQUIRE(out[i] == 6);
+    for (uint64_t i = 0; i < kN; ++i)
+        REQUIRE(out[i] == 6);
 
     REQUIRE(hazeFree(d_a) == HAZE_SUCCESS);
     REQUIRE(hazeFree(d_b) == HAZE_SUCCESS);
@@ -174,7 +175,8 @@ TEST_CASE("ring_dim consistency: 50 reset/configure/compute cycles", "[integrati
 // SUCCESS. A "shared modulus identity convert" (src_base == dst_base,
 // single residue) is the simplest non-trivial case: dst should
 // equal src byte-for-byte.
-TEST_CASE("ring_dim consistency: hazeBasisConvert preserves data on identity convert", "[integration]") {
+TEST_CASE("ring_dim consistency: hazeBasisConvert preserves data on identity convert",
+          "[integration]") {
     setup_4096();
 
     void *src = nullptr, *dst = nullptr;
@@ -182,7 +184,8 @@ TEST_CASE("ring_dim consistency: hazeBasisConvert preserves data on identity con
     REQUIRE(hazeMalloc(&dst, kBytes) == HAZE_SUCCESS);
 
     std::vector<uint64_t> src_data(kN);
-    for (uint64_t i = 0; i < kN; ++i) src_data[i] = (i * 7919 + 13) % kQ;
+    for (uint64_t i = 0; i < kN; ++i)
+        src_data[i] = (i * 7919 + 13) % kQ;
     h2d(src, src_data);
 
     const uint64_t base[] = {kQ};
@@ -227,12 +230,13 @@ TEST_CASE("ring_dim consistency: hazeDeviceReset between two epochs at same N", 
         REQUIRE(hazeAddScalar(d_dst, d_a, 2, 0, nullptr) == HAZE_SUCCESS);
         std::vector<uint64_t> out(kN, 0);
         d2h(out, d_dst);
-        for (uint64_t i = 0; i < kN; ++i) REQUIRE(out[i] == 7);
+        for (uint64_t i = 0; i < kN; ++i)
+            REQUIRE(out[i] == 7);
         REQUIRE(hazeFree(d_a) == HAZE_SUCCESS);
         REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
     }
 
-    setup_4096();  // reset + reconfigure at the same N
+    setup_4096(); // reset + reconfigure at the same N
     {
         void *d_a = nullptr, *d_dst = nullptr;
         REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
@@ -242,7 +246,8 @@ TEST_CASE("ring_dim consistency: hazeDeviceReset between two epochs at same N", 
         REQUIRE(hazeAddScalar(d_dst, d_a, 4, 0, nullptr) == HAZE_SUCCESS);
         std::vector<uint64_t> out(kN, 0);
         d2h(out, d_dst);
-        for (uint64_t i = 0; i < kN; ++i) REQUIRE(out[i] == 13);
+        for (uint64_t i = 0; i < kN; ++i)
+            REQUIRE(out[i] == 13);
         REQUIRE(hazeFree(d_a) == HAZE_SUCCESS);
         REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
     }


### PR DESCRIPTION
## Summary

- Run `clang-format -i` (in-tree `.clang-format`: LLVM, indent 4, column 100) over every haze C/C++ source file under `src/`, `include/`, `replay_bridge/`, `test/`.
- 31 files reformatted, 383 insertions / 405 deletions. No semantic changes. `vendor/` is excluded.
- This lands on `main` first so subsequent feature PRs (notably the replay-API removal at `remove-replay-api`) diff cleanly against an already-formatted base, instead of mixing semantic edits with reflow noise.

## Test plan

- [x] `make build` — clean compile under `nix develop`.
- [x] `make test` (unit + sim) — 18 passed, 9 `[!mayfail]` failed as expected, exit 0.
- [ ] `make test-transport NIOBIUM_COMPILER_ROOT=...` — same green criterion. (Not run in CI; local-only.)
- [ ] Reviewer spot-checks: every diff hunk is whitespace / line-break / argument-reflow only.