### PR TITLE
Dispatch haze_main_push to niobium-client on main push

### DIFF
--- a/.github/workflows/dispatch-to-niobium-client.yml
+++ b/.github/workflows/dispatch-to-niobium-client.yml
@@ -1,0 +1,34 @@
+name: Dispatch to niobium-client on main push
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Dispatch haze_main_push to niobium-client
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HAZE_SHA: ${{ github.sha }}
+        run: |
+          jq -n \
+            --arg sha "$HAZE_SHA" \
+            '{event_type: "haze_main_push", client_payload: {sha: $sha}}' \
+          | gh api --method POST \
+              repos/NiobiumInc/niobium-client/dispatches \
+              --input -


### PR DESCRIPTION
Adds a workflow that fires on every push to main and sends a repository_dispatch event (haze_main_push) to niobium-client carrying the commit SHA.

This is the trigger side of the automated submodule bump flow; the receiving workflow lives in NiobiumInc/niobium-client.