### PR TITLE
Mul rot rot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,13 +154,6 @@ that constant.
 A change is considered green when both `make test-sim` (in-process FHETCH
 simulator) and `make test-transport NIOBIUM_COMPILER_ROOT=...` (HTTP transport
 to `nbcc_fhetch_replay`) exit 0 with Catch2 reporting no unexpected failures.
-9 multi-residue cases in `test/test_basis_convert.cpp` are tagged
-`[!mayfail]` because the replay bridge does not yet synthesise an OpenFHE
-CryptoContext for multi-modulus traces; they will continue to print failed
-assertions but Catch2 will report them as `failed as expected` and the suite
-exit code stays 0. When the bridge gains MRP support, search
-`test/test_basis_convert.cpp` for `[!mayfail]` and strip the tag — at that
-point every assertion in the suite must pass.
 
 Sanitizers are mutually exclusive `cmake` cache options:
 `-DHAZE_SANITIZERS=ON` (ASAN+UBSAN) or `-DHAZE_TSAN=ON`. UBSAN's enum check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ add_executable(haze_tests
   test/test_config.cpp
   test/test_compute.cpp
   test/test_basis_convert.cpp
+  test/test_mul_rotation.cpp
   test/test_ring_dim_consistency.cpp
   test/test_integration_helpers.cpp
 )

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -149,11 +149,20 @@ std::expected<void, BridgeError> rebuild_context_locked(uint64_t ring_dim,
     CCParams<CryptoContextCKKSRNS> p;
     p.SetSecurityLevel(HEStd_NotSet); // toy: ring_dim is user-chosen
     p.SetRingDim(ring_dim);
-    // TODO(haze:multi-residue): SetMultiplicativeDepth(0) produces a
-    // single-tower DCRTPoly chain. Multi-residue paths (hazeModUp,
-    // hazeModDown) require depth > 0 and a fan of NativePolys per
-    // ciphertext element — see the failing integration tests in
-    // test/test_basis_convert.cpp at lines 117/245/291/331/381/443/757.
+    // SetMultiplicativeDepth(0) produces a single-tower DCRTPoly chain.
+    // Every haze output address holds one residue under one modulus, so
+    // single-tower templates are sufficient: the simulator pulls the
+    // per-output prime from the trace's modulus_table (built from the
+    // recorded sr_* ops), not from the template. Multi-modulus traces
+    // (e.g. test_basis_convert.cpp's 12-limb cases) work today via this
+    // single-residue-per-output addressing.
+    //
+    // A genuine multi-tower template — a single output address whose
+    // template carries a fan of NativePolys for `result(name, MRP&)` to
+    // deserialize as a true multi-residue polynomial — would require
+    // depth > 0 and explicit per-tower fill in synthesize_haze_ciphertext.
+    // Not currently needed by any client; flagged here so the constraint
+    // is visible if the requirement appears.
     p.SetMultiplicativeDepth(0);
     const uint32_t bits = bit_width_for_modulus(desired_modulus);
     p.SetScalingModSize(bits - 1);

--- a/test/test_mul_rotation.cpp
+++ b/test/test_mul_rotation.cpp
@@ -1,0 +1,186 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// Coverage for hazeMul followed by two hazeAutomorph calls sharing the
+// same product `c` in a single epoch. Host reference: pointwise mul +
+// σ_k slot permutation.
+
+#include "integration_helpers.hpp"
+
+#include <catch2/catch_message.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
+#include <vector>
+
+namespace {
+
+constexpr uint64_t kRingDim = 128;
+constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
+constexpr unsigned kLogRingDim = 7;
+static_assert((1ULL << kLogRingDim) == kRingDim, "kLogRingDim must match log2(kRingDim)");
+
+constexpr uint64_t kQ0 = 576460752303415297ULL;
+constexpr uint64_t kQ1 = 576460752303439873ULL;
+constexpr uint64_t kQ2 = 576460752303702017ULL;
+
+constexpr uint64_t kIdx1 = 5ULL;
+constexpr uint64_t kIdx2 = (kIdx1 * kIdx1) % (2ULL * kRingDim);
+static_assert(kIdx1 % 2 == 1, "kIdx1 must be odd");
+static_assert(kIdx2 % 2 == 1, "kIdx2 must be odd");
+static_assert(kIdx1 != 1, "kIdx1 must not be the identity automorphism");
+static_assert(kIdx2 != 1, "kIdx2 must not be the identity automorphism");
+static_assert(kIdx1 != kIdx2, "kIdx1 and kIdx2 must be distinct");
+static_assert((kIdx1 * kIdx2) % (2ULL * kRingDim) != 1,
+              "kIdx2 must not be the multiplicative inverse of kIdx1 mod 2N");
+
+struct SrpDriver {
+    static constexpr std::size_t kNumResidues = 1;
+    static constexpr const char *kShape = "SRP";
+
+    std::vector<uint64_t> base;
+
+    uint64_t setup() {
+        const uint64_t q =
+            haze::test::setup_integration_compute_config(kRingDim, kQ0, /*mod_idx=*/0);
+        base = {q};
+        return q;
+    }
+
+    static void mul(const std::vector<void *> &dst, const std::vector<const void *> &s1,
+                    const std::vector<const void *> &s2) {
+        REQUIRE(hazeMul(dst[0], s1[0], s2[0], 0, nullptr) == HAZE_SUCCESS);
+    }
+    static void automorph(const std::vector<void *> &dst, const std::vector<const void *> &src,
+                          uint64_t k) {
+        REQUIRE(hazeAutomorph(dst[0], src[0], k, nullptr) == HAZE_SUCCESS);
+    }
+};
+
+struct MrpDriver {
+    static constexpr std::size_t kNumResidues = 3;
+    static constexpr const char *kShape = "MRP";
+
+    std::vector<uint64_t> base;
+
+    uint64_t setup() {
+        REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+        REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+        uint64_t picked = 0;
+        REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
+        REQUIRE(picked != 0);
+        REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
+        REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
+        REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
+        REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+        base = {kQ0, kQ1, kQ2};
+        return kQ0;
+    }
+
+    void mul(const std::vector<void *> &dst, const std::vector<const void *> &s1,
+             const std::vector<const void *> &s2) const {
+        REQUIRE(hazeMulMrp(dst.data(), s1.data(), s2.data(), base.data(), base.size(), nullptr) ==
+                HAZE_SUCCESS);
+    }
+    void automorph(const std::vector<void *> &dst, const std::vector<const void *> &src,
+                   uint64_t k) const {
+        REQUIRE(hazeAutomorphMrp(dst.data(), src.data(), k, base.data(), base.size(), nullptr) ==
+                HAZE_SUCCESS);
+    }
+};
+
+inline uint64_t mul_mod(uint64_t a, uint64_t b, uint64_t q) {
+    return static_cast<uint64_t>((static_cast<__uint128_t>(a) * static_cast<__uint128_t>(b)) % q);
+}
+
+inline uint64_t bit_rev(uint64_t x, unsigned bits) {
+    uint64_t r = 0;
+    for (unsigned i = 0; i < bits; ++i) {
+        r |= ((x >> i) & 1ULL) << (bits - 1 - i);
+    }
+    return r;
+}
+
+// hazeAutomorph's docstring describes σ_k in slot space (output slot i
+// reads from input slot j where 2j+1 ≡ k*(2i+1) mod 2N), but the
+// FHETCH simulator stores eval-form values in bit-reversed positions
+// (NTL's ForwardTransformToBitReverse, simulator.cpp:266-296). Both
+// the output and source indices therefore need bit_rev to translate
+// between slot space and storage space — reversing only one direction
+// is the trap a naive read of the docstring falls into.
+inline std::vector<uint64_t> sigma(const std::vector<uint64_t> &in_storage, uint64_t k) {
+    const uint64_t two_n = 2ULL * kRingDim;
+    std::vector<uint64_t> out_storage(kRingDim);
+    for (uint64_t a = 0; a < kRingDim; ++a) {
+        const uint64_t i = bit_rev(a, kLogRingDim);
+        const uint64_t j = ((k * (2ULL * i + 1ULL) - 1ULL) % two_n) / 2ULL;
+        const uint64_t b = bit_rev(j, kLogRingDim);
+        out_storage[a] = in_storage[b];
+    }
+    return out_storage;
+}
+
+template <typename Driver>
+void check_against_per_residue(const Driver &d, const std::vector<void *> &dst,
+                               const std::vector<std::vector<uint64_t>> &expected) {
+    REQUIRE(dst.size() == Driver::kNumResidues);
+    REQUIRE(expected.size() == Driver::kNumResidues);
+    for (std::size_t i = 0; i < Driver::kNumResidues; ++i) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), dst[i], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        for (uint64_t k = 0; k < kRingDim; ++k) {
+            INFO(Driver::kShape << " residue " << i << " (mod " << d.base[i] << ") slot " << k);
+            REQUIRE(got[k] == expected[i][k]);
+        }
+    }
+}
+
+} // namespace
+
+TEMPLATE_TEST_CASE("mul→automorph→automorph: two rotations sharing one product", "[integration]",
+                   SrpDriver, MrpDriver) {
+    TestType d;
+    d.setup();
+
+    std::vector<std::vector<uint64_t>> a(TestType::kNumResidues);
+    std::vector<std::vector<uint64_t>> b(TestType::kNumResidues);
+    for (std::size_t i = 0; i < TestType::kNumResidues; ++i) {
+        a[i] = haze::test::make_residue(d.base[i], 0xA110CULL + i, kRingDim);
+        b[i] = haze::test::make_residue(d.base[i], 0xB055ULL + i, kRingDim);
+    }
+
+    std::vector<std::vector<uint64_t>> r1_expected(TestType::kNumResidues);
+    std::vector<std::vector<uint64_t>> r2_expected(TestType::kNumResidues);
+    for (std::size_t i = 0; i < TestType::kNumResidues; ++i) {
+        const uint64_t q = d.base[i];
+        std::vector<uint64_t> c_i(kRingDim);
+        for (uint64_t s = 0; s < kRingDim; ++s) {
+            c_i[s] = mul_mod(a[i][s], b[i][s], q);
+        }
+        r1_expected[i] = sigma(c_i, kIdx1);
+        r2_expected[i] = sigma(c_i, kIdx2);
+    }
+
+    auto d_a = haze::test::allocate_and_h2d_residues(a);
+    auto d_b = haze::test::allocate_and_h2d_residues(b);
+    auto d_c = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
+    auto d_r1 = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
+    auto d_r2 = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
+
+    // Single epoch: no D2H between automorph calls.
+    d.mul(d_c, haze::test::to_const(d_a), haze::test::to_const(d_b));
+    d.automorph(d_r1, haze::test::to_const(d_c), kIdx1);
+    d.automorph(d_r2, haze::test::to_const(d_c), kIdx2);
+
+    check_against_per_residue(d, d_r1, r1_expected);
+    check_against_per_residue(d, d_r2, r2_expected);
+
+    haze::test::free_all_residues(d_a);
+    haze::test::free_all_residues(d_b);
+    haze::test::free_all_residues(d_c);
+    haze::test::free_all_residues(d_r1);
+    haze::test::free_all_residues(d_r2);
+}


### PR DESCRIPTION
Previously this test failed when we tried integration with FIDESlib; we replicate the test here to make sure we don't have a problem with this sequence of instructions at the haze level.