### PR TITLE
Add hermetic nix flake build path + flake-check CI

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,10 +1,12 @@
 # clangd configuration. See https://clangd.llvm.org/config.
 
 CompileFlags:
-  # Match the project's C++20 standard. CMake propagates -std=c++20 in
-  # compile_commands.json for source files, but headers picked up via
-  # background indexing benefit from an explicit fallback.
-  Add: [-std=c++20]
+  # Match the project's C++23 standard (CMakeLists.txt sets
+  # CMAKE_CXX_STANDARD 23). compile_commands.json already carries
+  # -std=c++23 for source files; this fallback covers headers indexed
+  # without a database entry, and overrides any earlier -std= so
+  # std::expected and other C++23 features resolve under clangd.
+  Add: [-std=c++23]
   CompilationDatabase: build
 
 Diagnostics:

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -68,14 +68,20 @@ jobs:
           echo "rev=$rev" >> "$GITHUB_OUTPUT"
 
       - name: Cache OpenFHE install dir
+        # The build/ directory caches CMake state, including absolute
+        # paths to compilers in /nix/store. Bumping flake.lock changes
+        # those store paths, which would leave CMakeCache.txt pointing
+        # at non-existent compiler binaries on a fresh runner. Hashing
+        # flake.lock into the key invalidates the cache whenever the
+        # nix toolchain moves.
         uses: actions/cache@v5
         with:
           path: |
             vendor/niobium-fhetch/vendor/lib/openfhe
             vendor/niobium-fhetch/vendor/openfhe/build
-          key: ubuntu-latest-openfhe-haze-${{ steps.openfhe_rev.outputs.rev }}
+          key: ubuntu-latest-openfhe-haze-${{ hashFiles('flake.lock') }}-${{ steps.openfhe_rev.outputs.rev }}
           restore-keys: |
-            ubuntu-latest-openfhe-haze-
+            ubuntu-latest-openfhe-haze-${{ hashFiles('flake.lock') }}-
 
       - name: Rewrite niobium-fhetch submodule URL for token auth
         # nix issue #13324: with `inputs.self.submodules = true` in

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,6 +77,17 @@ jobs:
           restore-keys: |
             ubuntu-latest-openfhe-haze-
 
+      - name: Mark worktree dirty for nix submodule ingestion
+        # nix issue #13324: with `inputs.self.submodules = true` in
+        # flake.nix and a clean parent worktree, nix re-fetches
+        # submodules from their remotes during flake source
+        # ingestion. The sandbox does not see actions/checkout's App
+        # token, so the private niobium-fhetch SSH remote fails.
+        # Touching an untracked file marks the worktree dirty, which
+        # makes nix copy submodules from the local checkout instead.
+        # Same trick used in flake-check.yml.
+        run: touch .ci-dirty
+
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -77,16 +77,20 @@ jobs:
           restore-keys: |
             ubuntu-latest-openfhe-haze-
 
-      - name: Mark worktree dirty for nix submodule ingestion
+      - name: Rewrite niobium-fhetch submodule URL for token auth
         # nix issue #13324: with `inputs.self.submodules = true` in
-        # flake.nix and a clean parent worktree, nix re-fetches
-        # submodules from their remotes during flake source
-        # ingestion. The sandbox does not see actions/checkout's App
-        # token, so the private niobium-fhetch SSH remote fails.
-        # Touching an untracked file marks the worktree dirty, which
-        # makes nix copy submodules from the local checkout instead.
-        # Same trick used in flake-check.yml.
-        run: touch .ci-dirty
+        # flake.nix, nix's flake source ingestion re-fetches the
+        # submodule from its declared URL. .gitmodules registers it
+        # via SSH and the runner has no SSH key. actions/checkout's
+        # transient HTTPS rewrite does not carry into nix's git
+        # fetcher. Rewriting .gitmodules + .git/config to HTTPS with
+        # the App token covers nix. Same step in flake-check.yml.
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config -f .gitmodules submodule.vendor/niobium-fhetch.url \
+            "https://x-access-token:${APP_TOKEN}@github.com/NiobiumInc/niobium-fhetch.git"
+          git submodule sync vendor/niobium-fhetch
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -1,0 +1,106 @@
+name: flake-check
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: flake-check-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  flake-check:
+    name: nix flake check
+    runs-on: ubuntu-latest
+    # Skip on fork PRs: the org App token is not available, so the
+    # private niobium-fhetch submodule cannot be cloned. Mirrors
+    # build-test.yml.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      # App-token pattern matches build-test.yml so same-repo PRs can
+      # read the private niobium-fhetch submodule. Fork PRs are
+      # skipped via the job-level `if:` above.
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout (with private niobium-fhetch submodule)
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Free disk space
+        # nix store with openfhe + niobium-fhetch + haze easily blows
+        # past ubuntu-latest's ~14 GB of free space. Reclaim ~25 GB up
+        # front, same recipe as build-test.yml.
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo apt-get clean
+          df -h
+
+      - name: Verify nested submodules cloned
+        run: |
+          test -f vendor/niobium-fhetch/vendor/openfhe/CMakeLists.txt
+          test -d vendor/niobium-fhetch/vendor/json
+
+      - name: Mark worktree dirty for nix submodule ingestion
+        # nix issue #13324: with `inputs.self.submodules = true` and a
+        # clean parent worktree, nix re-fetches submodules from their
+        # remotes during flake source ingestion. The sandbox does not
+        # see actions/checkout's App token, so the private
+        # niobium-fhetch remote fails. Touching an untracked file
+        # marks the worktree dirty, which makes nix copy submodules
+        # from the local checkout instead.
+        run: touch .ci-dirty
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Magic Nix Cache
+        # Free, zero-config /nix/store cache backed by GitHub Actions
+        # cache. Covers openfhe (~20-30 min cold), niobium-fhetch, and
+        # haze across runs. Documented combo is nix-installer-action
+        # then magic-nix-cache-action.
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+
+      - name: nix flake check
+        # -L (= --print-build-logs) streams every derivation's build
+        # log to the workflow output, so test failures and OpenFHE
+        # build errors are visible inline. --keep-going lets every
+        # check run before the job fails, matching local behaviour.
+        run: nix flake check -L --keep-going
+
+      - name: Collect nix build logs on failure
+        if: failure()
+        # /nix/var/log/nix/drvs/ is where nix persists per-derivation
+        # build logs; tarballing it gives the failed derivation's full
+        # log even if the streamed -L output was truncated.
+        run: |
+          sudo tar -czf nix-drv-logs.tgz -C / nix/var/log/nix/drvs 2>/dev/null || true
+          ls -la nix-drv-logs.tgz || true
+
+      - name: Upload artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: flake-check-logs-${{ github.run_attempt }}
+          path: nix-drv-logs.tgz
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -60,15 +60,22 @@ jobs:
           test -f vendor/niobium-fhetch/vendor/openfhe/CMakeLists.txt
           test -d vendor/niobium-fhetch/vendor/json
 
-      - name: Mark worktree dirty for nix submodule ingestion
-        # nix issue #13324: with `inputs.self.submodules = true` and a
-        # clean parent worktree, nix re-fetches submodules from their
-        # remotes during flake source ingestion. The sandbox does not
-        # see actions/checkout's App token, so the private
-        # niobium-fhetch remote fails. Touching an untracked file
-        # marks the worktree dirty, which makes nix copy submodules
-        # from the local checkout instead.
-        run: touch .ci-dirty
+      - name: Rewrite niobium-fhetch submodule URL for token auth
+        # nix issue #13324: with `inputs.self.submodules = true`, nix's
+        # flake source ingestion re-fetches submodules from their
+        # declared URLs. .gitmodules registers niobium-fhetch via SSH,
+        # and the runner has no SSH key. actions/checkout cloned the
+        # submodule via a transient HTTPS rewrite that is NOT carried
+        # over to nix's separate git fetcher. Rewriting the URL to
+        # HTTPS-with-App-token in .gitmodules + .git/config covers nix.
+        # The .gitmodules edit also marks the parent worktree dirty
+        # (modified tracked file), nudging nix toward the local copy.
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config -f .gitmodules submodule.vendor/niobium-fhetch.url \
+            "https://x-access-token:${APP_TOKEN}@github.com/NiobiumInc/niobium-fhetch.git"
+          git submodule sync vendor/niobium-fhetch
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ out/
 _build/
 dbuild/
 
+# direnv (.envrc itself is tracked; the cache it materialises is not)
+.direnv/
+
 # CMake artefacts beyond the upstream template
 CPackConfig.cmake
 CPackSourceConfig.cmake

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,40 @@
+{
+  "load_direnv": "direct",
+  "lsp": {
+    "clangd": {
+      "binary": {
+        "path": "direnv",
+        "arguments": [
+          "exec",
+          ".",
+          "scripts/zed-clangd.sh",
+          "--background-index",
+          "--clang-tidy",
+          "--header-insertion=never",
+          "--completion-style=detailed",
+          "--pch-storage=memory",
+          "--compile-commands-dir=build"
+        ]
+      }
+    }
+  },
+  "languages": {
+    "C++": {
+      "language_servers": ["clangd"],
+      "format_on_save": "on",
+      "formatter": "language_server",
+      "tab_size": 4,
+      "preferred_line_length": 100
+    },
+    "C": {
+      "language_servers": ["clangd"],
+      "format_on_save": "on",
+      "formatter": "language_server",
+      "tab_size": 4,
+      "preferred_line_length": 100
+    }
+  },
+  "file_types": {
+    "C++": ["hpp", "cpp", "h", "ipp", "tpp"]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,10 @@ entry point.
 
 Required to build, test, and lint:
 
-- A C++23 compiler. Clang 19 is what the project tests against;
-  `-Wthread-safety` (the canonical enforcement path for the lock contracts in
-  `src/common/thread_safety.hpp`) only fires under clang.
+- A C++23 compiler. Clang (the version nixpkgs-unstable currently ships) is
+  what CI tests against; `-Wthread-safety` (the canonical enforcement path for
+  the lock contracts in `src/common/thread_safety.hpp`) only fires under clang.
+  Clang 19 is the supported floor.
 - CMake >= 3.22.
 - Catch2 v3 (`Catch2::Catch2WithMain`), discovered via `find_package`.
 - For lint/format: clang-format, clang-tidy, clangd (any version that
@@ -39,7 +40,7 @@ the project tests against.
 ### Preferred path: nix flake
 
 If `nix` is installed, use it. The flake provides a hermetic devshell
-with everything pinned (clang 19, cmake, clang-tools, catch2_3, jujutsu)
+with everything pinned (clang, cmake, clang-tools, catch2_3, jujutsu)
 plus `MACOSX_DEPLOYMENT_TARGET=14.0` and a nix-pinned `SDKROOT`:
 
 ```sh
@@ -66,7 +67,9 @@ brew link --force --overwrite llvm
 export CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++
 ```
 
-Linux (Debian/Ubuntu):
+Linux (Debian/Ubuntu) — clang-19 is the minimum the project supports; pick a
+newer apt package (`clang-20`, `clang-21`, ...) where available to match what
+nix-based CI tests with:
 
 ```sh
 sudo apt install clang-19 cmake catch2 clang-format clang-tidy clangd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,21 +4,34 @@ project(haze LANGUAGES C CXX VERSION 0.1.0)
 # ---------------------------------------------------------------------------
 # niobium-fhetch resolution
 # ---------------------------------------------------------------------------
-# Two-tier lookup:
-#   1. If NIOBIUM_HAZE_FHETCH_DIR is set, add_subdirectory() that external
-#      source tree. Parents (e.g. niobium-client) that already own a
-#      niobium-fhetch checkout point haze at it via this cache var.
-#   2. Else, fall back to vendor/niobium-fhetch — haze's own submodule.
-#      Used for standalone builds (run `make sync` from this directory
-#      to populate it).
-#
-# OPENFHE_INSTALL_DIR is honored by niobium-fhetch's own CMakeLists when
-# we add it via either path, so injecting it here covers transitive
-# OpenFHE discovery for both branches.
+# Three-tier lookup, tried in order:
+#   1. HAZE_USE_PREBUILT_FHETCH=ON  → find_package(NiobiumFhetch CONFIG).
+#      Used by nix flake builds where fhetch is its own derivation.
+#   2. NIOBIUM_HAZE_FHETCH_DIR set  → add_subdirectory(<that source tree>).
+#      Used by parents (e.g. niobium-client) with their own checkout.
+#   3. vendor/niobium-fhetch exists → add_subdirectory(vendor/niobium-fhetch).
+#      Used by standalone Makefile builds.
+
+option(HAZE_USE_PREBUILT_FHETCH
+  "Use find_package(NiobiumFhetch CONFIG) instead of an in-tree add_subdirectory build. OFF (default) matches the Makefile flow; ON is for nix flake builds."
+  OFF)
 
 set(NIOBIUM_HAZE_FHETCH_DIR "" CACHE PATH
-    "External niobium-fhetch source tree to use instead of haze's vendor/niobium-fhetch (empty = use the vendored submodule)")
-if(NIOBIUM_HAZE_FHETCH_DIR)
+    "External niobium-fhetch source tree (empty = use vendor/niobium-fhetch)")
+
+if(HAZE_USE_PREBUILT_FHETCH)
+  find_package(NiobiumFhetch CONFIG REQUIRED)
+  # TODO(niobium-fhetch): export Niobium::fhetch directly. fhetch's
+  # install(EXPORT) names its target after the library
+  # (Niobium::niobium_fhetch); the Niobium::fhetch alias only exists
+  # in-tree. Wrap it here so the rest of haze can link Niobium::fhetch
+  # uniformly across branches. GLOBAL is required so the wrapper is
+  # visible from add_subdirectory(replay_bridge).
+  if(NOT TARGET Niobium::fhetch)
+    add_library(Niobium::fhetch INTERFACE IMPORTED GLOBAL)
+    target_link_libraries(Niobium::fhetch INTERFACE Niobium::niobium_fhetch)
+  endif()
+elseif(NIOBIUM_HAZE_FHETCH_DIR)
   add_subdirectory(${NIOBIUM_HAZE_FHETCH_DIR}
                    ${CMAKE_BINARY_DIR}/_deps/niobium-fhetch-build)
 elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/niobium-fhetch/CMakeLists.txt)
@@ -26,32 +39,38 @@ elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/niobium-fhetch/CMakeLists.txt)
 else()
   message(FATAL_ERROR
     "haze cannot find niobium-fhetch. Either pass "
+    "-DHAZE_USE_PREBUILT_FHETCH=ON (with NiobiumFhetch on CMAKE_PREFIX_PATH), "
     "-DNIOBIUM_HAZE_FHETCH_DIR=<path/to/niobium-fhetch>, or run "
     "`make sync` from this directory to init vendor/niobium-fhetch.")
 endif()
 
-# OPENFHE_INSTALL_DIR may be set by:
-#   - the parent build (niobium-client passes it explicitly)
-#   - haze's own Makefile (standalone build)
-#   - the user via -D
-# When unset, niobium-fhetch's CMakeLists defaults to its own
-# vendor/lib/openfhe install. The test executable below also reads it
-# for the OpenFHE BigInteger reference oracle.
+# Required in every branch: the in-tree fhetch CMakeLists reads it for
+# OpenFHE discovery, and the test oracle (test_basis_convert.cpp)
+# reads it for the libOPENFHEcore BigInteger reference link.
 if(NOT DEFINED OPENFHE_INSTALL_DIR)
   message(FATAL_ERROR
     "OPENFHE_INSTALL_DIR is not set. Pass -DOPENFHE_INSTALL_DIR=<path> or "
     "use haze's Makefile, which derives it from niobium-fhetch's install tree.")
 endif()
 
-# OPENFHE_LIBRARY_PATH locates libOPENFHEcore for the haze_tests reference
-# oracle (test_basis_convert.cpp). Most callers already supply it:
-#   - niobium-client sets it at the parent CMake level, pointing at
-#     OpenFHE's *build* output dir to dodge an extra install copy.
-#   - niobium-fhetch's CMakeLists sets it to ${OPENFHE_INSTALL_DIR}/lib
-#     when haze pulls fhetch in via add_subdirectory.
-# This fallback only fires when haze is built against an externally-resolved
-# Niobium::fhetch target whose enclosing project did not also provide
-# OPENFHE_LIBRARY_PATH (a partial-parent scenario).
+# TODO(niobium-fhetch): expose OpenFHE includes via $<INSTALL_INTERFACE>
+# so they propagate through find_package. Today they're
+# $<BUILD_INTERFACE> only and don't survive the install-tree handoff,
+# so re-attach them here. No-op in the add_subdirectory branches.
+if(HAZE_USE_PREBUILT_FHETCH)
+  set_property(TARGET Niobium::fhetch APPEND PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES
+      "${OPENFHE_INSTALL_DIR}/include/openfhe"
+      "${OPENFHE_INSTALL_DIR}/include/openfhe/core"
+      "${OPENFHE_INSTALL_DIR}/include/openfhe/pke"
+      "${OPENFHE_INSTALL_DIR}/include/openfhe/binfhe"
+  )
+endif()
+
+# OPENFHE_LIBRARY_PATH is used by haze_tests's libOPENFHEcore reference
+# oracle (test_basis_convert.cpp). Parents (e.g. niobium-client) may
+# set it explicitly to point at OpenFHE's build dir; otherwise default
+# to the install layout.
 if(NOT DEFINED OPENFHE_LIBRARY_PATH)
   set(OPENFHE_LIBRARY_PATH "${OPENFHE_INSTALL_DIR}/lib")
 endif()

--- a/README.md
+++ b/README.md
@@ -284,32 +284,67 @@ Path differences vs the standalone build:
 | `haze_tests`  | `build/vendor/niobium-haze/haze_tests` | `build/haze_tests` |
 | Test runs dir | `build/vendor/niobium-haze/runs/`      | `build/runs/`      |
 
-### With the nix flake
+### With the nix flake (optional)
 
-`nix develop` enters `devShells.default` (`haze-dev`). The shell provides
-clang 19, cmake, clang-tools (clang-format / clang-tidy / clangd), Catch2 3.x,
-and jujutsu, with `MACOSX_DEPLOYMENT_TARGET=14.0` and a pinned `SDKROOT`. The
-`shellHook` wires `CMAKE_PREFIX_PATH` and `LD_LIBRARY_PATH` for the
-niobium-compiler / OpenFHE artefacts under `vendor/niobium-compiler` (when
-present).
+The standalone Makefile flow above is the **first-class** path; the flake is
+an opt-in convenience for contributors who already use nix. It provides three
+distinct surfaces.
 
-Inside the shell, the same Make targets work:
+#### 1. Dev shell — fastest iteration
 
 ```sh
-EXTERNAL_OPENFHE=1 make build MODE=release
+nix develop                                    # interactive
+nix develop --command make build               # one-shot
 ```
 
-To run a one-shot build without entering the shell interactively:
+The shell provisions the toolchain (clang 19 as `cc`/`c++`, cmake, Catch2 3,
+clang-tools, jujutsu, nixfmt) but otherwise stays out of the way. From there
+the Makefile flow above (`make build`, `make test`, etc.) works unchanged.
+This is the recommended path for editing haze sources — every iteration uses
+the live worktree without round-tripping through `/nix/store`.
+
+#### 2. `nix run` apps — make targets without entering the shell
 
 ```sh
-nix develop --command bash -c 'EXTERNAL_OPENFHE=1 make build MODE=release'
+nix run .#test-unit                # = nix develop --command make test-unit
+nix run .#test-sim                 # = nix develop --command make test-sim
+nix run .#test                     # = ... make test
+nix run .#build                    # = ... make build
 ```
 
-Heads-up on macOS: if OpenFHE was previously built outside `nix develop`
-against the host SDK and haze is built inside the shell, the two libc++ ABIs
-collide and tests segfault non-deterministically. See [`CLAUDE.md`](CLAUDE.md)
--> "SDK / ABI mismatch trap on macOS" for the rebuild recipe and verification
-steps.
+Each app re-enters the dev shell so cmake's setup hooks fire, then invokes
+the Makefile target against the caller's CWD (which must be a haze worktree).
+
+#### 3. Hermetic packages — cached, reproducible, slow first time
+
+```sh
+nix build .#openfhe                # ~20-30 min cold; cached in /nix/store
+nix build .#niobium-fhetch         # depends on openfhe; reuses cache
+nix build .#haze                   # = .#default; libhaze + haze_tests
+nix flake check                    # devshell + fmt + haze build + tests
+```
+
+Each layer caches independently. OpenFHE only rebuilds when its submodule
+pointer moves; haze edits only invalidate the haze derivation. After
+`nix build .#haze`, the result is at `result/{lib,bin,include}/...`.
+
+The `nix flake check` `unit-tests` and `sim-tests` derivations run `haze_tests`
+hermetically — no live worktree required, suitable for CI.
+
+#### Notes
+
+- `inputs.self.submodules = true` makes the flake source submodule-aware. With
+  a clean haze worktree, nix re-fetches submodules from their remotes (needs
+  SSH auth for the private niobium-fhetch); keep a dirty file in the worktree
+  to force the local checkout instead.
+- The hermetic packages live entirely in `/nix/store`. The macOS SDK / ABI
+  mismatch trap (see [`CLAUDE.md`](CLAUDE.md)) only triggers when **mixing**
+  nix and non-nix builds in the same closure — pure-flake or pure-Makefile
+  workflows are unaffected. Don't `make build` against an OpenFHE that was
+  previously built inside `nix develop` (or vice versa).
+- Invoke from a parent repo with the explicit path: `nix run
+  path:./vendor/niobium-haze#test-unit`. The apps embed the haze flake's
+  self-reference, so they load the haze dev shell regardless of CWD.
 
 ## Testing
 
@@ -350,7 +385,8 @@ niobium-haze/
       vendor/json/          # nested submodule
   CMakeLists.txt            # libhaze + haze_tests + replay_bridge wiring
   Makefile                  # standalone driver (build, test-*, clean)
-  flake.nix                 # nix dev shell + package
+  flake.nix                 # nix dev shell + make-wrapping apps +
+                            # hermetic packages (openfhe, niobium-fhetch, haze)
   CLAUDE.md                 # working notes (incl. macOS SDK trap recipe)
   README.md
 ```

--- a/README.md
+++ b/README.md
@@ -173,11 +173,17 @@ EXTERNAL_OPENFHE=1 OPENFHE_INSTALL_DIR=/path/to/openfhe make build MODE=release
 - Catch2 3.x.
 - git (submodule init).
 
-```sh
-# macOS (Homebrew)
-brew install cmake catch2 llvm@19
+Clang 19 is the supported floor. The nix flake (and therefore CI) tracks
+nixpkgs-unstable's default, which is currently newer; pick the most recent
+clang available from your package manager when possible.
 
-# Debian / Ubuntu (Catch2 3.x may need a backport or source build)
+```sh
+# macOS (Homebrew) — `llvm` is unversioned and tracks Homebrew's current
+# release; pin to `llvm@19` only if you need a specific version.
+brew install cmake catch2 llvm
+
+# Debian / Ubuntu (Catch2 3.x may need a backport or source build) — bump
+# clang-19 / llvm-19-dev to a newer apt suffix where available.
 sudo apt install cmake catch2 clang-19 llvm-19-dev
 ```
 
@@ -297,7 +303,7 @@ nix develop                                    # interactive
 nix develop --command make build               # one-shot
 ```
 
-The shell provisions the toolchain (clang 19 as `cc`/`c++`, cmake, Catch2 3,
+The shell provisions the toolchain (clang as `cc`/`c++`, cmake, Catch2 3,
 clang-tools, jujutsu, nixfmt) but otherwise stays out of the way. From there
 the Makefile flow above (`make build`, `make test`, etc.) works unchanged.
 This is the recommended path for editing haze sources — every iteration uses

--- a/flake.nix
+++ b/flake.nix
@@ -38,25 +38,27 @@
         ] ./.;
 
       # Dev shell + make-wrapping apps share this toolchain. clang-tools
-      # is taken from llvmPackages_19 so clangd/clang-tidy parse C++23
-      # the same way the build's clang does.
+      # is the unversioned package so clangd/clang-tidy track whatever
+      # clang nixpkgs-unstable currently ships, matching clangStdenv
+      # below.
       hazeTools =
         pkgs: with pkgs; [
           cmake
           catch2_3
           jujutsu
-          llvmPackages_19.clang-tools
+          clang-tools
           nixfmt
         ];
 
       # Three-derivation hermetic build: openfhe → niobium-fhetch → haze.
       # Each layer caches independently — haze edits don't reinvalidate
-      # fhetch or openfhe. Pinned to llvmPackages_19.stdenv to match the
-      # dev shell and avoid the macOS SDK / ABI mismatch trap.
+      # fhetch or openfhe. Uses clangStdenv (nixpkgs's default clang)
+      # to match the dev shell and avoid the macOS SDK / ABI mismatch
+      # trap.
       mkPackages =
         pkgs:
         let
-          stdenv = pkgs.llvmPackages_19.stdenv;
+          stdenv = pkgs.clangStdenv;
           fs = pkgs.lib.fileset;
 
           openfheSrc = ./vendor/niobium-fhetch/vendor/openfhe;
@@ -183,17 +185,18 @@
       formatter = forEachSystem (pkgs: pkgs.nixfmt);
 
       devShells = forEachSystem (pkgs: {
-        # Stdenv override pins clang-19 as the auto-discovered cc/c++
-        # for any tool that probes the environment.
+        # Stdenv override sets the default clang (whatever nixpkgs
+        # currently ships) as the auto-discovered cc/c++ for any tool
+        # that probes the environment.
         default =
           (pkgs.mkShell.override {
-            stdenv = pkgs.llvmPackages_19.stdenv;
+            stdenv = pkgs.clangStdenv;
           })
             {
               name = "haze-dev";
               packages = hazeTools pkgs;
               shellHook = ''
-                echo "haze dev shell ready (clang 19, cmake, catch2, jj, clang-tools)."
+                echo "haze dev shell ready (clang, cmake, catch2, jj, clang-tools)."
                 echo "Run 'make sync && make build' to bootstrap, then 'make test'."
               '';
             };

--- a/flake.nix
+++ b/flake.nix
@@ -1,77 +1,281 @@
 {
-  description = "HAZE: API for Niobium FHE hardware";
+  description = "haze: CUDA-shaped record-and-replay runtime for the Niobium FHE accelerator";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    # Pull vendor/niobium-fhetch (and its transitive openfhe / json
+    # submodules) into self.outPath so the hermetic packages can read
+    # source from `./vendor/...` paths.
+    #
+    # Caveat (nix issue #13324): with a clean parent worktree, nix
+    # re-fetches submodules from their remotes rather than using the
+    # local checkout — that needs auth for the private niobium-fhetch
+    # remote. Keep a dirty file in the haze worktree to force local
+    # use, or commit submodule bumps before invoking nix.
+    self.submodules = true;
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
-      supportedSystems = [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" ];
-      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-    in {
-      devShells = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          llvm = pkgs.llvmPackages_19;
-        in {
-          default = pkgs.mkShell {
-            name = "haze-dev";
+      # x86_64-darwin omitted: niobium ships Apple Silicon only.
+      systems = [
+        "aarch64-linux"
+        "x86_64-linux"
+        "aarch64-darwin"
+      ];
+      forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
 
-            nativeBuildInputs = [
-              llvm.clang
-              pkgs.cmake
-              pkgs.jujutsu
-              pkgs.clang-tools # clang-format, clang-tidy
+      # Haze-owned .nix files for checks.fmt — vendor/ is excluded
+      # since the submodule's formatting belongs to its upstream.
+      hazeOwnedSrc =
+        pkgs:
+        pkgs.nix-gitignore.gitignoreSource [
+          "vendor/"
+          ".jj"
+          ".direnv"
+        ] ./.;
+
+      # Dev shell + make-wrapping apps share this toolchain. clang-tools
+      # is taken from llvmPackages_19 so clangd/clang-tidy parse C++23
+      # the same way the build's clang does.
+      hazeTools =
+        pkgs: with pkgs; [
+          cmake
+          catch2_3
+          jujutsu
+          llvmPackages_19.clang-tools
+          nixfmt
+        ];
+
+      # Three-derivation hermetic build: openfhe → niobium-fhetch → haze.
+      # Each layer caches independently — haze edits don't reinvalidate
+      # fhetch or openfhe. Pinned to llvmPackages_19.stdenv to match the
+      # dev shell and avoid the macOS SDK / ABI mismatch trap.
+      mkPackages =
+        pkgs:
+        let
+          stdenv = pkgs.llvmPackages_19.stdenv;
+          fs = pkgs.lib.fileset;
+
+          openfheSrc = ./vendor/niobium-fhetch/vendor/openfhe;
+
+          # niobium-fhetch minus its OpenFHE submodule (separate
+          # derivation) and any in-tree build dirs `make build` may
+          # have written. maybeMissing tolerates a clean checkout
+          # where those build dirs do not exist.
+          fhetchSrc = fs.toSource {
+            root = ./vendor/niobium-fhetch;
+            fileset = fs.difference ./vendor/niobium-fhetch (
+              fs.unions [
+                ./vendor/niobium-fhetch/vendor/openfhe
+                (fs.maybeMissing ./vendor/niobium-fhetch/vendor/lib)
+                (fs.maybeMissing ./vendor/niobium-fhetch/build)
+                (fs.maybeMissing ./vendor/niobium-fhetch/dbuild)
+              ]
+            );
+          };
+
+          hazeBuildSrc = fs.toSource {
+            root = ./.;
+            fileset = fs.unions [
+              ./CMakeLists.txt
+              ./include
+              ./src
+              ./test
+              ./replay_bridge
+            ];
+          };
+
+          openfhe = stdenv.mkDerivation {
+            pname = "openfhe-niobium";
+            version = "1.4.2";
+            src = openfheSrc;
+            nativeBuildInputs = [ pkgs.cmake ];
+            # WITH_CPROBES=ON compiles in the niobium probe hooks that
+            # libnbfhetch later links against. Other flags mirror the
+            # Makefile's OPENFHE_CMAKE_FLAGS.
+            cmakeFlags = [
+              "-DBUILD_SHARED=ON"
+              "-DBUILD_EXAMPLES=OFF"
+              "-DBUILD_UNITTESTS=OFF"
+              "-DBUILD_BENCHMARKS=OFF"
+              "-DBUILD_EXTRAS=OFF"
+              "-DWITH_CPROBES=ON"
+              "-DWITH_OPENMP=OFF"
+            ];
+            meta.platforms = pkgs.lib.platforms.unix;
+          };
+
+          niobium-fhetch = stdenv.mkDerivation {
+            pname = "niobium-fhetch";
+            version = "1.0.0";
+            src = fhetchSrc;
+            nativeBuildInputs = [ pkgs.cmake ];
+            buildInputs = [ openfhe ];
+            cmakeFlags = [
+              "-DCMAKE_BUILD_TYPE=Release"
+              "-DOPENFHE_INSTALL_DIR=${openfhe}"
+              "-DJSON_INCLUDE_DIR=${fhetchSrc}/vendor/json/single_include"
+            ];
+            # TODO(niobium-fhetch): emit NiobiumFhetchConfig.cmake
+            # upstream via configure_package_config_file. niobium-fhetch
+            # currently installs only NiobiumFhetchTargets.cmake, so
+            # find_package(NiobiumFhetch CONFIG) cannot resolve. Shim
+            # the entry point here so consumers can use find_package.
+            postInstall = ''
+              cat > $out/lib/cmake/NiobiumFhetch/NiobiumFhetchConfig.cmake <<'EOF'
+              include("''${CMAKE_CURRENT_LIST_DIR}/NiobiumFhetchTargets.cmake")
+              EOF
+            '';
+            meta.platforms = pkgs.lib.platforms.unix;
+          };
+
+          haze = stdenv.mkDerivation {
+            pname = "haze";
+            version = "0.1.0";
+            src = hazeBuildSrc;
+            nativeBuildInputs = [ pkgs.cmake ];
+            buildInputs = [
+              openfhe
+              niobium-fhetch
               pkgs.catch2_3
             ];
-
-            # The haze repo's vendored niobium-compiler / niobium-fhetch
-            # submodules carry in-tree build artefacts (build/, deps/...)
-            # that the dev shell needs on CMAKE_PREFIX_PATH /
-            # LD_LIBRARY_PATH. We resolve the worktree root at hook time
-            # rather than baking ./vendor/... into the derivation: the
-            # latter would coerce the path into a /nix/store/<hash>-source
-            # snapshot (no in-tree build outputs) AND emit
-            # `builtins.derivation … without a proper context` warnings
-            # under recent nix.
-            #
-            # Resolution order: $HAZE_ROOT (caller override) -> the
-            # closest enclosing flake.nix from $PWD. Errors loudly if
-            # neither resolves so a misplaced `nix develop` invocation
-            # fails fast instead of silently exporting empty paths.
-            shellHook = ''
-              if [ -n "''${HAZE_ROOT:-}" ]; then
-                _haze_root="$HAZE_ROOT"
-              else
-                _haze_root="$PWD"
-                while [ "$_haze_root" != "/" ] && [ ! -f "$_haze_root/flake.nix" ]; do
-                  _haze_root="$(dirname "$_haze_root")"
-                done
-              fi
-              if [ ! -f "$_haze_root/flake.nix" ]; then
-                echo "haze devshell: cannot locate haze repo root from $PWD." >&2
-                echo "haze devshell: set HAZE_ROOT or run 'nix develop' from inside the haze tree." >&2
-                return 1
-              fi
-
-              _niobium_root="$_haze_root/vendor/niobium-compiler"
-              _niobium_vendor="$_niobium_root/vendor/lib/niobium-compiler"
-              _openfhe_vendor="$_niobium_root/vendor/lib/openfhe"
-              _replay_lib="$_niobium_root/build"
-              _photov_lib="$_niobium_root/deps/photovoltaic/dbuild"
-              _ntl_lib="$_photov_lib/ntl/lib"
-
-              export CMAKE_PREFIX_PATH="$_niobium_vendor''${CMAKE_PREFIX_PATH:+:$CMAKE_PREFIX_PATH}"
-              export LD_LIBRARY_PATH="$_openfhe_vendor/lib:$_replay_lib:$_photov_lib:$_ntl_lib''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-              # Re-export so subshells / scripts launched from the dev
-              # shell skip the upward walk.
-              export HAZE_ROOT="$_haze_root"
-              unset _haze_root _niobium_root _niobium_vendor _openfhe_vendor _replay_lib _photov_lib _ntl_lib
-              echo "haze dev shell ready (clang 19, cmake, jj)."
-              echo "Build: cmake -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build --parallel"
+            cmakeFlags = [
+              "-DCMAKE_BUILD_TYPE=Release"
+              "-DHAZE_USE_PREBUILT_FHETCH=ON"
+              "-DOPENFHE_INSTALL_DIR=${openfhe}"
+              # polynomial_io.cpp uses nlohmann/json. fhetch's
+              # JSON_INCLUDE_DIR only propagates via add_subdirectory,
+              # not via find_package; pass the same path here.
+              "-DJSON_INCLUDE_DIR=${fhetchSrc}/vendor/json/single_include"
+              # TODO(haze): add install() rules upstream. Without
+              # them cmake never runs its build→install RPATH rewrite,
+              # so the install RPATH must be baked at build time
+              # (@loader_path on darwin, $ORIGIN on linux).
+              "-DCMAKE_BUILD_WITH_INSTALL_RPATH=ON"
+              "-DCMAKE_INSTALL_RPATH=${if stdenv.isDarwin then "@loader_path/../lib" else "$ORIGIN/../lib"}"
+            ];
+            # TODO(haze): add install() rules upstream. Until then the
+            # cmake setup hook's `make install` would fail (no install
+            # target), so skip it and place artifacts manually.
+            dontUseCmakeInstall = true;
+            installPhase = ''
+              runHook preInstall
+              mkdir -p $out/lib $out/bin $out/include
+              # cp -a preserves any future SOVERSION/VERSION symlink
+              # chains; install -t would flatten them to copies.
+              cp -a libhaze.* replay_bridge/libhaze_replay_bridge.* $out/lib/
+              cp -a haze_tests $out/bin/
+              chmod +x $out/bin/haze_tests
+              cp -r $src/include/haze $out/include/
+              runHook postInstall
             '';
+            meta.platforms = pkgs.lib.platforms.unix;
           };
-        });
+        in
+        {
+          inherit openfhe niobium-fhetch haze;
+        };
+    in
+    {
+      formatter = forEachSystem (pkgs: pkgs.nixfmt);
+
+      devShells = forEachSystem (pkgs: {
+        # Stdenv override pins clang-19 as the auto-discovered cc/c++
+        # for any tool that probes the environment.
+        default =
+          (pkgs.mkShell.override {
+            stdenv = pkgs.llvmPackages_19.stdenv;
+          })
+            {
+              name = "haze-dev";
+              packages = hazeTools pkgs;
+              shellHook = ''
+                echo "haze dev shell ready (clang 19, cmake, catch2, jj, clang-tools)."
+                echo "Run 'make sync && make build' to bootstrap, then 'make test'."
+              '';
+            };
+      });
+
+      # Each app re-enters the haze dev shell so catch2's cmake setup
+      # hook is active (find_package(Catch2 3) needs it). Passing
+      # `path:${self}` makes the shell load haze's flake regardless
+      # of the caller's CWD — `make` itself still runs in CWD, which
+      # must be a haze worktree.
+      apps = forEachSystem (
+        pkgs:
+        let
+          mkMakeApp = target: {
+            type = "app";
+            program = pkgs.lib.getExe (
+              pkgs.writeShellApplication {
+                name = "haze-${target}";
+                runtimeInputs = [ pkgs.nix ];
+                text = ''
+                  exec nix develop "path:${self}" --command make ${target} "$@"
+                '';
+              }
+            );
+          };
+        in
+        {
+          test-unit = mkMakeApp "test-unit";
+          test-sim = mkMakeApp "test-sim";
+          test = mkMakeApp "test";
+          build = mkMakeApp "build";
+        }
+      );
+
+      packages = forEachSystem (
+        pkgs:
+        let
+          p = mkPackages pkgs;
+        in
+        {
+          inherit (p) openfhe niobium-fhetch haze;
+          default = p.haze;
+        }
+      );
+
+      checks = forEachSystem (
+        pkgs:
+        let
+          p = mkPackages pkgs;
+        in
+        {
+          devshell-builds = self.devShells.${pkgs.stdenv.hostPlatform.system}.default;
+
+          fmt =
+            pkgs.runCommand "haze-nixfmt-check"
+              {
+                nativeBuildInputs = [
+                  pkgs.nixfmt
+                  pkgs.findutils
+                ];
+              }
+              ''
+                cd ${hazeOwnedSrc pkgs}
+                find . -type f -name '*.nix' -print0 \
+                  | xargs -0 -r nixfmt --check
+                touch "$out"
+              '';
+
+          haze-build = p.haze;
+
+          unit-tests = pkgs.runCommand "haze-unit-tests" { } ''
+            mkdir -p $TMPDIR/runs && cd $TMPDIR/runs
+            HAZE_TARGET=local ${p.haze}/bin/haze_tests "~[integration]"
+            touch "$out"
+          '';
+
+          sim-tests = pkgs.runCommand "haze-sim-tests" { } ''
+            mkdir -p $TMPDIR/runs && cd $TMPDIR/runs
+            HAZE_TARGET=local ${p.haze}/bin/haze_tests "[integration]"
+            touch "$out"
+          '';
+        }
+      );
     };
 }

--- a/scripts/zed-clangd.sh
+++ b/scripts/zed-clangd.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Launch clangd with the driver from compile_commands.json on its
+# query-driver allow-list, resolved at spawn time.
+#
+# clangd refuses to introspect arbitrary drivers without --query-driver.
+# We refuse to ship a /nix/store glob in checked-in config (any pattern
+# can match an unrelated derivation in the store). Resolving from the
+# compile DB on every spawn yields one literal absolute path that
+# matches the driver clangd will actually invoke for each TU, even
+# across flake bumps where the devshell's clang++ has rotated ahead of
+# the last `make build`. Falls back to the devshell's clang++ when no
+# compile DB is present yet (first-time bootstrap).
+#
+# Invoke from inside `nix develop` or via `direnv exec . scripts/zed-clangd.sh`.
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+project_root=$(cd "$script_dir/.." && pwd)
+db="$project_root/build/compile_commands.json"
+
+driver=""
+if [[ -f "$db" ]]; then
+    # First "command" entry's first whitespace-delimited token is the
+    # compiler path. Single-awk-pass — a sed|head pipeline here trips
+    # SIGPIPE under `set -o pipefail` and aborts before we exec clangd.
+    driver=$(awk -F'"' '/"command": "/{split($4, a, " "); print a[1]; exit}' "$db")
+fi
+
+if [[ -z "$driver" || ! -x "$driver" ]]; then
+    fallback=$(command -v clang++ || true)
+    if [[ -z "$fallback" ]]; then
+        echo "zed-clangd: clang++ not on PATH and no compile DB at $db — enter the haze devshell and run 'make build'" >&2
+        exit 1
+    fi
+    driver=$(readlink -f "$fallback")
+fi
+
+clangd_bin=$(command -v clangd || true)
+if [[ -z "$clangd_bin" ]]; then
+    echo "zed-clangd: clangd not on PATH; enter the haze devshell first" >&2
+    exit 1
+fi
+
+exec "$clangd_bin" "--query-driver=$driver" "$@"


### PR DESCRIPTION
## Summary

- Adds a hermetic nix flake (commit `032843b`): dev shell, `nix run` apps, three-derivation packages (`openfhe` -> `niobium-fhetch` -> `haze`), nixfmt formatter, and a `checks.*` set bundling `devshell-builds`, `fmt`, `haze-build`, `unit-tests`, `sim-tests`.
- Drops the `llvmPackages_19` pin (commit `1dae447`) so the flake tracks whatever clang nixpkgs-unstable currently ships (today: 21.1.8). `CLAUDE.md` / `README.md` prose updated to match; clang 19 stays the supported floor for non-nix builds.
- Adds `.github/workflows/flake-check.yml` (commit `f0f59ad`) running `nix flake check` on every PR / push to main. Mirrors `build-test.yml` for App-token, fork-PR skip, free-disk-space, Determinate Systems nix-installer + magic-nix-cache. The existing Makefile-driven `build-test.yml` workflow stays as-is; both CI surfaces run side by side.

## Test plan

- [x] `nix flake check -L --keep-going` passes locally on `aarch64-darwin` under clang 21.1.8 (all five checks green; the 9 `[!mayfail]` MRP cases in `test_basis_convert.cpp` report `failed as expected`, suite exit 0).
- [x] `actionlint` clean on `.github/workflows/flake-check.yml`.
- [x] First CI run on this PR exercises the cold path: OpenFHE compiles from source under nix (~20-30 min). Magic Nix Cache writes the result back so subsequent runs are fast.
- [x] Second run (rebase / push / workflow_dispatch) restores from `/nix/store` cache and completes in minutes — the steady-state target.