### PR TITLE
mrp: route MRP outputs through fhetch shape API + tighten internals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,17 @@ Lint and format use the in-tree `.clang-format` (LLVM, indent 4, column 100)
 and `.clang-tidy` (broad set with bugprone/cppcoreguidelines/modernize/etc.).
 
 Three CI gates must pass before a PR merges. Each one has a local
-equivalent — run them before pushing rather than after CI fails:
+equivalent — run them before pushing rather than after CI fails.
+
+**Run all three before claiming lint clean.** `cmake --build` enforces
+only compiler-level `-Werror`, a much smaller set than these gates. The
+local build will happily pass while clang-tidy fails on
+`misc-include-cleaner`, `modernize-use-designated-initializers`,
+`readability-isolate-declaration`, and other tidy-only categories. Same
+for `clangd --check`, which uses a grep post-pass for warnings.
+clang-format alone is not a substitute. New files you author need this
+most: existing files have history that filters out these patterns, fresh
+ones don't.
 
 1. `Check clang-format` — runs `clang-format --dry-run -Werror` over
    every first-party `.cpp` / `.hpp` / `.h` / `.c` under `src/`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ add_executable(haze_tests
   test/test_mul_rotation.cpp
   test/test_ring_dim_consistency.cpp
   test/test_integration_helpers.cpp
+  test/test_user_crypto_context.cpp
 )
 
 target_include_directories(haze_tests PRIVATE
@@ -256,6 +257,8 @@ target_include_directories(haze_tests PRIVATE
 target_include_directories(haze_tests SYSTEM PRIVATE
   ${_openfhe_include}
   ${_openfhe_include}/core
+  ${_openfhe_include}/pke
+  ${_openfhe_include}/binfhe
 )
 
 target_link_libraries(haze_tests PRIVATE

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "niobium-fhetch-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778596875,
-        "narHash": "sha256-ij34qjT/egLD4fPR/YrI5wtYR1S2wxpGBufMT2byIVM=",
+        "lastModified": 1778605016,
+        "narHash": "sha256-O2KUt3mVZlqFf7V1F1l9llj9wepDQ4Eeaa0wIrQOEWw=",
         "ref": "refs/heads/main",
-        "rev": "e689a42e50b79014e5a719fb77f7bfafb9ecbb6c",
-        "revCount": 98,
+        "rev": "d111dd15dece72916a788593bdff60a6a5c3680a",
+        "revCount": 101,
         "submodules": true,
         "type": "git",
         "url": "ssh://git@github.com/NiobiumInc/niobium-fhetch.git"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "niobium-fhetch-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778104550,
-        "narHash": "sha256-Xq7G37wk4ToT8EcbguMG7TliyMi7VGkRhoxmLw3El5w=",
+        "lastModified": 1778286732,
+        "narHash": "sha256-tdTXPrJUzXcDK/159kEWuSw9GovbigewYREUaRICp7U=",
         "ref": "refs/heads/main",
-        "rev": "afd625912737d6509eb5d3f66376860803e3790a",
-        "revCount": 91,
+        "rev": "0aba6aef294b37d5114db777cd46a2d350743098",
+        "revCount": 95,
         "submodules": true,
         "type": "git",
         "url": "ssh://git@github.com/NiobiumInc/niobium-fhetch.git"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "niobium-fhetch-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778286732,
-        "narHash": "sha256-tdTXPrJUzXcDK/159kEWuSw9GovbigewYREUaRICp7U=",
+        "lastModified": 1778596875,
+        "narHash": "sha256-ij34qjT/egLD4fPR/YrI5wtYR1S2wxpGBufMT2byIVM=",
         "ref": "refs/heads/main",
-        "rev": "0aba6aef294b37d5114db777cd46a2d350743098",
-        "revCount": 95,
+        "rev": "e689a42e50b79014e5a719fb77f7bfafb9ecbb6c",
+        "revCount": 98,
         "submodules": true,
         "type": "git",
         "url": "ssh://git@github.com/NiobiumInc/niobium-fhetch.git"

--- a/replay_bridge/README.md
+++ b/replay_bridge/README.md
@@ -1,0 +1,301 @@
+# haze_replay_bridge — OpenFHE boundary for haze
+
+A small shared library that synthesizes the OpenFHE artifacts the replay path
+needs in order to consume a haze recording. `libhaze` itself is FHETCH-only
+and links no OpenFHE; the bridge is the **single** translation unit in the
+project that does. Splitting it out keeps `<openfhe.h>` out of `libhaze`'s
+public surface and out of every downstream consumer that does not explicitly
+opt in.
+
+The bridge solves two problems:
+
+1. **Inputs / templates the simulator and `nbcc_fhetch_replay` cannot build
+   themselves.** A `.fhetch` trace describes polynomial-level ops; it does
+   not describe the CKKS `CryptoContext`, the `Ciphertext<DCRTPoly>` shells
+   that wrap each input residue, or the per-output templates the replay path
+   stamps with computed values. The bridge writes all three so the replay
+   path has something to deserialize from disk.
+
+2. **`niobium::fhetch::result(...)` resolution.** `epoch.cpp` calls
+   `fhetch::result(name, Polynomial& / MRP& / MRPArray&)` to read each
+   tagged output back from `serialized_probes/<name>.ct`. The overloads
+   are intentionally _not_ in `libnbfhetch` — that would force OpenFHE
+   into every consumer of fhetch. The bridge supplies them, with default
+   visibility, and `libhaze` links the bridge to satisfy the references.
+
+## How it sits in the haze stack
+
+```mermaid
+flowchart TB
+  app[Customer C / C++ application]:::user
+  haze[libhaze<br/>CUDA-shaped C ABI<br/>record-and-replay engine]:::haze
+  bridge[haze_replay_bridge<br/>OpenFHE boundary]:::bridge
+  fhetch[libnbfhetch<br/>niobium::compiler singleton<br/>fhetch::sr_* recording<br/>fhetch::tag_input / tag_output]:::fhetch
+  openfhe[OpenFHE<br/>CKKSRNS CryptoContext<br/>Ciphertext / DCRTPoly / NativePoly<br/>cereal binary serialization]:::ofh
+  sim[in-process FHETCH simulator<br/>HAZE_TARGET=local]:::backend
+  transport[nbcc_fhetch_replay<br/>HAZE_TARGET=FUNC_SIM /<br/>FHE_SIM / FPGA_TRI / ...]:::backend
+
+  app -->|hazeMalloc / hazeAdd / ...| haze
+  haze -->|sr_*, tag_input / tag_output| fhetch
+  haze -->|hazeReplayBridgeInitCryptoContext| bridge
+  bridge -->|capture_crypto_context<br/>set_post_recording_hook| fhetch
+  bridge -->|GenCryptoContext, KeyGen,<br/>Encrypt, SerializeToFile| openfhe
+  fhetch -.->|stop_epoch calls<br/>on_post_recording| bridge
+  fhetch -->|.fhetch trace +<br/>cryptocontext.dat +<br/>inputs/*.bin +<br/>ciphertext_templates/*.template| sim
+  fhetch -->|same artifacts over HTTP| transport
+  sim -.->|serialized_probes/&lt;name&gt;.ct| bridge
+  transport -.->|serialized_probes/&lt;name&gt;.ct| bridge
+  bridge -->|fhetch::result(name, Polynomial / MRP / MRPArray)| haze
+
+  classDef user fill:#fef3c7,stroke:#b45309,color:#000
+  classDef haze fill:#dbeafe,stroke:#1e40af,color:#000
+  classDef bridge fill:#fce7f3,stroke:#9d174d,color:#000
+  classDef fhetch fill:#dcfce7,stroke:#166534,color:#000
+  classDef ofh fill:#ede9fe,stroke:#5b21b6,color:#000
+  classDef backend fill:#f1f5f9,stroke:#334155,color:#000
+```
+
+Dashed edges are file-system handoffs (the trace, the synthesized inputs,
+the per-output `.ct` files); solid edges are direct symbol calls.
+
+## Lifecycle of one epoch
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant T as Test / app
+  participant H as libhaze (epoch.cpp)
+  participant B as haze_replay_bridge
+  participant F as libnbfhetch
+  participant O as OpenFHE
+  participant R as Replay (sim or transport)
+  participant FS as &lt;program_dir&gt;/
+
+  T->>B: hazeReplayBridgeInitCryptoContext(N, q, &picked)
+  B->>O: GenCryptoContext(CKKSRNS, N, depth=0, FIXEDMANUAL)
+  B->>O: KeyGen, capture picked moduli
+  B->>F: capture_crypto_context(cc)
+  F->>FS: cryptocontext.dat
+  B->>F: set_post_recording_hook(on_post_recording)
+  T->>H: hazeMalloc / hazeMemcpy(H2D) / hazeAdd / hazeMul / ...
+  H->>F: sr_*, tag_input(name, poly)
+  T->>H: hazeMemcpy(D2H)
+  H->>F: tag_output(name, poly / MRP / MRPArray)
+  H->>F: stop_epoch()
+  F-->>B: on_post_recording()
+  loop for each captured input
+    B->>O: Encrypt zeros, trim to shape, fill_native_poly
+    B->>F: write_ciphertext_input_bin(name, ct, addr_ids)
+    F->>FS: inputs/&lt;name&gt;.bin + &lt;name&gt;.ids
+  end
+  loop for each captured output
+    B->>O: build empty CT shell of matching shape
+    B->>F: write_ciphertext_template(name, ct)
+    F->>FS: ciphertext_templates/&lt;name&gt;.template
+  end
+  H->>R: replay() (in-process sim, or HTTP to nbcc_fhetch_replay)
+  R->>FS: read .fhetch + cryptocontext.dat + inputs/* + templates/*
+  R->>FS: serialized_probes/&lt;name&gt;.ct
+  loop for each output binding
+    H->>B: fhetch::result(name, Polynomial& / MRP& / MRPArray&)
+    B->>FS: read serialized_probes/&lt;name&gt;.ct
+    B->>O: DeserializeFromFile(BINARY)
+    B-->>H: fhetch::Polynomial / MRP / MRPArray
+  end
+  H->>T: D2H bytes (from shadow buffer)
+```
+
+The post-recording hook (step 11) is what keeps OpenFHE out of `libhaze`:
+recording emits FHETCH IR with no knowledge of ciphertext shells, and the
+bridge fills in the OpenFHE side _after_ the trace is closed but _before_
+replay reads it back.
+
+## Public surface
+
+Two C entry points (see [`include/haze/replay_bridge.h`](include/haze/replay_bridge.h)):
+
+| Symbol                                 | When to call                                                                   |
+| -------------------------------------- | ------------------------------------------------------------------------------ |
+| `hazeReplayBridgeInitCryptoContext`    | After `hazeDeviceReset` and `hazeSetRingDimension`, before any `hazeMalloc`.   |
+| `hazeReplayBridgeReset`                | Called from `hazeDeviceReset` to drop the CC cache and on-disk artifacts.      |
+
+The bridge also exposes the three `niobium::fhetch::result` overloads with
+default visibility so `libhaze`'s link line resolves them out of the bridge
+dylib rather than out of `libnbfhetch`.
+
+`setup_integration_compute_config` in
+[`test/integration_helpers.hpp`](../test/integration_helpers.hpp) is the
+canonical caller: reset → set ring dim → init bridge → align haze's
+ciphertext modulus to the modulus OpenFHE actually picked → configure
+device. Every `[integration]` test goes through it.
+
+## Ciphertext shapes
+
+A captured input or output carries a `niobium::CapturedShape` whose `kind`
+selects one of four geometries. The bridge picks the matching CKKS
+`CryptoContext` depth, builds an `Encrypt(zeros)` shell of the right
+element / tower count, and either fills it (inputs) or leaves it as a
+template (outputs).
+
+| `CapturedKind` | Elements | Towers per element | CC depth | Built by                              |
+| -------------- | -------- | ------------------ | -------- | ------------------------------------- |
+| `SRP`          | 1        | 1                  | 0        | `synthesize_haze_ciphertext`          |
+| `MRP`          | 1        | _N_                | _N_-1    | `synthesize_haze_mrp_ciphertext`      |
+| `SRPArray`     | _K_      | 1                  | 0        | `synthesize_haze_array_ciphertext`    |
+| `MRPArray`     | _K_      | _M_                | _M_-1    | `synthesize_haze_array_ciphertext`    |
+
+`HEStd_NotSet` and `FIXEDMANUAL` are deliberate: the bridge is producing
+structural shells, not running CKKS evaluation. Security level is up to
+the caller's choice of ring dimension and moduli; `FIXEDMANUAL` keeps
+`GenCryptoContext` from silently reshaping the modulus chain (the
+`FLEXIBLEAUTO` default would break the depth-_(N-1)_ → _N_-tower
+assumption MRP templates rely on).
+
+Array shapes (SRPArray / MRPArray) currently require **homogeneous**
+per-element bases. Heterogeneous arrays would need multi-CC stitching
+OpenFHE does not support; the bridge logs and returns `nullptr` rather
+than emitting a wrong-shape template.
+
+## CryptoContext cache
+
+The bridge keeps a per-process cache of CCs keyed by the user-requested
+moduli vector:
+
+```mermaid
+flowchart LR
+  init["hazeReplayBridgeInitCryptoContext<br/>(N, q_primary)"] --> primary[("g_ctx_cache[ {q_primary} ]<br/>depth-0 single-tower CC<br/>+ KeyPair + picked_moduli")]
+  primary --> primary_key[("g_primary_key = {q_primary}")]
+  primary --> cc_dat[(cryptocontext.dat)]
+
+  hook[on_post_recording] -.->|MRP / SRPArray / MRPArray<br/>output with new moduli| build[get_or_build_context_locked]
+  build --> entry[("g_ctx_cache[ moduli ]<br/>depth-(N-1) chain CC")]
+
+  reset["hazeReplayBridgeReset<br/>(via hazeDeviceReset)"] --> wipe[("clear g_ctx_cache<br/>clear g_primary_key<br/>remove ciphertext_templates/<br/>remove serialized_probes/")]
+```
+
+- `hazeReplayBridgeInitCryptoContext` seeds the **primary** CC (depth 0,
+  one tower) and writes `cryptocontext.dat` via libnbfhetch's capture
+  path. Its return value is OpenFHE's picked prime — the caller must
+  thread that back through `hazeSetCiphertextModulus` so the recording
+  side and the `.ct` round-trip agree on the residue modulus.
+- Non-primary CCs (one per distinct MRP / array moduli vector encountered
+  during recording) are built lazily inside `on_post_recording`. They
+  share OpenFHE's static CC ↔ Ciphertext registry with the primary.
+- `hazeReplayBridgeReset` (fired by every `hazeDeviceReset`) wipes the
+  in-memory cache **and** the on-disk `serialized_probes/` /
+  `ciphertext_templates/` directories. Without the disk half,
+  addr-derived names from prior tests pollute the content-based MRP
+  lookups inside libnbfhetch.
+- The post-recording hook is wiped by `niobium::compiler().reset()`,
+  which is why every test that resets must re-call
+  `hazeReplayBridgeInitCryptoContext` afterward.
+
+## Reading `.ct` back into FHETCH polynomials
+
+The three `niobium::fhetch::result` overloads close the loop:
+
+| Overload                                                       | Reads from                                       | Returns                                    |
+| -------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
+| `result(name, fhetch::Polynomial&)`                            | `serialized_probes/<name>.ct`, element[0] tower[0] | one residue                                |
+| `result(name, fhetch::MRP&)`                                   | element[0], every tower                           | _N_-residue MRP                            |
+| `result(name, fhetch::MRPArray&)`                              | every element, every tower                        | _K_-element array of MRPs                  |
+
+Each one deserializes via `Serial::DeserializeFromFile(BINARY)`, pulls
+the `NativePoly::GetValues()` as a `std::vector<uint64_t>`, and rebuilds
+the fhetch type with the format (`Coefficient` / `Evaluation`) recovered
+from OpenFHE's `Format` enum. They are the **only** functions in the
+bridge dylib with default visibility — everything else is hidden because
+`CXX_VISIBILITY_PRESET=hidden` is set on the target.
+
+## Build wiring
+
+`replay_bridge` is its own CMake target:
+
+```cmake
+add_library(haze_replay_bridge SHARED src/openfhe_template.cpp ...)
+target_link_libraries(haze_replay_bridge PUBLIC Niobium::fhetch)
+```
+
+The top-level `CMakeLists.txt` links it into `libhaze` privately so the
+`fhetch::result` overloads resolve, but downstream consumers of `libhaze`
+do not need OpenFHE headers or libraries on their own link line.
+
+A few subtleties worth knowing if you touch the CMake graph:
+
+- The bridge compiles its own copy of `src/common/log.cpp` from haze.
+  Both copies are hidden-visibility, so there is no exported-symbol
+  collision when `haze_tests` links both libraries.
+- `target_compile_options` narrows OpenFHE's noisy diagnostics
+  (`-Wno-pedantic -Wno-shadow -Wno-conversion -Wno-unused-parameter
+  -Wno-deprecated-declarations` and friends). Haze proper keeps strict
+  diagnostics; the warning suppression stays scoped to this target.
+- `HAZE_BUILDING_LIBRARY` is defined privately so `HAZE_API` resolves to
+  the export macro on this side of the boundary.
+
+## Private libnbfhetch hooks
+
+The bridge calls four detail-namespace symbols that are intentionally
+not part of fhetch's public API (`compiler_internal.h` is private to
+libnbfhetch's `src/` tree):
+
+| Symbol                                  | Purpose                                                                            |
+| --------------------------------------- | ---------------------------------------------------------------------------------- |
+| `niobium::detail::write_ciphertext_template`   | Serialize a CT shell to `ciphertext_templates/<name>.template`.            |
+| `niobium::detail::write_ciphertext_input_bin`  | Serialize a populated CT to `inputs/<name>.{bin,ids}`.                      |
+| `niobium::detail::for_each_captured_input`     | Iterate every distinct `fhetch::tag_input` with shape + values + addr_ids.  |
+| `niobium::detail::for_each_captured_output`    | Iterate every `fhetch::tag_output` with shape information.                  |
+
+They are forward-declared in `openfhe_template.cpp` because the cereal
+polymorphic-type registrations live in libnbfhetch's TU; inlining the
+calls into the bridge would throw "unregistered polymorphic type" on
+macOS, where the registry is per-dylib.
+
+## Why a separate dylib at all
+
+Three reasons, in decreasing order of importance:
+
+1. **Symbol isolation.** OpenFHE pulls in cereal, an N-tower
+   `DCRTPoly` template instantiation graph, and a static
+   CC ↔ Ciphertext registry. Compiling that into every haze translation
+   unit balloons build times and forces every downstream consumer of
+   `libhaze` to ship OpenFHE. Keeping it in one TU behind a stable C ABI
+   is much cheaper.
+2. **Warning hygiene.** OpenFHE headers trip every `-W` in haze's
+   strict set. Suppressing them at file scope inside haze would leak the
+   suppression; isolating them to a target lets haze proper stay
+   `-Werror -Wpedantic -Wshadow -Wconversion` clean.
+3. **Two-way handoff.** The bridge implements both halves of the
+   OpenFHE round trip: it writes the artifacts the replay path needs
+   (`cryptocontext.dat`, `inputs/*.bin`, `ciphertext_templates/*`) and
+   it reads the artifacts the replay path produces
+   (`serialized_probes/*.ct`). Co-locating them keeps the
+   shape-to-CT-geometry logic in one place — change the SRPArray /
+   MRPArray rules in `synthesize_haze_array_ciphertext` and the
+   `MRPArray` overload of `result(...)` together.
+
+## File layout
+
+```
+replay_bridge/
+  CMakeLists.txt                         # haze_replay_bridge target
+  include/haze/replay_bridge.h           # public C ABI (2 entry points)
+  src/openfhe_template.cpp               # the entire bridge:
+                                         #   - CC cache + builders
+                                         #   - shape dispatch (SRP/MRP/*Array)
+                                         #   - on_post_recording hook
+                                         #   - fhetch::result(...) overloads
+```
+
+## See also
+
+- [`../README.md`](../README.md) — haze overall and the record/replay
+  execution model.
+- [`../CLAUDE.md`](../CLAUDE.md) — working notes, including the macOS
+  SDK / ABI mismatch trap, which is most often diagnosed by checking
+  the bridge dylib's `LC_BUILD_VERSION`.
+- [`../vendor/niobium-fhetch/include/niobium/compiler.h`](../vendor/niobium-fhetch/include/niobium/compiler.h)
+  — `capture_crypto_context`, `set_post_recording_hook`, and the
+  captured-input / captured-output iteration surface the bridge plugs
+  into.
+- [`../test/integration_helpers.hpp`](../test/integration_helpers.hpp)
+  — the canonical caller (`setup_integration_compute_config`).

--- a/replay_bridge/README.md
+++ b/replay_bridge/README.md
@@ -63,16 +63,16 @@ the per-output `.ct` files); solid edges are direct symbol calls.
 ```mermaid
 sequenceDiagram
   autonumber
-  participant T as Test / app
-  participant H as libhaze (epoch.cpp)
-  participant B as haze_replay_bridge
+  participant T as Test
+  participant H as libhaze
+  participant B as bridge
   participant F as libnbfhetch
   participant O as OpenFHE
-  participant R as Replay (sim or transport)
-  participant FS as &lt;program_dir&gt;/
+  participant R as Replay
+  participant FS as program_dir
 
-  T->>B: hazeReplayBridgeInitCryptoContext(N, q, &picked)
-  B->>O: GenCryptoContext(CKKSRNS, N, depth=0, FIXEDMANUAL)
+  T->>B: hazeReplayBridgeInitCryptoContext(N, q, picked)
+  B->>O: GenCryptoContext CKKSRNS, depth=0, FIXEDMANUAL
   B->>O: KeyGen, capture picked moduli
   B->>F: capture_crypto_context(cc)
   F->>FS: cryptocontext.dat
@@ -86,24 +86,29 @@ sequenceDiagram
   loop for each captured input
     B->>O: Encrypt zeros, trim to shape, fill_native_poly
     B->>F: write_ciphertext_input_bin(name, ct, addr_ids)
-    F->>FS: &lt;prog&gt;.input_&lt;name&gt;.bin + &lt;prog&gt;.input_&lt;name&gt;.ids
+    F->>FS: prog.input_name.bin + prog.input_name.ids
   end
   loop for each captured output
     B->>O: build empty CT shell of matching shape
     B->>F: write_ciphertext_template(name, ct)
-    F->>FS: ciphertext_templates/&lt;name&gt;.template
+    F->>FS: ciphertext_templates/name.template
   end
-  H->>R: replay() (in-process sim, or HTTP to nbcc_fhetch_replay)
-  R->>FS: read .fhetch + cryptocontext.dat + inputs/* + templates/*
-  R->>FS: serialized_probes/&lt;name&gt;.ct
+  H->>R: replay (in-process sim, or HTTP to nbcc_fhetch_replay)
+  R->>FS: read .fhetch + cryptocontext.dat + inputs + templates
+  R->>FS: serialized_probes/name.ct
   loop for each output binding
-    H->>B: fhetch::result(name, Polynomial& / MRP& / MRPArray&)
-    B->>FS: read serialized_probes/&lt;name&gt;.ct
-    B->>O: DeserializeFromFile(BINARY)
+    H->>B: fhetch::result(name, Polynomial / MRP / MRPArray)
+    B->>FS: read serialized_probes/name.ct
+    B->>O: DeserializeFromFile BINARY
     B-->>H: fhetch::Polynomial / MRP / MRPArray
   end
   H->>T: D2H bytes (from shadow buffer)
 ```
+
+Participants: `T` = test or customer app, `H` = `libhaze` (`epoch.cpp`),
+`B` = `haze_replay_bridge`, `F` = `libnbfhetch`, `O` = OpenFHE,
+`R` = the replay target (in-process simulator or `nbcc_fhetch_replay`),
+`FS` = the on-disk `<program_dir>`.
 
 The post-recording hook (step 11) is what keeps OpenFHE out of `libhaze`:
 recording emits FHETCH IR with no knowledge of ciphertext shells, and the

--- a/replay_bridge/README.md
+++ b/replay_bridge/README.md
@@ -27,36 +27,52 @@ The bridge solves two problems:
 
 ```mermaid
 flowchart TB
-  app[Customer C / C++ application]:::user
-  haze[libhaze<br/>CUDA-shaped C ABI<br/>record-and-replay engine]:::haze
-  bridge[haze_replay_bridge<br/>OpenFHE boundary]:::bridge
-  fhetch[libnbfhetch<br/>niobium::compiler singleton<br/>fhetch::sr_* recording<br/>fhetch::tag_input / tag_output]:::fhetch
-  openfhe[OpenFHE<br/>CKKSRNS CryptoContext<br/>Ciphertext / DCRTPoly / NativePoly<br/>cereal binary serialization]:::ofh
-  sim[in-process FHETCH simulator<br/>HAZE_TARGET=local]:::backend
-  transport[nbcc_fhetch_replay<br/>HAZE_TARGET=FUNC_SIM /<br/>FHE_SIM / FPGA_TRI / ...]:::backend
+  app["Customer C / C++ application"]:::user
+  haze["libhaze<br/>CUDA-shaped C ABI<br/>record-and-replay engine"]:::haze
+  bridge["haze_replay_bridge<br/>OpenFHE boundary"]:::bridge
+  fhetch["libnbfhetch<br/>niobium::compiler singleton<br/>FHETCH IR recording<br/>cereal serialization"]:::fhetch
+  openfhe["OpenFHE<br/>CKKSRNS CryptoContext<br/>Ciphertext / DCRTPoly / NativePoly"]:::ofh
+  fs[("program_dir/<br/>.fhetch trace<br/>cryptocontext.dat<br/>prog.input_NAME.bin / .ids<br/>ciphertext_templates/NAME.template<br/>serialized_probes/NAME.ct")]:::fs
+  sim["in-process FHETCH simulator<br/>HAZE_TARGET=local"]:::backend
+  transport["nbcc_fhetch_replay over HTTP<br/>HAZE_TARGET=FUNC_SIM / FHE_SIM / FPGA_TRI / ..."]:::backend
 
-  app -->|hazeMalloc / hazeAdd / ...| haze
-  haze -->|sr_*, tag_input / tag_output| fhetch
-  haze -->|hazeReplayBridgeInitCryptoContext| bridge
-  bridge -->|capture_crypto_context<br/>set_post_recording_hook| fhetch
-  bridge -->|GenCryptoContext, KeyGen,<br/>Encrypt, SerializeToFile| openfhe
-  fhetch -.->|stop_epoch calls<br/>on_post_recording| bridge
-  fhetch -->|.fhetch trace +<br/>cryptocontext.dat +<br/>&lt;prog&gt;.input_*.bin/.ids +<br/>ciphertext_templates/*.template| sim
-  fhetch -->|same artifacts over HTTP| transport
-  sim -.->|serialized_probes/&lt;name&gt;.ct| bridge
-  transport -.->|serialized_probes/&lt;name&gt;.ct| bridge
-  bridge -->|"fhetch::result(name, Polynomial / MRP / MRPArray)"| haze
+  app -->|"haze API calls"| haze
+  app -->|"hazeReplayBridgeInitCryptoContext"| bridge
+  haze -->|"sr_*, tag_input / tag_output,<br/>stop_epoch, replay"| fhetch
+  bridge -->|"capture_crypto_context,<br/>set_post_recording_hook,<br/>for_each_captured_*"| fhetch
+  bridge -->|"GenCryptoContext, KeyGen, Encrypt,<br/>DeserializeFromFile"| openfhe
+  fhetch -.->|"stop_epoch fires on_post_recording"| bridge
+
+  bridge -.->|"writes via libnbfhetch's cereal TU:<br/>cryptocontext.dat,<br/>prog.input_NAME.bin/.ids,<br/>ciphertext_templates/NAME.template"| fs
+  fhetch -.->|"writes .fhetch trace"| fs
+
+  fs -->|"read locally"| sim
+  fs -->|"HTTP-shipped"| transport
+  sim -.->|"writes serialized_probes/NAME.ct"| fs
+  transport -.->|"writes serialized_probes/NAME.ct"| fs
+
+  fs -.->|"fhetch::result reads .ct"| bridge
+  bridge -->|"fhetch::Polynomial / MRP / MRPArray"| haze
 
   classDef user fill:#fef3c7,stroke:#b45309,color:#000
   classDef haze fill:#dbeafe,stroke:#1e40af,color:#000
   classDef bridge fill:#fce7f3,stroke:#9d174d,color:#000
   classDef fhetch fill:#dcfce7,stroke:#166534,color:#000
   classDef ofh fill:#ede9fe,stroke:#5b21b6,color:#000
+  classDef fs fill:#fee2e2,stroke:#991b1b,color:#000
   classDef backend fill:#f1f5f9,stroke:#334155,color:#000
 ```
 
-Dashed edges are file-system handoffs (the trace, the synthesized inputs,
-the per-output `.ct` files); solid edges are direct symbol calls.
+Dashed edges are filesystem reads / writes; solid edges are direct symbol
+calls. The `program_dir/` cylinder is the rendezvous: the bridge synthesizes
+`cryptocontext.dat`, the per-input `.bin`/`.ids` pairs, and per-output
+`.template` shells (going through libnbfhetch's cereal TU so polymorphic
+registrations resolve in the right dylib); libnbfhetch separately writes
+the `.fhetch` trace. Only after **all** of those exist on disk does the
+replay target — in-process simulator or `nbcc_fhetch_replay` over HTTP —
+consume them and write `serialized_probes/NAME.ct` back to the same
+directory. The bridge then closes the loop by deserializing those `.ct`
+files via OpenFHE in response to libhaze's `fhetch::result(...)` calls.
 
 ## Lifecycle of one epoch
 

--- a/replay_bridge/README.md
+++ b/replay_bridge/README.md
@@ -25,33 +25,72 @@ The bridge solves two problems:
 
 ## How it sits in the haze stack
 
+The diagram below reads top to bottom in usage order. Three arrow
+conventions:
+
+- **Solid (`-->`)** is a direct symbol call between libraries. Labels name
+  the function. Callbacks (libnbfhetch firing back into the bridge) are
+  solid too, labeled "fires X".
+- **Thick (`==>`)** is a filesystem write. Labels name the file being
+  written, so producer ownership is unambiguous.
+- **Dashed (`-.->`)** is a filesystem read. Labels name the file being
+  read.
+
+`program_dir/` is broken into one node per artifact so each `==>` and
+`-.->` can point at exactly the file it touches.
+
 ```mermaid
 flowchart TB
   app["Customer C / C++ application"]:::user
-  haze["libhaze<br/>CUDA-shaped C ABI<br/>record-and-replay engine"]:::haze
-  bridge["haze_replay_bridge<br/>OpenFHE boundary"]:::bridge
-  fhetch["libnbfhetch<br/>niobium::compiler singleton<br/>FHETCH IR recording<br/>cereal serialization"]:::fhetch
-  openfhe["OpenFHE<br/>CKKSRNS CryptoContext<br/>Ciphertext / DCRTPoly / NativePoly"]:::ofh
-  fs[("program_dir/<br/>.fhetch trace<br/>cryptocontext.dat<br/>prog.input_NAME.bin / .ids<br/>ciphertext_templates/NAME.template<br/>serialized_probes/NAME.ct")]:::fs
-  sim["in-process FHETCH simulator<br/>HAZE_TARGET=local"]:::backend
-  transport["nbcc_fhetch_replay over HTTP<br/>HAZE_TARGET=FUNC_SIM / FHE_SIM / FPGA_TRI / ..."]:::backend
+  haze["libhaze<br/>record-and-replay engine"]:::haze
+  bridge["haze_replay_bridge<br/>OpenFHE artifact producer + reader"]:::bridge
+  fhetch["libnbfhetch<br/>FHETCH IR recorder + replay dispatcher"]:::fhetch
+  openfhe["OpenFHE"]:::ofh
 
-  app -->|"haze API calls"| haze
-  app -->|"hazeReplayBridgeInitCryptoContext"| bridge
-  haze -->|"sr_*, tag_input / tag_output,<br/>stop_epoch, replay"| fhetch
-  bridge -->|"capture_crypto_context,<br/>set_post_recording_hook,<br/>for_each_captured_*"| fhetch
-  bridge -->|"GenCryptoContext, KeyGen, Encrypt,<br/>DeserializeFromFile"| openfhe
-  fhetch -.->|"stop_epoch fires on_post_recording"| bridge
+  subgraph fs ["program_dir/"]
+    direction TB
+    fs_cc["cryptocontext.dat"]:::fs_file
+    fs_trace[".fhetch trace"]:::fs_file
+    fs_inputs["prog.input_NAME.bin/.ids"]:::fs_file
+    fs_tmpl["ciphertext_templates/NAME.template"]:::fs_file
+    fs_probes["serialized_probes/NAME.ct"]:::fs_file
+  end
 
-  bridge -.->|"writes via libnbfhetch's cereal TU:<br/>cryptocontext.dat,<br/>prog.input_NAME.bin/.ids,<br/>ciphertext_templates/NAME.template"| fs
-  fhetch -.->|"writes .fhetch trace"| fs
+  replay["Replay target (HAZE_TARGET):<br/>local → in-process simulator<br/>FUNC_SIM / FHE_SIM / FPGA_TRI → nbcc_fhetch_replay over HTTP"]:::backend
 
-  fs -->|"read locally"| sim
-  fs -->|"HTTP-shipped"| transport
-  sim -.->|"writes serialized_probes/NAME.ct"| fs
-  transport -.->|"writes serialized_probes/NAME.ct"| fs
+  %% (1) Init: bridge primes the directory with the CC and registers its
+  %% post-recording callback.
+  app -->|"1. hazeReplayBridgeInitCryptoContext"| bridge
+  bridge -->|"GenCryptoContext, KeyGen,<br/>Encrypt, DeserializeFromFile"| openfhe
+  bridge -->|"capture_crypto_context,<br/>set_post_recording_hook"| fhetch
+  bridge ==>|"writes cryptocontext.dat"| fs_cc
 
-  fs -.->|"fhetch::result reads .ct"| bridge
+  %% (2) Record: libhaze appends to libnbfhetch's in-memory IR.
+  app -->|"2. hazeMalloc, hazeMemcpy(H2D),<br/>hazeAdd, hazeMul, ..."| haze
+  haze -->|"sr_*, tag_input"| fhetch
+
+  %% (3, 4) D2H -> stop_epoch -> post-recording callback.
+  app -->|"3. hazeMemcpy(D2H)"| haze
+  haze -->|"tag_output, stop_epoch"| fhetch
+  fhetch ==>|"writes .fhetch trace"| fs_trace
+  fhetch -->|"4. fires on_post_recording"| bridge
+
+  %% (5) Inside the callback, the bridge writes the OpenFHE-side inputs.
+  bridge ==>|"5. writes prog.input_NAME.bin/.ids"| fs_inputs
+  bridge ==>|"5. writes ciphertext_templates/NAME.template"| fs_tmpl
+
+  %% (6) Replay reads every input artifact and writes per-output probes.
+  haze -->|"6. replay()"| fhetch
+  fhetch -->|"dispatch"| replay
+  fs_cc -.->|"reads cryptocontext.dat"| replay
+  fs_trace -.->|"reads .fhetch trace"| replay
+  fs_inputs -.->|"reads prog.input_NAME.bin/.ids"| replay
+  fs_tmpl -.->|"reads ciphertext_templates/NAME.template"| replay
+  replay ==>|"writes serialized_probes/NAME.ct"| fs_probes
+
+  %% (7) Bridge reads probes back via fhetch::result.
+  haze -->|"7. fhetch::result(name, ...)"| bridge
+  fs_probes -.->|"reads serialized_probes/NAME.ct"| bridge
   bridge -->|"fhetch::Polynomial / MRP / MRPArray"| haze
 
   classDef user fill:#fef3c7,stroke:#b45309,color:#000
@@ -59,20 +98,51 @@ flowchart TB
   classDef bridge fill:#fce7f3,stroke:#9d174d,color:#000
   classDef fhetch fill:#dcfce7,stroke:#166534,color:#000
   classDef ofh fill:#ede9fe,stroke:#5b21b6,color:#000
-  classDef fs fill:#fee2e2,stroke:#991b1b,color:#000
+  classDef fs_file fill:#fee2e2,stroke:#991b1b,color:#000
   classDef backend fill:#f1f5f9,stroke:#334155,color:#000
 ```
 
-Dashed edges are filesystem reads / writes; solid edges are direct symbol
-calls. The `program_dir/` cylinder is the rendezvous: the bridge synthesizes
-`cryptocontext.dat`, the per-input `.bin`/`.ids` pairs, and per-output
-`.template` shells (going through libnbfhetch's cereal TU so polymorphic
-registrations resolve in the right dylib); libnbfhetch separately writes
-the `.fhetch` trace. Only after **all** of those exist on disk does the
-replay target — in-process simulator or `nbcc_fhetch_replay` over HTTP —
-consume them and write `serialized_probes/NAME.ct` back to the same
-directory. The bridge then closes the loop by deserializing those `.ct`
-files via OpenFHE in response to libhaze's `fhetch::result(...)` calls.
+A small implementation note: the byte-level filesystem writes for the
+three bridge-owned files actually happen inside libnbfhetch's translation
+unit (the `niobium::detail::write_*` helpers in [Private libnbfhetch
+hooks](#private-libnbfhetch-hooks) below). That is a cereal-registration
+trick — the polymorphic-type registry has to resolve in the same dylib —
+but the **content**, **timing**, and **decision to write at all** are
+the bridge's, so the diagram attributes those three files to the bridge.
+
+### How the bridge gets invoked
+
+The bridge has three entry routes, one per arrow type into the `bridge`
+node above:
+
+1. **Explicit C ABI call (step 1).** The application — usually through
+   `setup_integration_compute_config` in
+   [`test/integration_helpers.hpp`](../test/integration_helpers.hpp) —
+   calls `hazeReplayBridgeInitCryptoContext(ring_dim, desired_modulus,
+   &picked)`. The bridge builds the primary CKKS CryptoContext via
+   OpenFHE, hands it to libnbfhetch (which serializes it as
+   `cryptocontext.dat`), and registers `on_post_recording` as
+   libnbfhetch's `post_recording_hook`. A symmetric `hazeReplayBridgeReset`
+   is called from `lifecycle.cpp` on every `hazeDeviceReset`.
+
+2. **Callback from libnbfhetch (step 4 → step 5).** During `stop_epoch`,
+   libnbfhetch fires the registered post-recording hook. That is the
+   bridge's `on_post_recording`. The hook walks libnbfhetch's
+   captured-input and captured-output records via
+   `for_each_captured_input` / `for_each_captured_output`, synthesizes
+   OpenFHE `Ciphertext<DCRTPoly>` shells of the matching shape
+   (`SRP` / `MRP` / `SRPArray` / `MRPArray`), and writes the rest of
+   the inputs the replay target consumes.
+
+3. **Implicit symbol resolution (step 7).** The three
+   `niobium::fhetch::result` overloads libhaze calls after replay are
+   _defined_ in the bridge dylib — not in libnbfhetch. They have
+   default visibility (the rest of the bridge is
+   `CXX_VISIBILITY_PRESET=hidden`), so libhaze's link line resolves
+   `fhetch::result(name, Polynomial&)`, `... MRP&)`, and `... MRPArray&)`
+   out of `libhaze_replay_bridge.dylib`. The overloads deserialize
+   `serialized_probes/NAME.ct` via OpenFHE and return an `fhetch::` type
+   that libhaze converts to bytes for its shadow buffer.
 
 ## Lifecycle of one epoch
 

--- a/replay_bridge/README.md
+++ b/replay_bridge/README.md
@@ -1,41 +1,18 @@
 # haze_replay_bridge — OpenFHE boundary for haze
 
-A small shared library that synthesizes the OpenFHE artifacts the replay path
-needs in order to consume a haze recording. `libhaze` itself is FHETCH-only
-and links no OpenFHE; the bridge is the **single** translation unit in the
-project that does. Splitting it out keeps `<openfhe.h>` out of `libhaze`'s
-public surface and out of every downstream consumer that does not explicitly
-opt in.
+A small shared library that adapts between libnbfhetch's captured-record
+format and OpenFHE-serialized `Ciphertext<DCRTPoly>` files on disk.
+`libhaze` is FHETCH-only; the bridge is the **single** TU in the project
+that links OpenFHE, so OpenFHE never leaks into libhaze's public surface
+or any downstream consumer.
 
-The bridge solves two problems:
+## Architecture
 
-1. **Inputs / templates the simulator and `nbcc_fhetch_replay` cannot build
-   themselves.** A `.fhetch` trace describes polynomial-level ops; it does
-   not describe the CKKS `CryptoContext`, the `Ciphertext<DCRTPoly>` shells
-   that wrap each input residue, or the per-output templates the replay path
-   stamps with computed values. The bridge writes all three so the replay
-   path has something to deserialize from disk.
-
-2. **`niobium::fhetch::result(...)` resolution.** `epoch.cpp` calls
-   `fhetch::result(name, Polynomial& / MRP& / MRPArray&)` to read each
-   tagged output back from `serialized_probes/<name>.ct`. The overloads
-   are intentionally _not_ in `libnbfhetch` — that would force OpenFHE
-   into every consumer of fhetch. The bridge supplies them, with default
-   visibility, and `libhaze` links the bridge to satisfy the references.
-
-## How it sits in the haze stack
-
-The diagram below reads top to bottom in usage order. Three arrow
-conventions: solid (`-->`) is a direct symbol call, thick (`==>`) is a
-filesystem **write** (label names the file), and dashed (`-.->`) is a
-filesystem **read** (label names the file).
-
-`program_dir/` holds two kinds of artifact: **ciphertext data** (every
-OpenFHE-serialized file — CC, per-input ciphertexts, output templates,
-output probes) and the **`.fhetch` trace** (libnbfhetch's polynomial-op
-schedule). Splitting them this way makes the bridge's job obvious: it
-owns every byte on the ciphertext-data side, both writing it before
-replay and reading it after.
+Solid `-->` is a function call. Thick `==>` is a filesystem write
+(label = file written). Dashed `-.->` is a filesystem read.
+`program_dir/` holds two kinds of artifact: ciphertext data (every
+OpenFHE-serialized file — bridge-owned) and the `.fhetch` trace
+(libnbfhetch-owned).
 
 ```mermaid
 flowchart TB
@@ -55,35 +32,27 @@ flowchart TB
 
   bridge ---|"all OpenFHE work:<br/>GenCryptoContext, KeyGen,<br/>build Ciphertext shells,<br/>DeserializeFromFile"| openfhe
 
-  %% (1) Init: bridge primes the CC, registers its callback.
   app -->|"1. hazeReplayBridgeInitCryptoContext"| bridge
   bridge -->|"capture_crypto_context,<br/>set_post_recording_hook"| fhetch
   bridge ==>|"1. writes cryptocontext.dat"| ct_data
 
-  %% (2) Record: libhaze streams IR nodes into libnbfhetch.
   app -->|"2. hazeMalloc, hazeMemcpy(H2D),<br/>hazeAdd, hazeMul, ..."| haze
   haze -->|"sr_*, tag_input, tag_output"| fhetch
 
-  %% (3, 4) D2H -> stop_epoch -> post-recording callback.
   app -->|"3. hazeMemcpy(D2H)"| haze
   haze -->|"stop_epoch"| fhetch
   fhetch ==>|"3. writes .fhetch trace"| trace
   fhetch -->|"4. fires on_post_recording"| bridge
 
-  %% (5) THE ADAPTER STEP. The hook reads libnbfhetch's captured-input /
-  %% captured-output records (per-residue values, shape, addr_ids), builds
-  %% matching OpenFHE Ciphertext<DCRTPoly> objects, and serializes them.
   bridge -->|"5a. reads captured records:<br/>per-residue values, shape, addr_ids"| fhetch
   bridge ==>|"5b. writes input ciphertexts +<br/>output templates"| ct_data
 
-  %% (6) Replay reads both artifact kinds and produces probes.
   haze -->|"6. replay()"| fhetch
   fhetch -->|"dispatch"| replay
   trace -.->|"reads .fhetch trace"| replay
   ct_data -.->|"reads CC + inputs + templates"| replay
   replay ==>|"6. writes serialized_probes/NAME.ct"| ct_data
 
-  %% (7) Bridge reads probes back via fhetch::result.
   haze -->|"7. fhetch::result(name, ...)"| bridge
   ct_data -.->|"reads serialized_probes/NAME.ct"| bridge
   bridge -->|"fhetch::Polynomial / MRP / MRPArray"| haze
@@ -97,303 +66,34 @@ flowchart TB
   classDef backend fill:#f1f5f9,stroke:#334155,color:#000
 ```
 
-**Step 5 is the bridge's reason to exist.** The `on_post_recording` hook
-fires _after_ libnbfhetch has finished recording the `.fhetch` trace but
-_before_ replay starts. It pulls libnbfhetch's in-memory captured records
-(per-residue `uint64_t` values, a `CapturedKind` shape tag, and the
-FHETCH `addr_ids` that name each tower), builds a corresponding
-`Ciphertext<DCRTPoly>` via OpenFHE — filled for inputs, empty for
-outputs — and serializes it into the ciphertext-data side of
-`program_dir/`. Without step 5 the replay target has nothing to feed
-into the trace and no output shells to stamp; with it, the replay
-target's IO boundary is pure OpenFHE-serialized ciphertexts. Step 7 is
-the reverse half of the same adapter: deserialize a probe `.ct` and
-hand the values back as an `fhetch::` type.
+**Step 5 is the bridge's reason to exist.** `on_post_recording` fires
+after libnbfhetch finishes the `.fhetch` trace but before replay starts.
+It walks libnbfhetch's captured-input / captured-output records, builds
+a matching `Ciphertext<DCRTPoly>` via OpenFHE (filled for inputs, empty
+for outputs), and serializes it. The replay target's IO boundary is
+therefore pure OpenFHE-serialized ciphertexts. Step 7 is the reverse
+half: the `fhetch::result(...)` overloads — defined in the bridge dylib
+with default visibility so libhaze's link line resolves them — read a
+probe `.ct` back as an `fhetch::` type.
 
-(Implementation note: the byte-level writes in steps 1, 5b, and the
-trace dump go through libnbfhetch's translation unit — the
-`niobium::detail::write_*` helpers in
-[Private libnbfhetch hooks](#private-libnbfhetch-hooks) — so cereal's
-polymorphic-type registry resolves in the right dylib. The decision to
-write, the content, and the timing are still the bridge's.)
+## Public C ABI
 
-### How the bridge gets invoked
-
-The bridge has three entry routes, one per arrow type into the `bridge`
-node above:
-
-1. **Explicit C ABI call (step 1).** The application — usually through
-   `setup_integration_compute_config` in
-   [`test/integration_helpers.hpp`](../test/integration_helpers.hpp) —
-   calls `hazeReplayBridgeInitCryptoContext(ring_dim, desired_modulus,
-   &picked)`. The bridge builds the primary CKKS CryptoContext via
-   OpenFHE, hands it to libnbfhetch (which serializes it as
-   `cryptocontext.dat`), and registers `on_post_recording` as
-   libnbfhetch's `post_recording_hook`. A symmetric `hazeReplayBridgeReset`
-   is called from `lifecycle.cpp` on every `hazeDeviceReset`.
-
-2. **Callback from libnbfhetch (step 4 → step 5).** During `stop_epoch`,
-   libnbfhetch fires the registered post-recording hook. That is the
-   bridge's `on_post_recording`. The hook walks libnbfhetch's
-   captured-input and captured-output records via
-   `for_each_captured_input` / `for_each_captured_output`, synthesizes
-   OpenFHE `Ciphertext<DCRTPoly>` shells of the matching shape
-   (`SRP` / `MRP` / `SRPArray` / `MRPArray`), and writes the rest of
-   the inputs the replay target consumes.
-
-3. **Implicit symbol resolution (step 7).** The three
-   `niobium::fhetch::result` overloads libhaze calls after replay are
-   _defined_ in the bridge dylib — not in libnbfhetch. They have
-   default visibility (the rest of the bridge is
-   `CXX_VISIBILITY_PRESET=hidden`), so libhaze's link line resolves
-   `fhetch::result(name, Polynomial&)`, `... MRP&)`, and `... MRPArray&)`
-   out of `libhaze_replay_bridge.dylib`. The overloads deserialize
-   `serialized_probes/NAME.ct` via OpenFHE and return an `fhetch::` type
-   that libhaze converts to bytes for its shadow buffer.
-
-## Lifecycle of one epoch
-
-```mermaid
-sequenceDiagram
-  autonumber
-  participant T as Test
-  participant H as libhaze
-  participant B as bridge
-  participant F as libnbfhetch
-  participant O as OpenFHE
-  participant R as Replay
-  participant FS as program_dir
-
-  T->>B: hazeReplayBridgeInitCryptoContext(N, q, picked)
-  B->>O: GenCryptoContext CKKSRNS, depth=0, FIXEDMANUAL
-  B->>O: KeyGen, capture picked moduli
-  B->>F: capture_crypto_context(cc)
-  F->>FS: cryptocontext.dat
-  B->>F: set_post_recording_hook(on_post_recording)
-  T->>H: hazeMalloc / hazeMemcpy(H2D) / hazeAdd / hazeMul / ...
-  H->>F: sr_*, tag_input(name, poly)
-  T->>H: hazeMemcpy(D2H)
-  H->>F: tag_output(name, poly / MRP / MRPArray)
-  H->>F: stop_epoch()
-  F-->>B: on_post_recording()
-  loop for each captured input
-    B->>O: Encrypt zeros, trim to shape, fill_native_poly
-    B->>F: write_ciphertext_input_bin(name, ct, addr_ids)
-    F->>FS: prog.input_name.bin + prog.input_name.ids
-  end
-  loop for each captured output
-    B->>O: build empty CT shell of matching shape
-    B->>F: write_ciphertext_template(name, ct)
-    F->>FS: ciphertext_templates/name.template
-  end
-  H->>R: replay (in-process sim, or HTTP to nbcc_fhetch_replay)
-  R->>FS: read .fhetch + cryptocontext.dat + inputs + templates
-  R->>FS: serialized_probes/name.ct
-  loop for each output binding
-    H->>B: fhetch::result(name, Polynomial / MRP / MRPArray)
-    B->>FS: read serialized_probes/name.ct
-    B->>O: DeserializeFromFile BINARY
-    B-->>H: fhetch::Polynomial / MRP / MRPArray
-  end
-  H->>T: D2H bytes (from shadow buffer)
+```c
+hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
+                                              uint64_t desired_modulus,
+                                              uint64_t *picked_modulus);
+void        hazeReplayBridgeReset(void);
 ```
 
-Participants: `T` = test or customer app, `H` = `libhaze` (`epoch.cpp`),
-`B` = `haze_replay_bridge`, `F` = `libnbfhetch`, `O` = OpenFHE,
-`R` = the replay target (in-process simulator or `nbcc_fhetch_replay`),
-`FS` = the on-disk `<program_dir>`.
+Init must be called after every `hazeDeviceReset` (which fires
+`hazeReplayBridgeReset` for you);
+[`test/integration_helpers.hpp`](../test/integration_helpers.hpp)'s
+`setup_integration_compute_config` is the canonical caller.
 
-The post-recording hook (step 11) is what keeps OpenFHE out of `libhaze`:
-recording emits FHETCH IR with no knowledge of ciphertext shells, and the
-bridge fills in the OpenFHE side _after_ the trace is closed but _before_
-replay reads it back.
+## Source layout
 
-## Public surface
-
-Two C entry points (see [`include/haze/replay_bridge.h`](include/haze/replay_bridge.h)):
-
-| Symbol                                 | When to call                                                                   |
-| -------------------------------------- | ------------------------------------------------------------------------------ |
-| `hazeReplayBridgeInitCryptoContext`    | After `hazeDeviceReset` and `hazeSetRingDimension`, before any `hazeMalloc`.   |
-| `hazeReplayBridgeReset`                | Called from `hazeDeviceReset` to drop the CC cache and on-disk artifacts.      |
-
-The bridge also exposes the three `niobium::fhetch::result` overloads with
-default visibility so `libhaze`'s link line resolves them out of the bridge
-dylib rather than out of `libnbfhetch`.
-
-`setup_integration_compute_config` in
-[`test/integration_helpers.hpp`](../test/integration_helpers.hpp) is the
-canonical caller: reset → set ring dim → init bridge → align haze's
-ciphertext modulus to the modulus OpenFHE actually picked → configure
-device. Every `[integration]` test goes through it.
-
-## Ciphertext shapes
-
-A captured input or output carries a `niobium::CapturedShape` whose `kind`
-selects one of four geometries. The bridge picks the matching CKKS
-`CryptoContext` depth, builds an `Encrypt(zeros)` shell of the right
-element / tower count, and either fills it (inputs) or leaves it as a
-template (outputs).
-
-| `CapturedKind` | Elements | Towers per element | CC depth | Built by                              |
-| -------------- | -------- | ------------------ | -------- | ------------------------------------- |
-| `SRP`          | 1        | 1                  | 0        | `synthesize_haze_ciphertext`          |
-| `MRP`          | 1        | _N_                | _N_-1    | `synthesize_haze_mrp_ciphertext`      |
-| `SRPArray`     | _K_      | 1                  | 0        | `synthesize_haze_array_ciphertext`    |
-| `MRPArray`     | _K_      | _M_                | _M_-1    | `synthesize_haze_array_ciphertext`    |
-
-`HEStd_NotSet` and `FIXEDMANUAL` are deliberate: the bridge is producing
-structural shells, not running CKKS evaluation. Security level is up to
-the caller's choice of ring dimension and moduli; `FIXEDMANUAL` keeps
-`GenCryptoContext` from silently reshaping the modulus chain (the
-`FLEXIBLEAUTO` default would break the depth-_(N-1)_ → _N_-tower
-assumption MRP templates rely on).
-
-Array shapes (SRPArray / MRPArray) currently require **homogeneous**
-per-element bases. Heterogeneous arrays would need multi-CC stitching
-OpenFHE does not support; the bridge logs and returns `nullptr` rather
-than emitting a wrong-shape template.
-
-## CryptoContext cache
-
-The bridge keeps a per-process cache of CCs keyed by the user-requested
-moduli vector:
-
-```mermaid
-flowchart LR
-  init["hazeReplayBridgeInitCryptoContext<br/>(N, q_primary)"] --> primary[("g_ctx_cache[ {q_primary} ]<br/>depth-0 single-tower CC<br/>+ KeyPair + picked_moduli")]
-  primary --> primary_key[("g_primary_key = {q_primary}")]
-  primary --> cc_dat[(cryptocontext.dat)]
-
-  hook[on_post_recording] -.->|MRP / SRPArray / MRPArray<br/>output with new moduli| build[get_or_build_context_locked]
-  build --> entry[("g_ctx_cache[ moduli ]<br/>depth-(N-1) chain CC")]
-
-  reset["hazeReplayBridgeReset<br/>(via hazeDeviceReset)"] --> wipe[("clear g_ctx_cache<br/>clear g_primary_key<br/>remove ciphertext_templates/<br/>remove serialized_probes/")]
-```
-
-- `hazeReplayBridgeInitCryptoContext` seeds the **primary** CC (depth 0,
-  one tower) and writes `cryptocontext.dat` via libnbfhetch's capture
-  path. Its return value is OpenFHE's picked prime — the caller must
-  thread that back through `hazeSetCiphertextModulus` so the recording
-  side and the `.ct` round-trip agree on the residue modulus.
-- Non-primary CCs (one per distinct MRP / array moduli vector encountered
-  during recording) are built lazily inside `on_post_recording`. They
-  share OpenFHE's static CC ↔ Ciphertext registry with the primary.
-- `hazeReplayBridgeReset` (fired by every `hazeDeviceReset`) wipes the
-  in-memory cache **and** the on-disk `serialized_probes/` /
-  `ciphertext_templates/` directories. Without the disk half,
-  addr-derived names from prior tests pollute the content-based MRP
-  lookups inside libnbfhetch.
-- The post-recording hook is wiped by `niobium::compiler().reset()`,
-  which is why every test that resets must re-call
-  `hazeReplayBridgeInitCryptoContext` afterward.
-
-## Reading `.ct` back into FHETCH polynomials
-
-The three `niobium::fhetch::result` overloads close the loop:
-
-| Overload                                                       | Reads from                                       | Returns                                    |
-| -------------------------------------------------------------- | ------------------------------------------------ | ------------------------------------------ |
-| `result(name, fhetch::Polynomial&)`                            | `serialized_probes/<name>.ct`, element[0] tower[0] | one residue                                |
-| `result(name, fhetch::MRP&)`                                   | element[0], every tower                           | _N_-residue MRP                            |
-| `result(name, fhetch::MRPArray&)`                              | every element, every tower                        | _K_-element array of MRPs                  |
-
-Each one deserializes via `Serial::DeserializeFromFile(BINARY)`, pulls
-the `NativePoly::GetValues()` as a `std::vector<uint64_t>`, and rebuilds
-the fhetch type with the format (`Coefficient` / `Evaluation`) recovered
-from OpenFHE's `Format` enum. They are the **only** functions in the
-bridge dylib with default visibility — everything else is hidden because
-`CXX_VISIBILITY_PRESET=hidden` is set on the target.
-
-## Build wiring
-
-`replay_bridge` is its own CMake target:
-
-```cmake
-add_library(haze_replay_bridge SHARED src/openfhe_template.cpp ...)
-target_link_libraries(haze_replay_bridge PUBLIC Niobium::fhetch)
-```
-
-The top-level `CMakeLists.txt` links it into `libhaze` privately so the
-`fhetch::result` overloads resolve, but downstream consumers of `libhaze`
-do not need OpenFHE headers or libraries on their own link line.
-
-A few subtleties worth knowing if you touch the CMake graph:
-
-- The bridge compiles its own copy of `src/common/log.cpp` from haze.
-  Both copies are hidden-visibility, so there is no exported-symbol
-  collision when `haze_tests` links both libraries.
-- `target_compile_options` narrows OpenFHE's noisy diagnostics
-  (`-Wno-pedantic -Wno-shadow -Wno-conversion -Wno-unused-parameter
-  -Wno-deprecated-declarations` and friends). Haze proper keeps strict
-  diagnostics; the warning suppression stays scoped to this target.
-- `HAZE_BUILDING_LIBRARY` is defined privately so `HAZE_API` resolves to
-  the export macro on this side of the boundary.
-
-## Private libnbfhetch hooks
-
-The bridge calls four detail-namespace symbols that are intentionally
-not part of fhetch's public API (`compiler_internal.h` is private to
-libnbfhetch's `src/` tree):
-
-| Symbol                                  | Purpose                                                                            |
-| --------------------------------------- | ---------------------------------------------------------------------------------- |
-| `niobium::detail::write_ciphertext_template`   | Serialize a CT shell to `ciphertext_templates/<name>.template`.            |
-| `niobium::detail::write_ciphertext_input_bin`  | Serialize a populated CT to `<prog>.input_<name>.bin` + `.ids` at the program-dir root. |
-| `niobium::detail::for_each_captured_input`     | Iterate every distinct `fhetch::tag_input` with shape + values + addr_ids.  |
-| `niobium::detail::for_each_captured_output`    | Iterate every `fhetch::tag_output` with shape information.                  |
-
-They are forward-declared in `openfhe_template.cpp` because the cereal
-polymorphic-type registrations live in libnbfhetch's TU; inlining the
-calls into the bridge would throw "unregistered polymorphic type" on
-macOS, where the registry is per-dylib.
-
-## Why a separate dylib at all
-
-Three reasons, in decreasing order of importance:
-
-1. **Symbol isolation.** OpenFHE pulls in cereal, an N-tower
-   `DCRTPoly` template instantiation graph, and a static
-   CC ↔ Ciphertext registry. Compiling that into every haze translation
-   unit balloons build times and forces every downstream consumer of
-   `libhaze` to ship OpenFHE. Keeping it in one TU behind a stable C ABI
-   is much cheaper.
-2. **Warning hygiene.** OpenFHE headers trip every `-W` in haze's
-   strict set. Suppressing them at file scope inside haze would leak the
-   suppression; isolating them to a target lets haze proper stay
-   `-Werror -Wpedantic -Wshadow -Wconversion` clean.
-3. **Two-way handoff.** The bridge implements both halves of the
-   OpenFHE round trip: it writes the artifacts the replay path needs
-   (`cryptocontext.dat`, `<prog>.input_*.bin/.ids`,
-   `ciphertext_templates/*.template`) and it reads the artifacts the
-   replay path produces (`serialized_probes/*.ct`). Co-locating them keeps the
-   shape-to-CT-geometry logic in one place — change the SRPArray /
-   MRPArray rules in `synthesize_haze_array_ciphertext` and the
-   `MRPArray` overload of `result(...)` together.
-
-## File layout
-
-```
-replay_bridge/
-  CMakeLists.txt                         # haze_replay_bridge target
-  include/haze/replay_bridge.h           # public C ABI (2 entry points)
-  src/openfhe_template.cpp               # the entire bridge:
-                                         #   - CC cache + builders
-                                         #   - shape dispatch (SRP/MRP/*Array)
-                                         #   - on_post_recording hook
-                                         #   - fhetch::result(...) overloads
-```
-
-## See also
-
-- [`../README.md`](../README.md) — haze overall and the record/replay
-  execution model.
-- [`../CLAUDE.md`](../CLAUDE.md) — working notes, including the macOS
-  SDK / ABI mismatch trap, which is most often diagnosed by checking
-  the bridge dylib's `LC_BUILD_VERSION`.
-- [`../vendor/niobium-fhetch/include/niobium/compiler.h`](../vendor/niobium-fhetch/include/niobium/compiler.h)
-  — `capture_crypto_context`, `set_post_recording_hook`, and the
-  captured-input / captured-output iteration surface the bridge plugs
-  into.
-- [`../test/integration_helpers.hpp`](../test/integration_helpers.hpp)
-  — the canonical caller (`setup_integration_compute_config`).
+| Path                                       | What                                                  |
+| ------------------------------------------ | ----------------------------------------------------- |
+| `include/haze/replay_bridge.h`             | Two-symbol public C ABI.                              |
+| `src/openfhe_template.cpp`                 | Everything else: CC cache, shape dispatch (SRP/MRP/SRPArray/MRPArray), `on_post_recording` hook, `fhetch::result` overloads. |
+| `CMakeLists.txt`                           | Builds `haze_replay_bridge` SHARED, linked PRIVATE into `libhaze`. |

--- a/replay_bridge/README.md
+++ b/replay_bridge/README.md
@@ -41,11 +41,11 @@ flowchart TB
   bridge -->|capture_crypto_context<br/>set_post_recording_hook| fhetch
   bridge -->|GenCryptoContext, KeyGen,<br/>Encrypt, SerializeToFile| openfhe
   fhetch -.->|stop_epoch calls<br/>on_post_recording| bridge
-  fhetch -->|.fhetch trace +<br/>cryptocontext.dat +<br/>inputs/*.bin +<br/>ciphertext_templates/*.template| sim
+  fhetch -->|.fhetch trace +<br/>cryptocontext.dat +<br/>&lt;prog&gt;.input_*.bin/.ids +<br/>ciphertext_templates/*.template| sim
   fhetch -->|same artifacts over HTTP| transport
   sim -.->|serialized_probes/&lt;name&gt;.ct| bridge
   transport -.->|serialized_probes/&lt;name&gt;.ct| bridge
-  bridge -->|fhetch::result(name, Polynomial / MRP / MRPArray)| haze
+  bridge -->|"fhetch::result(name, Polynomial / MRP / MRPArray)"| haze
 
   classDef user fill:#fef3c7,stroke:#b45309,color:#000
   classDef haze fill:#dbeafe,stroke:#1e40af,color:#000
@@ -86,7 +86,7 @@ sequenceDiagram
   loop for each captured input
     B->>O: Encrypt zeros, trim to shape, fill_native_poly
     B->>F: write_ciphertext_input_bin(name, ct, addr_ids)
-    F->>FS: inputs/&lt;name&gt;.bin + &lt;name&gt;.ids
+    F->>FS: &lt;prog&gt;.input_&lt;name&gt;.bin + &lt;prog&gt;.input_&lt;name&gt;.ids
   end
   loop for each captured output
     B->>O: build empty CT shell of matching shape
@@ -241,7 +241,7 @@ libnbfhetch's `src/` tree):
 | Symbol                                  | Purpose                                                                            |
 | --------------------------------------- | ---------------------------------------------------------------------------------- |
 | `niobium::detail::write_ciphertext_template`   | Serialize a CT shell to `ciphertext_templates/<name>.template`.            |
-| `niobium::detail::write_ciphertext_input_bin`  | Serialize a populated CT to `inputs/<name>.{bin,ids}`.                      |
+| `niobium::detail::write_ciphertext_input_bin`  | Serialize a populated CT to `<prog>.input_<name>.bin` + `.ids` at the program-dir root. |
 | `niobium::detail::for_each_captured_input`     | Iterate every distinct `fhetch::tag_input` with shape + values + addr_ids.  |
 | `niobium::detail::for_each_captured_output`    | Iterate every `fhetch::tag_output` with shape information.                  |
 
@@ -266,9 +266,9 @@ Three reasons, in decreasing order of importance:
    `-Werror -Wpedantic -Wshadow -Wconversion` clean.
 3. **Two-way handoff.** The bridge implements both halves of the
    OpenFHE round trip: it writes the artifacts the replay path needs
-   (`cryptocontext.dat`, `inputs/*.bin`, `ciphertext_templates/*`) and
-   it reads the artifacts the replay path produces
-   (`serialized_probes/*.ct`). Co-locating them keeps the
+   (`cryptocontext.dat`, `<prog>.input_*.bin/.ids`,
+   `ciphertext_templates/*.template`) and it reads the artifacts the
+   replay path produces (`serialized_probes/*.ct`). Co-locating them keeps the
    shape-to-CT-geometry logic in one place — change the SRPArray /
    MRPArray rules in `synthesize_haze_array_ciphertext` and the
    `MRPArray` overload of `result(...)` together.

--- a/replay_bridge/README.md
+++ b/replay_bridge/README.md
@@ -26,71 +26,66 @@ The bridge solves two problems:
 ## How it sits in the haze stack
 
 The diagram below reads top to bottom in usage order. Three arrow
-conventions:
+conventions: solid (`-->`) is a direct symbol call, thick (`==>`) is a
+filesystem **write** (label names the file), and dashed (`-.->`) is a
+filesystem **read** (label names the file).
 
-- **Solid (`-->`)** is a direct symbol call between libraries. Labels name
-  the function. Callbacks (libnbfhetch firing back into the bridge) are
-  solid too, labeled "fires X".
-- **Thick (`==>`)** is a filesystem write. Labels name the file being
-  written, so producer ownership is unambiguous.
-- **Dashed (`-.->`)** is a filesystem read. Labels name the file being
-  read.
-
-`program_dir/` is broken into one node per artifact so each `==>` and
-`-.->` can point at exactly the file it touches.
+`program_dir/` holds two kinds of artifact: **ciphertext data** (every
+OpenFHE-serialized file — CC, per-input ciphertexts, output templates,
+output probes) and the **`.fhetch` trace** (libnbfhetch's polynomial-op
+schedule). Splitting them this way makes the bridge's job obvious: it
+owns every byte on the ciphertext-data side, both writing it before
+replay and reading it after.
 
 ```mermaid
 flowchart TB
   app["Customer C / C++ application"]:::user
   haze["libhaze<br/>record-and-replay engine"]:::haze
-  bridge["haze_replay_bridge<br/>OpenFHE artifact producer + reader"]:::bridge
+  bridge["haze_replay_bridge<br/>post-recording adapter:<br/>libnbfhetch captured records ⇄ OpenFHE Ciphertext bytes"]:::bridge
   fhetch["libnbfhetch<br/>FHETCH IR recorder + replay dispatcher"]:::fhetch
   openfhe["OpenFHE"]:::ofh
 
   subgraph fs ["program_dir/"]
     direction TB
-    fs_cc["cryptocontext.dat"]:::fs_file
-    fs_trace[".fhetch trace"]:::fs_file
-    fs_inputs["prog.input_NAME.bin/.ids"]:::fs_file
-    fs_tmpl["ciphertext_templates/NAME.template"]:::fs_file
-    fs_probes["serialized_probes/NAME.ct"]:::fs_file
+    ct_data["Ciphertext data (OpenFHE-serialized)<br/>cryptocontext.dat<br/>prog.input_NAME.bin / .ids<br/>ciphertext_templates/NAME.template<br/>serialized_probes/NAME.ct"]:::fs_file
+    trace[".fhetch trace<br/>(polynomial-op schedule)"]:::fs_file
   end
 
   replay["Replay target (HAZE_TARGET):<br/>local → in-process simulator<br/>FUNC_SIM / FHE_SIM / FPGA_TRI → nbcc_fhetch_replay over HTTP"]:::backend
 
-  %% (1) Init: bridge primes the directory with the CC and registers its
-  %% post-recording callback.
-  app -->|"1. hazeReplayBridgeInitCryptoContext"| bridge
-  bridge -->|"GenCryptoContext, KeyGen,<br/>Encrypt, DeserializeFromFile"| openfhe
-  bridge -->|"capture_crypto_context,<br/>set_post_recording_hook"| fhetch
-  bridge ==>|"writes cryptocontext.dat"| fs_cc
+  bridge ---|"all OpenFHE work:<br/>GenCryptoContext, KeyGen,<br/>build Ciphertext shells,<br/>DeserializeFromFile"| openfhe
 
-  %% (2) Record: libhaze appends to libnbfhetch's in-memory IR.
+  %% (1) Init: bridge primes the CC, registers its callback.
+  app -->|"1. hazeReplayBridgeInitCryptoContext"| bridge
+  bridge -->|"capture_crypto_context,<br/>set_post_recording_hook"| fhetch
+  bridge ==>|"1. writes cryptocontext.dat"| ct_data
+
+  %% (2) Record: libhaze streams IR nodes into libnbfhetch.
   app -->|"2. hazeMalloc, hazeMemcpy(H2D),<br/>hazeAdd, hazeMul, ..."| haze
-  haze -->|"sr_*, tag_input"| fhetch
+  haze -->|"sr_*, tag_input, tag_output"| fhetch
 
   %% (3, 4) D2H -> stop_epoch -> post-recording callback.
   app -->|"3. hazeMemcpy(D2H)"| haze
-  haze -->|"tag_output, stop_epoch"| fhetch
-  fhetch ==>|"writes .fhetch trace"| fs_trace
+  haze -->|"stop_epoch"| fhetch
+  fhetch ==>|"3. writes .fhetch trace"| trace
   fhetch -->|"4. fires on_post_recording"| bridge
 
-  %% (5) Inside the callback, the bridge writes the OpenFHE-side inputs.
-  bridge ==>|"5. writes prog.input_NAME.bin/.ids"| fs_inputs
-  bridge ==>|"5. writes ciphertext_templates/NAME.template"| fs_tmpl
+  %% (5) THE ADAPTER STEP. The hook reads libnbfhetch's captured-input /
+  %% captured-output records (per-residue values, shape, addr_ids), builds
+  %% matching OpenFHE Ciphertext<DCRTPoly> objects, and serializes them.
+  bridge -->|"5a. reads captured records:<br/>per-residue values, shape, addr_ids"| fhetch
+  bridge ==>|"5b. writes input ciphertexts +<br/>output templates"| ct_data
 
-  %% (6) Replay reads every input artifact and writes per-output probes.
+  %% (6) Replay reads both artifact kinds and produces probes.
   haze -->|"6. replay()"| fhetch
   fhetch -->|"dispatch"| replay
-  fs_cc -.->|"reads cryptocontext.dat"| replay
-  fs_trace -.->|"reads .fhetch trace"| replay
-  fs_inputs -.->|"reads prog.input_NAME.bin/.ids"| replay
-  fs_tmpl -.->|"reads ciphertext_templates/NAME.template"| replay
-  replay ==>|"writes serialized_probes/NAME.ct"| fs_probes
+  trace -.->|"reads .fhetch trace"| replay
+  ct_data -.->|"reads CC + inputs + templates"| replay
+  replay ==>|"6. writes serialized_probes/NAME.ct"| ct_data
 
   %% (7) Bridge reads probes back via fhetch::result.
   haze -->|"7. fhetch::result(name, ...)"| bridge
-  fs_probes -.->|"reads serialized_probes/NAME.ct"| bridge
+  ct_data -.->|"reads serialized_probes/NAME.ct"| bridge
   bridge -->|"fhetch::Polynomial / MRP / MRPArray"| haze
 
   classDef user fill:#fef3c7,stroke:#b45309,color:#000
@@ -102,13 +97,25 @@ flowchart TB
   classDef backend fill:#f1f5f9,stroke:#334155,color:#000
 ```
 
-A small implementation note: the byte-level filesystem writes for the
-three bridge-owned files actually happen inside libnbfhetch's translation
-unit (the `niobium::detail::write_*` helpers in [Private libnbfhetch
-hooks](#private-libnbfhetch-hooks) below). That is a cereal-registration
-trick — the polymorphic-type registry has to resolve in the same dylib —
-but the **content**, **timing**, and **decision to write at all** are
-the bridge's, so the diagram attributes those three files to the bridge.
+**Step 5 is the bridge's reason to exist.** The `on_post_recording` hook
+fires _after_ libnbfhetch has finished recording the `.fhetch` trace but
+_before_ replay starts. It pulls libnbfhetch's in-memory captured records
+(per-residue `uint64_t` values, a `CapturedKind` shape tag, and the
+FHETCH `addr_ids` that name each tower), builds a corresponding
+`Ciphertext<DCRTPoly>` via OpenFHE — filled for inputs, empty for
+outputs — and serializes it into the ciphertext-data side of
+`program_dir/`. Without step 5 the replay target has nothing to feed
+into the trace and no output shells to stamp; with it, the replay
+target's IO boundary is pure OpenFHE-serialized ciphertexts. Step 7 is
+the reverse half of the same adapter: deserialize a probe `.ct` and
+hand the values back as an `fhetch::` type.
+
+(Implementation note: the byte-level writes in steps 1, 5b, and the
+trace dump go through libnbfhetch's translation unit — the
+`niobium::detail::write_*` helpers in
+[Private libnbfhetch hooks](#private-libnbfhetch-hooks) — so cereal's
+polymorphic-type registry resolves in the right dylib. The decision to
+write, the content, and the timing are still the bridge's.)
 
 ### How the bridge gets invoked
 

--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -4,42 +4,11 @@
 // agreement signed by a duly authorized officer of Niobium Microsystems,
 // Inc. (a "License Agreement").
 //
-// haze_replay_bridge — OpenFHE-using helper that synthesizes the artifacts
-// downstream replay paths need to produce serialized_probes/ from a haze
-// recording. Specifically:
-//
-//   1. <program_dir>/cryptocontext.dat
-//      A minimal CKKS CryptoContext<DCRTPoly> matching haze's configured
-//      ring dimension and (single) modulus.
-//
-//   2. <program_dir>/ciphertext_templates/<name>.template
-//      An empty Ciphertext<DCRTPoly> shell. The replay path fills it with
-//      simulator-computed polynomial values and re-serializes to
-//      <program_dir>/serialized_probes/<name>.ct.
-//
-// Same artifact shapes are consumed by both the in-process simulator
-// path (HAZE_TARGET=local, libnbfhetch fills + serializes the
-// templates) AND the HTTP transport path (HAZE_TARGET=FUNC_SIM etc.,
-// nbcc_fhetch_replay does the same). The bridge is therefore agnostic
-// to which replay tier the caller selects.
-//
-// The bridge is the OpenFHE boundary for haze: libhaze sources stay
-// FHETCH-only (no OpenFHE includes), but libhaze links the bridge to
-// resolve niobium::fhetch::result(...) references from epoch.cpp.
-//
-// Usage (in an integration test):
-//
-//     // Once per program directory: build CC, learn the picked modulus.
-//     uint64_t picked = 0;
-//     hazeReplayBridgeInitCryptoContext(kRingDim, kDesiredModulus, &picked);
-//     hazeSetCiphertextModulus(kModIdx, picked);
-//
-//     // Per-input .bin / .ids and per-output .template files are written
-//     // automatically inside the D2H-triggered replay via a post-recording
-//     // hook the bridge registers during InitCryptoContext. Tests just
-//     // compute and read back via hazeMemcpy(D2H).
-//     hazeMemcpy(host, dev, bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
-//     // Both in-process simulator and HTTP transport go through this path.
+// haze_replay_bridge — OpenFHE boundary for haze: synthesizes cryptocontext.dat
+// and per-output ciphertext_templates/<name>.template that the replay path
+// (in-process simulator or HTTP transport) consumes to emit serialized_probes/
+// <name>.ct. libhaze stays FHETCH-only and links the bridge for
+// niobium::fhetch::result(...) resolution.
 
 #ifndef HAZE_REPLAY_BRIDGE_H
 #define HAZE_REPLAY_BRIDGE_H
@@ -54,31 +23,17 @@
 extern "C" {
 #endif
 
-/// Build a single-limb CKKS CryptoContext targeting the given ring dimension
-/// and modulus, and serialize it to <program_dir>/cryptocontext.dat.
-///
-/// OpenFHE chooses the actual tower modulus from primes near 2^bits(modulus),
-/// so the picked modulus may differ from the requested one. The picked value
-/// is returned via `picked_modulus` (must be non-null) so callers can align
-/// haze's configured modulus with what the .ct files will use on round-trip
-/// (call hazeSetCiphertextModulus with this value).
-///
-/// Subsequent calls with the same (ring_dim, desired_modulus) reuse the
-/// cached CryptoContext. Calls with different parameters rebuild it; the
-/// previously serialized cryptocontext.dat is overwritten.
-///
-/// niobium::compiler() must already be initialized (i.e. at least one haze
-/// compute call must have happened, or hazeConfigureDevice must have been
-/// called) so the program directory resolves correctly.
-///
-/// Must be called AFTER every hazeDeviceReset(): reset clears the post-
-/// recording hook this function registers, and without re-registration
-/// the next D2H-triggered replay ships an incomplete project (no .bin /
-/// .ids / .template files), which the compiler-side rejects. The
-/// setup_integration_compute_config helper enforces this ordering
-/// automatically.
+/// Build a CKKS CryptoContext for (ring_dim, desired_modulus), write
+/// cryptocontext.dat, and return the OpenFHE-picked modulus via
+/// `picked_modulus` (non-null) so callers can align via hazeSetCiphertextModulus.
+/// Must be re-called after every hazeDeviceReset (setup_integration_compute_config
+/// enforces this; the post-recording hook is cleared by reset).
 HAZE_API hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim, uint64_t desired_modulus,
                                                        uint64_t *picked_modulus) HAZE_NOEXCEPT;
+
+/// Drop the bridge's cached CryptoContexts so they don't outlive a
+/// hazeDeviceReset; idempotent and safe to call before init.
+HAZE_API void hazeReplayBridgeReset(void) HAZE_NOEXCEPT;
 
 #ifdef __cplusplus
 }

--- a/replay_bridge/include/haze/replay_bridge_cc.hpp
+++ b/replay_bridge/include/haze/replay_bridge_cc.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+//
+// Bridge C++ entry point for callers that build their own CryptoContext
+// (FIDESlib, integration tests with a specific scaling technique, etc.).
+// libhaze still consumes only the C ABI in replay_bridge.h; this header
+// is for downstream C++ TUs that link the bridge directly.
+
+#pragma once
+
+#include <haze/haze_types.h>
+#include <openfhe.h>
+
+namespace haze {
+
+// Register a caller-built CryptoContext + KeyPair for template synthesis;
+// the bridge uses these instead of building its own. Replaces
+// hazeReplayBridgeInitCryptoContext when the caller needs control over
+// scaling technique, chain length, or other CC parameters.
+//
+// The CC's chain length must be >= the largest residue count any output
+// uses; smaller-residue templates are produced by trimming towers from a
+// fresh encryption. Callers are responsible for aligning
+// hazeSetCiphertextModulus(i, q) with the CC's chain.
+HAZE_API hazeError_t
+hazeReplayBridgeRegisterCryptoContext(const lbcrypto::CryptoContext<lbcrypto::DCRTPoly> &cc,
+                                      const lbcrypto::KeyPair<lbcrypto::DCRTPoly> &keys) noexcept;
+
+} // namespace haze

--- a/replay_bridge/include/haze/replay_bridge_cc.hpp
+++ b/replay_bridge/include/haze/replay_bridge_cc.hpp
@@ -17,14 +17,15 @@
 namespace haze {
 
 // Register a caller-built CryptoContext + KeyPair for template synthesis;
-// the bridge uses these instead of building its own. Replaces
-// hazeReplayBridgeInitCryptoContext when the caller needs control over
-// scaling technique, chain length, or other CC parameters.
+// the bridge uses these instead of building its own. The CC's chain length
+// must be >= the largest residue count any output uses, and the caller is
+// responsible for aligning the CC's ring_dim with hazeSetRingDimension and
+// hazeSetCiphertextModulus(i, q) with the primes the chain carries.
 //
-// The CC's chain length must be >= the largest residue count any output
-// uses; smaller-residue templates are produced by trimming towers from a
-// fresh encryption. Callers are responsible for aligning
-// hazeSetCiphertextModulus(i, q) with the CC's chain.
+// Replaces any previously-registered CC (or one built via the C-entry
+// hazeReplayBridgeInitCryptoContext). Must be re-called after every
+// hazeDeviceReset, which clears the bridge's CC slot and the
+// post-recording hook.
 HAZE_API hazeError_t
 hazeReplayBridgeRegisterCryptoContext(const lbcrypto::CryptoContext<lbcrypto::DCRTPoly> &cc,
                                       const lbcrypto::KeyPair<lbcrypto::DCRTPoly> &keys) noexcept;

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -18,7 +18,6 @@
 
 #include <algorithm>
 #include <bit>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <exception>
@@ -27,7 +26,6 @@
 #include <functional>
 #include <haze/haze_types.h>
 #include <haze/replay_bridge.h>
-#include <limits>
 #include <map>
 #include <memory>
 #include <niobium/compiler.h>
@@ -77,7 +75,6 @@ using DCRTPoly = lbcrypto::DCRTPoly;
 // BridgeError surfaces specific failure modes from the C-ABI entry; lives
 // in this TU because there's exactly one caller and one implementation.
 enum class BridgeError : uint8_t {
-    InvalidRingDim,
     InvalidModulus,
     KeygenFailed,
     OpenFheUnavailable,
@@ -96,31 +93,16 @@ struct CachedContext {
     lbcrypto::KeyPair<DCRTPoly> keys;
 };
 
-// Cache key: ring_dim plus the user-requested moduli vector (lex-compared).
-struct ContextKey {
-    uint64_t ring_dim;
-    std::vector<uint64_t> moduli;
-    bool operator<(const ContextKey &o) const {
-        if (ring_dim != o.ring_dim)
-            return ring_dim < o.ring_dim;
-        return moduli < o.moduli;
-    }
-};
-
-std::map<ContextKey, CachedContext> g_ctx_cache;
-// Primary CC key: the entry that init seeded and that captured
+// Cache keyed by user-requested moduli; ring_dim is pinned per process via
+// hazeSetRingDimension, and reset_bridge_caches wipes the cache on every
+// hazeDeviceReset, so the moduli vector alone disambiguates entries.
+std::map<std::vector<uint64_t>, CachedContext> g_ctx_cache;
+// Primary CC moduli: the entry that init seeded and that captured
 // cryptocontext.dat; nullopt before init / after reset_bridge_caches.
-std::optional<ContextKey> g_primary_key;
+std::optional<std::vector<uint64_t>> g_primary_key;
 // Program directory snapshotted at init so reset_bridge_caches's disk
 // cleanup is independent of niobium::compiler().reset() ordering.
 fs::path g_program_dir;
-
-// Bit width of a CKKS prime modulus; assert ≥2 since GenCryptoContext
-// rejects smaller upstream and the caller path has already validated.
-uint32_t bit_width_for_modulus(uint64_t modulus) {
-    assert(modulus >= 2);
-    return static_cast<uint32_t>(std::bit_width(modulus));
-}
 
 // Build or look up a CryptoContext + keypair: moduli.size() == 1 → depth-0
 // single-tower CC; >1 → depth-(N-1) chain with one tower per residue. On
@@ -128,20 +110,10 @@ uint32_t bit_width_for_modulus(uint64_t modulus) {
 std::expected<const CachedContext *, BridgeError>
 get_or_build_context_locked(uint64_t ring_dim, const std::vector<uint64_t> &moduli) {
     using namespace lbcrypto;
-    // ring_dim must be ≥2 (CKKS packs N/2 slots) and within uint32_t (SetRingDim
-    // takes usint, so anything bigger silently truncates at the cast below).
-    if (ring_dim < 2 || ring_dim > std::numeric_limits<uint32_t>::max())
-        return std::unexpected(BridgeError::InvalidRingDim);
     if (moduli.empty())
         return std::unexpected(BridgeError::InvalidModulus);
-    // q<4 underflows SetScalingModSize(min_bits - 1) and is too small for CKKS.
-    for (auto q : moduli) {
-        if (q < 4)
-            return std::unexpected(BridgeError::InvalidModulus);
-    }
 
-    ContextKey key{.ring_dim = ring_dim, .moduli = moduli};
-    auto it = g_ctx_cache.find(key);
+    auto it = g_ctx_cache.find(moduli);
     if (it != g_ctx_cache.end())
         return &it->second;
 
@@ -153,18 +125,19 @@ get_or_build_context_locked(uint64_t ring_dim, const std::vector<uint64_t> &modu
     p.SetMultiplicativeDepth(static_cast<uint32_t>(moduli.size() - 1));
     // First-mod bit-width tracks the primary modulus; scaling-mod tracks the
     // smallest remaining modulus, minus 1 per OpenFHE's scalingModSize+1 rule.
-    const uint32_t first_bits = bit_width_for_modulus(moduli.front());
+    const auto first_bits = static_cast<uint32_t>(std::bit_width(moduli.front()));
     p.SetFirstModSize(first_bits);
     if (moduli.size() == 1) {
         p.SetScalingModSize(first_bits - 1);
     } else {
-        uint32_t min_bits = bit_width_for_modulus(moduli[1]);
+        auto min_bits = static_cast<uint32_t>(std::bit_width(moduli[1]));
         for (size_t i = 2; i < moduli.size(); ++i)
-            min_bits = std::min(min_bits, bit_width_for_modulus(moduli[i]));
+            min_bits = std::min(min_bits, static_cast<uint32_t>(std::bit_width(moduli[i])));
         p.SetScalingModSize(min_bits - 1);
     }
-    // FIXEDMANUAL: these CTs are structural shells, never EvalMult'd, so
-    // auto-rescale would only churn the chain.
+    // FIXEDMANUAL: these CTs are structural shells, never EvalMult'd; default
+    // (FLEXIBLEAUTO) reshapes the chain during GenCryptoContext and breaks
+    // the bridge's depth-(N-1)→N-tower assumption for MRP templates.
     p.SetScalingTechnique(FIXEDMANUAL);
 
     auto cc = GenCryptoContext(p);
@@ -194,7 +167,7 @@ get_or_build_context_locked(uint64_t ring_dim, const std::vector<uint64_t> &modu
     entry.picked_moduli = std::move(picked);
     entry.cc = cc;
     entry.keys = keys;
-    auto [ins, _] = g_ctx_cache.emplace(std::move(key), std::move(entry));
+    auto [ins, _] = g_ctx_cache.emplace(moduli, std::move(entry));
     return &ins->second;
 }
 
@@ -239,7 +212,6 @@ void reset_bridge_caches() {
 // diagnostics, but the public surface is intentionally coarser.
 hazeError_t to_haze_error(BridgeError e) {
     switch (e) {
-    case BridgeError::InvalidRingDim:
     case BridgeError::InvalidModulus:
         return HAZE_ERROR_INVALID_VALUE;
     case BridgeError::KeygenFailed:
@@ -603,7 +575,7 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         if (!built)
             return to_haze_error(built.error());
 
-        g_primary_key = ContextKey{.ring_dim = ring_dim, .moduli = primary_moduli};
+        g_primary_key = std::move(primary_moduli);
 
         // capture_crypto_context populates ring/chain and serializes
         // cryptocontext.dat inside libnbfhetch's TU; push_crypto_to_compiler

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -83,11 +83,12 @@ enum class BridgeError : uint8_t {
 // Per-process CC cache: SRP outputs use a depth-0 single-tower CC, MRP
 // outputs use depth-(N-1) chains, all sharing OpenFHE's static
 // CC<->Ciphertext registry. picked_moduli records OpenFHE's chosen primes
-// (it picks by bit-width); rewrite_tower_moduli swaps them back to the
-// user-requested values at synthesis time.
+// (it picks by bit-width); only used by hazeReplayBridgeInitCryptoContext's
+// return value — reconstruct_probes overwrites per-tower moduli from the
+// trace before serializing .ct, so OpenFHE's picks aren't observable to readers.
 struct CachedContext {
     uint64_t ring_dim = 0;
-    std::vector<uint64_t> moduli;        // user-requested base
+    std::vector<uint64_t> moduli;        // user-requested base (cache key)
     std::vector<uint64_t> picked_moduli; // OpenFHE-picked primes per tower
     lbcrypto::CryptoContext<DCRTPoly> cc;
     lbcrypto::KeyPair<DCRTPoly> keys;
@@ -264,34 +265,10 @@ lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_ciphertext(const CachedContext &c
     return ct;
 }
 
-// Replace each tower's modulus with the user-requested value; OpenFHE picks
-// bits-near primes that are invisible to SRP readers but visible to MRP
-// (mrp.base() from GetModulus()), and the simulator preserves the
-// template's modulus when emitting probes, so the override has to happen here.
-void rewrite_tower_moduli(lbcrypto::DCRTPoly &dcrt, const std::vector<uint64_t> &user_moduli,
-                          uint32_t ring_dim) {
-    auto &towers = dcrt.GetAllElements();
-    if (towers.size() != user_moduli.size()) {
-        // CC was built for these moduli, so a mismatch means OpenFHE produced
-        // an unexpected chain; log it before the loop silently truncates.
-        std::ostringstream body;
-        body << "rewrite_tower_moduli: tower count " << towers.size() << " != user_moduli.size() "
-             << user_moduli.size();
-        haze::log_error("replay_bridge", body.str());
-    }
-    for (size_t i = 0; i < towers.size() && i < user_moduli.size(); ++i) {
-        const auto fmt = towers[i].GetFormat();
-        auto params = std::make_shared<lbcrypto::ILNativeParams>(
-            2 * ring_dim, lbcrypto::NativeInteger(user_moduli[i]));
-        // initializeElementToZero=true populates a length-ring_dim NativeVector;
-        // a later fill_native_poly overwrites with simulator-fed values.
-        towers[i] = lbcrypto::NativePoly(params, fmt, /*initializeElementToZero=*/true);
-    }
-}
-
 // Build a 1-element / N-tower CT for an MRP output (empty
-// per_residue_values → template shell). Tower moduli are rewritten to the
-// user base so result(name, MRP&) returns mrp.base() == moduli.
+// per_residue_values → template shell). The template's tower moduli are
+// OpenFHE's picks; reconstruct_probes overwrites them with the trace's
+// per-residue moduli before serializing the on-disk .ct.
 lbcrypto::Ciphertext<DCRTPoly>
 synthesize_haze_mrp_ciphertext(const CachedContext &ctx, const std::vector<uint64_t> &moduli,
                                const std::vector<std::vector<uint64_t>> &per_residue_values) {
@@ -305,9 +282,8 @@ synthesize_haze_mrp_ciphertext(const CachedContext &ctx, const std::vector<uint6
              << " != moduli.size() " << moduli.size() << " — CC was built with the wrong depth";
         throw std::runtime_error(body.str());
     }
-    rewrite_tower_moduli(dcrt, moduli, static_cast<uint32_t>(ctx.ring_dim));
     if (per_residue_values.empty())
-        return ct; // template — moduli were just installed; values stay zero.
+        return ct; // template — reconstruct_probes installs trace moduli.
     if (per_residue_values.size() != moduli.size()) {
         std::ostringstream body;
         body << "synthesize_haze_mrp_ciphertext: per_residue_values.size()="
@@ -348,10 +324,6 @@ lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_array_ciphertext(
     elements.reserve(k_count);
     for (size_t k = 0; k < k_count; ++k) {
         auto ct_k = empty_one_element_ct(ctx);
-        if (shared_moduli.size() > 1) {
-            rewrite_tower_moduli(ct_k->GetElements()[0], shared_moduli,
-                                 static_cast<uint32_t>(ctx.ring_dim));
-        }
         elements.push_back(std::move(ct_k->GetElements()[0]));
     }
     auto ct = empty_one_element_ct(ctx);

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -159,7 +159,7 @@ get_or_build_context_locked(uint64_t ring_dim, const std::vector<uint64_t> &modu
     if (!element_params || element_params->GetParams().empty())
         return std::unexpected(BridgeError::OpenFheUnavailable);
 
-    CachedContext entry{cc, keys, ring_dim};
+    CachedContext entry{.cc = cc, .keys = keys, .ring_dim = ring_dim};
     auto [ins, _] = g_ctx_cache.emplace(moduli, std::move(entry));
     return &ins->second;
 }
@@ -607,7 +607,8 @@ HAZE_API hazeError_t hazeReplayBridgeRegisterCryptoContext(
         if (!element_params || element_params->GetParams().empty())
             return HAZE_ERROR_INVALID_VALUE;
 
-        g_user_ctx = CachedContext{cc, keys, element_params->GetRingDimension()};
+        g_user_ctx = CachedContext{
+            .cc = cc, .keys = keys, .ring_dim = element_params->GetRingDimension()};
         push_crypto_to_compiler(*g_user_ctx);
         return HAZE_SUCCESS;
     } catch (const std::exception &e) {

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -6,8 +6,10 @@
 //
 // haze_replay_bridge implementation: synthesize the CryptoContext, per-input
 // .bin files, and per-output templates the simulator / nbcc_fhetch_replay
-// consume to emit serialized_probes/<name>.ct. Called only from the epoch
-// path under EpochState::mutex_, so no internal lock is needed.
+// consume to emit serialized_probes/<name>.ct. Setup entries (Init/Register)
+// are called from test setup outside any lock; on_post_recording runs under
+// EpochState::mutex_. Bridge globals are race-free by the convention that
+// setup completes before any compute begins.
 
 #include "ciphertext-ser.h"
 #include "common/log.hpp"
@@ -81,18 +83,12 @@ enum class BridgeError : uint8_t {
     OpenFheUnavailable,
 };
 
-// Per-process CC cache: SRP outputs use a depth-0 single-tower CC, MRP
-// outputs use depth-(N-1) chains, all sharing OpenFHE's static
-// CC<->Ciphertext registry. picked_moduli records OpenFHE's chosen primes
-// (it picks by bit-width); only used by hazeReplayBridgeInitCryptoContext's
-// return value — reconstruct_probes overwrites per-tower moduli from the
-// trace before serializing .ct, so OpenFHE's picks aren't observable to readers.
+// Thin bundle used by both the per-shape cache and the user-CC slot.
+// ring_dim is cached for hot-path access; everything else lives in `cc`.
 struct CachedContext {
-    uint64_t ring_dim = 0;
-    std::vector<uint64_t> moduli;        // user-requested base (cache key)
-    std::vector<uint64_t> picked_moduli; // OpenFHE-picked primes per tower
     lbcrypto::CryptoContext<DCRTPoly> cc;
     lbcrypto::KeyPair<DCRTPoly> keys;
+    uint64_t ring_dim = 0;
 };
 
 // Cache keyed by user-requested moduli; ring_dim is pinned per process via
@@ -162,19 +158,20 @@ get_or_build_context_locked(uint64_t ring_dim, const std::vector<uint64_t> &modu
     auto element_params = cc->GetCryptoParameters()->GetElementParams();
     if (!element_params || element_params->GetParams().empty())
         return std::unexpected(BridgeError::OpenFheUnavailable);
-    std::vector<uint64_t> picked;
-    picked.reserve(element_params->GetParams().size());
-    for (const auto &ep : element_params->GetParams())
-        picked.push_back(ep->GetModulus().ConvertToInt());
 
-    CachedContext entry;
-    entry.ring_dim = ring_dim;
-    entry.moduli = moduli;
-    entry.picked_moduli = std::move(picked);
-    entry.cc = cc;
-    entry.keys = keys;
+    CachedContext entry{cc, keys, ring_dim};
     auto [ins, _] = g_ctx_cache.emplace(moduli, std::move(entry));
     return &ins->second;
+}
+
+// First-tower modulus of `cc`'s chain. Throws if the chain is empty;
+// get_or_build_context_locked has already validated, so the throw is just
+// defensive for the caller-built path.
+uint64_t first_tower_modulus(const lbcrypto::CryptoContext<DCRTPoly> &cc) {
+    const auto &params = cc->GetCryptoParameters()->GetElementParams()->GetParams();
+    if (params.empty())
+        throw std::runtime_error("first_tower_modulus: empty element params");
+    return params.front()->GetModulus().ConvertToInt();
 }
 
 // Convenience accessor for the primary CC; returns nullptr before init.
@@ -582,7 +579,7 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         // also installs our post_recording_hook for stop()-time synthesis.
         push_crypto_to_compiler(**built);
 
-        *picked_modulus = (*built)->picked_moduli.front();
+        *picked_modulus = first_tower_modulus((*built)->cc);
         return HAZE_SUCCESS;
     } catch (const std::exception &e) {
         haze::log_error("replay_bridge", std::string{"init threw: "} + e.what());
@@ -610,15 +607,7 @@ HAZE_API hazeError_t hazeReplayBridgeRegisterCryptoContext(
         if (!element_params || element_params->GetParams().empty())
             return HAZE_ERROR_INVALID_VALUE;
 
-        CachedContext entry;
-        entry.ring_dim = element_params->GetRingDimension();
-        entry.cc = cc;
-        entry.keys = keys;
-        entry.picked_moduli.reserve(element_params->GetParams().size());
-        for (const auto &ep : element_params->GetParams())
-            entry.picked_moduli.push_back(ep->GetModulus().ConvertToInt());
-
-        g_user_ctx = std::move(entry);
+        g_user_ctx = CachedContext{cc, keys, element_params->GetRingDimension()};
         push_crypto_to_compiler(*g_user_ctx);
         return HAZE_SUCCESS;
     } catch (const std::exception &e) {

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <haze/haze_types.h>
 #include <haze/replay_bridge.h>
+#include <haze/replay_bridge_cc.hpp>
 #include <map>
 #include <memory>
 #include <niobium/compiler.h>
@@ -101,6 +102,10 @@ std::map<std::vector<uint64_t>, CachedContext> g_ctx_cache;
 // Primary CC moduli: the entry that init seeded and that captured
 // cryptocontext.dat; nullopt before init / after reset_bridge_caches.
 std::optional<std::vector<uint64_t>> g_primary_key;
+// User-registered CC (via hazeReplayBridgeRegisterCryptoContext). When set,
+// all template synthesis uses this one CC and trims towers per output shape;
+// the per-shape g_ctx_cache build path is skipped.
+std::optional<CachedContext> g_user_ctx;
 // Program directory snapshotted at init so reset_bridge_caches's disk
 // cleanup is independent of niobium::compiler().reset() ordering.
 fs::path g_program_dir;
@@ -173,7 +178,10 @@ get_or_build_context_locked(uint64_t ring_dim, const std::vector<uint64_t> &modu
 }
 
 // Convenience accessor for the primary CC; returns nullptr before init.
+// A user-registered CC takes precedence over the per-shape cache.
 const CachedContext *primary_ctx() {
+    if (g_user_ctx)
+        return &*g_user_ctx;
     if (!g_primary_key)
         return nullptr;
     auto it = g_ctx_cache.find(*g_primary_key);
@@ -186,6 +194,7 @@ const CachedContext *primary_ctx() {
 void reset_bridge_caches() {
     g_ctx_cache.clear();
     g_primary_key.reset();
+    g_user_ctx.reset();
     if (g_program_dir.empty())
         return; // bridge never initialized; nothing on disk
     try {
@@ -253,11 +262,26 @@ void fill_native_poly(lbcrypto::NativePoly &np, const std::vector<uint64_t> &val
     np.SetValues(nv, np.GetFormat());
 }
 
+// Trim the leading DCRTPoly's tower count down to `target`. Used to shape
+// a freshly-encrypted CT (which always has the CC's full chain length) into
+// an N-tower template for an N-residue output.
+void trim_towers_to(lbcrypto::DCRTPoly &dcrt, size_t target) {
+    auto current = dcrt.GetAllElements().size();
+    if (current < target) {
+        std::ostringstream body;
+        body << "trim_towers_to: CC chain has " << current << " towers, need " << target;
+        throw std::runtime_error(body.str());
+    }
+    if (current > target)
+        dcrt.DropLastElements(current - target);
+}
+
 // SRP entrypoint: build a 1-element / 1-tower CT and fill its NativePoly
 // with `values` (empty `values` produces a template).
 lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_ciphertext(const CachedContext &ctx,
                                                           const std::vector<uint64_t> &values) {
     auto ct = empty_one_element_ct(ctx);
+    trim_towers_to(ct->GetElements()[0], 1);
     if (values.empty())
         return ct; // template
     fill_native_poly(ct->GetElements()[0].GetAllElements()[0], values,
@@ -274,14 +298,7 @@ synthesize_haze_mrp_ciphertext(const CachedContext &ctx, const std::vector<uint6
                                const std::vector<std::vector<uint64_t>> &per_residue_values) {
     auto ct = empty_one_element_ct(ctx);
     auto &dcrt = ct->GetElements()[0];
-    if (dcrt.GetAllElements().size() != moduli.size()) {
-        // Throw rather than emit a wrong-shape template; on_post_recording
-        // catches and skips this output instead of corrupting the trace.
-        std::ostringstream body;
-        body << "synthesize_haze_mrp_ciphertext: tower count " << dcrt.GetAllElements().size()
-             << " != moduli.size() " << moduli.size() << " — CC was built with the wrong depth";
-        throw std::runtime_error(body.str());
-    }
+    trim_towers_to(dcrt, moduli.size());
     if (per_residue_values.empty())
         return ct; // template — reconstruct_probes installs trace moduli.
     if (per_residue_values.size() != moduli.size()) {
@@ -324,7 +341,9 @@ lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_array_ciphertext(
     elements.reserve(k_count);
     for (size_t k = 0; k < k_count; ++k) {
         auto ct_k = empty_one_element_ct(ctx);
-        elements.push_back(std::move(ct_k->GetElements()[0]));
+        auto &dcrt_k = ct_k->GetElements()[0];
+        trim_towers_to(dcrt_k, shared_moduli.size());
+        elements.push_back(std::move(dcrt_k));
     }
     auto ct = empty_one_element_ct(ctx);
     ct->SetElements(elements);
@@ -362,6 +381,10 @@ lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_array_ciphertext(
 // (TODO(niobium-fhetch:mod-map-tracking): fhetch's address_modulus_map
 // doesn't register every output before sync_fhetch_state_to_compiler).
 const CachedContext *context_for_shape(uint64_t ring_dim, const niobium::CapturedShape &shape) {
+    // User-registered CC mode: one CC for every shape, towers trimmed per
+    // output. Skip the per-shape build path entirely.
+    if (g_user_ctx)
+        return &*g_user_ctx;
     if (shape.per_element_moduli.empty())
         return primary_ctx();
     const auto &moduli = shape.per_element_moduli.front();
@@ -570,6 +593,38 @@ extern "C" void hazeReplayBridgeReset() noexcept {
     // hooks are cleared separately via niobium::compiler().reset().
     reset_bridge_caches();
 }
+
+namespace haze {
+
+HAZE_API hazeError_t hazeReplayBridgeRegisterCryptoContext(
+    const lbcrypto::CryptoContext<DCRTPoly> &cc, const lbcrypto::KeyPair<DCRTPoly> &keys) noexcept {
+    if (!cc || !keys.publicKey || !keys.secretKey)
+        return HAZE_ERROR_INVALID_VALUE;
+    try {
+        auto element_params = cc->GetCryptoParameters()->GetElementParams();
+        if (!element_params || element_params->GetParams().empty())
+            return HAZE_ERROR_INVALID_VALUE;
+
+        CachedContext entry;
+        entry.ring_dim = element_params->GetRingDimension();
+        entry.cc = cc;
+        entry.keys = keys;
+        entry.picked_moduli.reserve(element_params->GetParams().size());
+        for (const auto &ep : element_params->GetParams())
+            entry.picked_moduli.push_back(ep->GetModulus().ConvertToInt());
+
+        g_user_ctx = std::move(entry);
+        push_crypto_to_compiler(*g_user_ctx);
+        return HAZE_SUCCESS;
+    } catch (const std::exception &e) {
+        log_error("replay_bridge", std::string{"register_crypto_context threw: "} + e.what());
+        return HAZE_ERROR_LAUNCH_FAILURE;
+    } catch (...) {
+        return HAZE_ERROR_LAUNCH_FAILURE;
+    }
+}
+
+} // namespace haze
 
 // ============================================================================
 // fhetch::result() overloads — read serialized_probes/<name>.ct as

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -4,16 +4,10 @@
 // agreement signed by a duly authorized officer of Niobium Microsystems,
 // Inc. (a "License Agreement").
 //
-// haze_replay_bridge implementation: synthesize the CryptoContext +
-// per-input cereal-binary .bin files + per-output ciphertext templates that
-// the in-process FHETCH simulator AND compiler-side nbcc_fhetch_replay both
-// consume to write serialized_probes/<name>.ct from a haze recording.
-// See replay_bridge.h for the public API and architectural rationale.
-//
-// Thread-safety: the bridge is called only from haze's epoch path, which
-// already holds EpochState::mutex_, and from haze tests (single-threaded
-// catch2 runner). Bridge state is therefore implicitly serialized; no
-// internal lock needed.
+// haze_replay_bridge implementation: synthesize the CryptoContext, per-input
+// .bin files, and per-output templates the simulator / nbcc_fhetch_replay
+// consume to emit serialized_probes/<name>.ct. Called only from the epoch
+// path under EpochState::mutex_, so no internal lock is needed.
 
 #include "ciphertext-ser.h"
 #include "common/log.hpp"
@@ -22,6 +16,7 @@
 #include "openfhe.h"
 #include "scheme/ckksrns/ckksrns-ser.h"
 
+#include <algorithm>
 #include <bit>
 #include <cassert>
 #include <cstddef>
@@ -32,33 +27,27 @@
 #include <functional>
 #include <haze/haze_types.h>
 #include <haze/replay_bridge.h>
+#include <limits>
 #include <map>
+#include <memory>
 #include <niobium/compiler.h>
 #include <niobium/fhetch_api.h>
+#include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
-#include <utility>
+#include <system_error>
+#include <utility> // std::move, std::unreachable (C++23)
 #include <vector>
 
-// libnbfhetch internal helpers used by the bridge. Forward-declared here
-// rather than via "compiler_internal.h" because that header lives under
-// libnbfhetch's PRIVATE src/ tree and including it from a downstream
-// library would couple the bridge to libnbfhetch's source layout.
-//
-// Cereal's polymorphic-type registrations are per-shared-library on macOS:
-// inlining Serial::SerializeToFile here throws "unregistered polymorphic
-// type" on intnat::NativeVectorT (input bin path) and CryptoContextImpl
-// (template path) — empirically confirmed. The four detail symbols below
-// route the cereal calls through libnbfhetch's TU where the registrations
-// are live. Long-term, niobium-fhetch could publish a stable C++ API for
-// these so the bridge can include a header instead of forward-declaring.
+// libnbfhetch internal helpers; forward-declared because compiler_internal.h
+// is private to libnbfhetch's src/ tree. The detail symbols route cereal
+// serialization through libnbfhetch's TU where polymorphic-type registrations
+// live (inlining the calls throws "unregistered polymorphic type" on macOS).
 namespace niobium::detail {
 
-// Serialize an empty Ciphertext<DCRTPoly> shell to
-// <program_dir>/ciphertext_templates/<name>.template. The replay path
-// (in-process simulator or transport) deserializes this template,
-// fills its first NativePoly with computed values, and re-serializes
-// it as serialized_probes/<name>.ct.
+// Serialize a Ciphertext<DCRTPoly> shell to ciphertext_templates/<name>.template;
+// the replay path fills it and re-serializes as serialized_probes/<name>.ct.
 bool write_ciphertext_template(const std::string &name,
                                const lbcrypto::Ciphertext<lbcrypto::DCRTPoly> &ct);
 
@@ -69,15 +58,14 @@ bool write_ciphertext_input_bin(const std::string &name,
                                 const lbcrypto::Ciphertext<lbcrypto::DCRTPoly> &ct,
                                 const std::vector<uint64_t> &addr_ids);
 
-// Iterate every captured input recorded via fhetch::tag_input. The
-// callback receives (name, addr_id, modulus, values) for each per-name
-// element so the bridge can fan-out a single ciphertext per name.
-void for_each_captured_input(const std::function<void(const std::string &, uint64_t, uint64_t,
-                                                      const std::vector<uint64_t> &)> &cb);
+// Fires once per distinct fhetch::tag_input with a full record snapshot
+// (shape, addr_ids, per-residue values) so the bridge can dispatch on kind.
+void for_each_captured_input(const std::function<void(const niobium::CapturedInputRecord &)> &cb);
 
-// Iterate every captured output name recorded via fhetch::tag_output.
-// Callback fires once per output name.
-void for_each_captured_output(const std::function<void(const std::string &)> &cb);
+// Iterate captured outputs; the bridge dispatches on shape.kind to pick the
+// CT geometry (SRP=1×1, MRP=1×N, SRPArray=K×1, MRPArray=K×M_k).
+void for_each_captured_output(
+    const std::function<void(const std::string &, const niobium::CapturedShape &)> &cb);
 
 } // namespace niobium::detail
 
@@ -86,10 +74,8 @@ namespace {
 namespace fs = std::filesystem;
 using DCRTPoly = lbcrypto::DCRTPoly;
 
-// BridgeError surfaces specific failure modes from the C-ABI entry to
-// help callers diagnose synthesis issues. Lives in this file (rather
-// than a header) because there's exactly one caller and one
-// implementation TU.
+// BridgeError surfaces specific failure modes from the C-ABI entry; lives
+// in this TU because there's exactly one caller and one implementation.
 enum class BridgeError : uint8_t {
     InvalidRingDim,
     InvalidModulus,
@@ -97,81 +83,88 @@ enum class BridgeError : uint8_t {
     OpenFheUnavailable,
 };
 
-// Per-process cache: same (ring_dim, desired_modulus) reuses the same
-// CryptoContext + keypair across cryptocontext.dat, every template, and
-// every input bin. OpenFHE resolves Ciphertext<->CryptoContext bindings
-// through a static tag registry on deserialize; sharing the CC keeps
-// the tag stable.
-//
-// The keypair stays cached even though we don't decrypt — Encrypt()
-// needs a publicKey to produce a structurally valid Ciphertext<DCRTPoly>.
-// See TODO(haze:no-keygen) below.
+// Per-process CC cache: SRP outputs use a depth-0 single-tower CC, MRP
+// outputs use depth-(N-1) chains, all sharing OpenFHE's static
+// CC<->Ciphertext registry. picked_moduli records OpenFHE's chosen primes
+// (it picks by bit-width); rewrite_tower_moduli swaps them back to the
+// user-requested values at synthesis time.
 struct CachedContext {
     uint64_t ring_dim = 0;
-    uint64_t desired_modulus = 0;
-    uint64_t picked_modulus = 0;
+    std::vector<uint64_t> moduli;        // user-requested base
+    std::vector<uint64_t> picked_moduli; // OpenFHE-picked primes per tower
     lbcrypto::CryptoContext<DCRTPoly> cc;
     lbcrypto::KeyPair<DCRTPoly> keys;
 };
 
-CachedContext g_ctx;
+// Cache key: ring_dim plus the user-requested moduli vector (lex-compared).
+struct ContextKey {
+    uint64_t ring_dim;
+    std::vector<uint64_t> moduli;
+    bool operator<(const ContextKey &o) const {
+        if (ring_dim != o.ring_dim)
+            return ring_dim < o.ring_dim;
+        return moduli < o.moduli;
+    }
+};
 
-// Number of bits needed to represent a CKKS prime modulus. Modulus is
-// asserted >= 2 because OpenFHE's GenCryptoContext rejects smaller
-// values upstream and the bridge's only caller path has already
-// validated the input. std::bit_width handles 2^63 cleanly (returns 64)
-// where an iterative shift would silently truncate.
+std::map<ContextKey, CachedContext> g_ctx_cache;
+// Primary CC key: the entry that init seeded and that captured
+// cryptocontext.dat; nullopt before init / after reset_bridge_caches.
+std::optional<ContextKey> g_primary_key;
+// Program directory snapshotted at init so reset_bridge_caches's disk
+// cleanup is independent of niobium::compiler().reset() ordering.
+fs::path g_program_dir;
+
+// Bit width of a CKKS prime modulus; assert ≥2 since GenCryptoContext
+// rejects smaller upstream and the caller path has already validated.
 uint32_t bit_width_for_modulus(uint64_t modulus) {
     assert(modulus >= 2);
     return static_cast<uint32_t>(std::bit_width(modulus));
 }
 
-// Build (or rebuild) the cached CryptoContext + keypair to match
-// (ring_dim, desired_modulus). Returns success on cache hit (already
-// correct shape) or after a successful rebuild; returns a structured
-// BridgeError otherwise so the caller can map to the matching
-// hazeError_t.
-std::expected<void, BridgeError> rebuild_context_locked(uint64_t ring_dim,
-                                                        uint64_t desired_modulus) {
+// Build or look up a CryptoContext + keypair: moduli.size() == 1 → depth-0
+// single-tower CC; >1 → depth-(N-1) chain with one tower per residue. On
+// success returns a stable g_ctx_cache pointer; on failure, a BridgeError.
+std::expected<const CachedContext *, BridgeError>
+get_or_build_context_locked(uint64_t ring_dim, const std::vector<uint64_t> &moduli) {
     using namespace lbcrypto;
-    // Sanity gate: 0 or 1 are trivially malformed. Real CKKS NTT-
-    // friendly primes are ~60-bit; OpenFHE will reject other invalid
-    // choices deeper in GenCryptoContext.
-    if (ring_dim == 0)
+    // ring_dim must be ≥2 (CKKS packs N/2 slots) and within uint32_t (SetRingDim
+    // takes usint, so anything bigger silently truncates at the cast below).
+    if (ring_dim < 2 || ring_dim > std::numeric_limits<uint32_t>::max())
         return std::unexpected(BridgeError::InvalidRingDim);
-    if (desired_modulus < 2)
+    if (moduli.empty())
         return std::unexpected(BridgeError::InvalidModulus);
-
-    if (g_ctx.cc && g_ctx.ring_dim == ring_dim && g_ctx.desired_modulus == desired_modulus) {
-        return {}; // cache hit
+    // q<4 underflows SetScalingModSize(min_bits - 1) and is too small for CKKS.
+    for (auto q : moduli) {
+        if (q < 4)
+            return std::unexpected(BridgeError::InvalidModulus);
     }
+
+    ContextKey key{.ring_dim = ring_dim, .moduli = moduli};
+    auto it = g_ctx_cache.find(key);
+    if (it != g_ctx_cache.end())
+        return &it->second;
 
     CCParams<CryptoContextCKKSRNS> p;
     p.SetSecurityLevel(HEStd_NotSet); // toy: ring_dim is user-chosen
-    p.SetRingDim(ring_dim);
-    // SetMultiplicativeDepth(0) produces a single-tower DCRTPoly chain.
-    // Every haze output address holds one residue under one modulus, so
-    // single-tower templates are sufficient: the simulator pulls the
-    // per-output prime from the trace's modulus_table (built from the
-    // recorded sr_* ops), not from the template. Multi-modulus traces
-    // (e.g. test_basis_convert.cpp's 12-limb cases) work today via this
-    // single-residue-per-output addressing.
-    //
-    // A genuine multi-tower template — a single output address whose
-    // template carries a fan of NativePolys for `result(name, MRP&)` to
-    // deserialize as a true multi-residue polynomial — would require
-    // depth > 0 and explicit per-tower fill in synthesize_haze_ciphertext.
-    // Not currently needed by any client; flagged here so the constraint
-    // is visible if the requirement appears.
-    p.SetMultiplicativeDepth(0);
-    const uint32_t bits = bit_width_for_modulus(desired_modulus);
-    p.SetScalingModSize(bits - 1);
-    p.SetFirstModSize(bits);
-    // FIXEDMANUAL leaves rescale to the caller. At depth 0 with a
-    // single tower, OpenFHE's auto-rescale modes would inject extra
-    // modulus elements between operations and break the 1-NativePoly
-    // invariant the bridge depends on (synthesize_haze_ciphertext_locked
-    // assumes ct->GetElements()[0].GetAllElements().size() == 1).
+    p.SetRingDim(static_cast<uint32_t>(ring_dim));
+    // Chain depth d → d+1 towers in a freshly encrypted CT, so SRP wants 0
+    // and MRP with N residues wants N-1; array shapes compose per-element.
+    p.SetMultiplicativeDepth(static_cast<uint32_t>(moduli.size() - 1));
+    // First-mod bit-width tracks the primary modulus; scaling-mod tracks the
+    // smallest remaining modulus, minus 1 per OpenFHE's scalingModSize+1 rule.
+    const uint32_t first_bits = bit_width_for_modulus(moduli.front());
+    p.SetFirstModSize(first_bits);
+    if (moduli.size() == 1) {
+        p.SetScalingModSize(first_bits - 1);
+    } else {
+        uint32_t min_bits = bit_width_for_modulus(moduli[1]);
+        for (size_t i = 2; i < moduli.size(); ++i)
+            min_bits = std::min(min_bits, bit_width_for_modulus(moduli[i]));
+        p.SetScalingModSize(min_bits - 1);
+    }
+    // FIXEDMANUAL: these CTs are structural shells, never EvalMult'd, so
+    // auto-rescale would only churn the chain.
     p.SetScalingTechnique(FIXEDMANUAL);
 
     auto cc = GenCryptoContext(p);
@@ -181,12 +174,8 @@ std::expected<void, BridgeError> rebuild_context_locked(uint64_t ring_dim,
     cc->Enable(KEYSWITCH);
     cc->Enable(LEVELEDSHE);
 
-    // TODO(haze:no-keygen): we keygen + Encrypt + trim only because
-    // OpenFHE doesn't expose a public no-key Ciphertext<DCRTPoly>
-    // constructor. The bridge never decrypts; the keygen is effectively
-    // structural ballast. If a public empty-ciphertext factory becomes
-    // available in OpenFHE (e.g. cc->NewCiphertext()), drop the keypair
-    // and the Encrypt round-trip in synthesize_haze_ciphertext_locked.
+    // TODO(haze:no-keygen): keygen+Encrypt+trim is structural ballast since
+    // OpenFHE has no public no-key Ciphertext<DCRTPoly> constructor.
     auto keys = cc->KeyGen();
     if (!keys.publicKey || !keys.secretKey)
         return std::unexpected(BridgeError::KeygenFailed);
@@ -194,20 +183,60 @@ std::expected<void, BridgeError> rebuild_context_locked(uint64_t ring_dim,
     auto element_params = cc->GetCryptoParameters()->GetElementParams();
     if (!element_params || element_params->GetParams().empty())
         return std::unexpected(BridgeError::OpenFheUnavailable);
-    uint64_t picked = element_params->GetParams()[0]->GetModulus().ConvertToInt();
+    std::vector<uint64_t> picked;
+    picked.reserve(element_params->GetParams().size());
+    for (const auto &ep : element_params->GetParams())
+        picked.push_back(ep->GetModulus().ConvertToInt());
 
-    g_ctx.ring_dim = ring_dim;
-    g_ctx.desired_modulus = desired_modulus;
-    g_ctx.picked_modulus = picked;
-    g_ctx.cc = cc;
-    g_ctx.keys = keys;
-    return {};
+    CachedContext entry;
+    entry.ring_dim = ring_dim;
+    entry.moduli = moduli;
+    entry.picked_moduli = std::move(picked);
+    entry.cc = cc;
+    entry.keys = keys;
+    auto [ins, _] = g_ctx_cache.emplace(std::move(key), std::move(entry));
+    return &ins->second;
 }
 
-// Map a BridgeError to the matching hazeError_t for the C ABI. The
-// granular BridgeError values exist for diagnostics (log_error tags,
-// future debug surfaces); the public hazeError_t is intentionally
-// coarser.
+// Convenience accessor for the primary CC; returns nullptr before init.
+const CachedContext *primary_ctx() {
+    if (!g_primary_key)
+        return nullptr;
+    auto it = g_ctx_cache.find(*g_primary_key);
+    return (it == g_ctx_cache.end()) ? nullptr : &it->second;
+}
+
+// Drop the CC cache, primary key, and on-disk artifacts so each test starts
+// clean; without the disk half, addr-derived names from prior tests pollute
+// content-based MRP lookups. Best-effort: fs errors are logged, not raised.
+void reset_bridge_caches() {
+    g_ctx_cache.clear();
+    g_primary_key.reset();
+    if (g_program_dir.empty())
+        return; // bridge never initialized; nothing on disk
+    try {
+        const auto cleanup = [&](const fs::path &sub) {
+            std::error_code ec;
+            fs::remove_all(g_program_dir / sub, ec);
+            if (ec) {
+                std::ostringstream body;
+                body << "reset_bridge_caches: remove_all('" << (g_program_dir / sub).string()
+                     << "') failed: " << ec.message();
+                haze::log_error("replay_bridge", body.str());
+            }
+        };
+        cleanup("serialized_probes");
+        cleanup("ciphertext_templates");
+    } catch (const std::exception &e) {
+        haze::log_error("replay_bridge",
+                        std::string{"reset_bridge_caches: disk cleanup threw: "} + e.what());
+    } catch (...) {
+        haze::log_error("replay_bridge", "reset_bridge_caches: disk cleanup threw (unknown)");
+    }
+}
+
+// Map BridgeError → hazeError_t at the C ABI; granular variants exist for
+// diagnostics, but the public surface is intentionally coarser.
 hazeError_t to_haze_error(BridgeError e) {
     switch (e) {
     case BridgeError::InvalidRingDim:
@@ -220,139 +249,342 @@ hazeError_t to_haze_error(BridgeError e) {
     return HAZE_ERROR_LAUNCH_FAILURE;
 }
 
-// Build a 1-element / 1-tower Ciphertext<DCRTPoly> and fill its first
-// NativePoly with `values`. Returns the synthesized ciphertext.
-//
-// TODO(haze:no-keygen): bypass Encrypt + element[1] trim with a direct
-// public-API no-key construction once OpenFHE exposes one. See the
-// rebuild_context_locked TODO.
-lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_ciphertext(const std::vector<uint64_t> &values) {
-    std::vector<double> zeros(g_ctx.ring_dim / 2, 0.0);
-    auto pt = g_ctx.cc->MakeCKKSPackedPlaintext(zeros);
-    auto ct = g_ctx.cc->Encrypt(g_ctx.keys.publicKey, pt);
-    // Trim the RLWE pair (a, b) down to a 1-element ciphertext so the
-    // .bin's NativePoly count matches haze's one-polynomial-per-input
-    // model. element[1] would otherwise land in the .bin as Encrypt-noise
-    // and the compiler-side would auto-allocate a colliding addr_id for
-    // it. The result is not-decryptable, but we never decrypt — the
-    // compiler-side reads NativePoly values positionally, not via the
-    // CKKS API.
-    {
-        auto &els = ct->GetElements();
-        if (els.size() > 1)
-            els.resize(1);
-    }
-    if (values.empty()) {
-        // Output template path: caller wants an empty shell, no fill.
-        return ct;
-    }
-    auto &dcrt = ct->GetElements()[0];
-    auto &np = dcrt.GetAllElements()[0];
+// Encrypt zeros and trim the RLWE pair to a 1-element shell; element[1]
+// would otherwise land in the .bin as Encrypt-noise with a colliding
+// auto-addr_id. TODO(haze:no-keygen): replace once OpenFHE exposes a
+// no-key shell constructor.
+lbcrypto::Ciphertext<DCRTPoly> empty_one_element_ct(const CachedContext &ctx) {
+    std::vector<double> zeros(ctx.ring_dim / 2, 0.0);
+    auto pt = ctx.cc->MakeCKKSPackedPlaintext(zeros);
+    auto ct = ctx.cc->Encrypt(ctx.keys.publicKey, pt);
+    auto &els = ct->GetElements();
+    if (els.size() > 1)
+        els.resize(1);
+    return ct;
+}
+
+// Fill NativePoly `np` with `values` after validating the ring-dim
+// match. Logs and leaves the polynomial untouched on size mismatch.
+void fill_native_poly(lbcrypto::NativePoly &np, const std::vector<uint64_t> &values,
+                      const std::string &diag) {
     size_t n = np.GetParams()->GetRingDimension();
     if (values.size() != n) {
         std::ostringstream body;
-        body << "values.size()=" << values.size() << " != ring_dim=" << n
-             << " — cannot fill input ciphertext";
+        body << diag << ": values.size()=" << values.size() << " != ring_dim=" << n;
         haze::log_error("replay_bridge", body.str());
-        return ct;
+        return;
     }
     lbcrypto::NativeVector nv(n, lbcrypto::NativeInteger(np.GetModulus()));
     for (size_t i = 0; i < n; ++i)
         nv[i] = lbcrypto::NativeInteger(values[i]);
     np.SetValues(nv, np.GetFormat());
+}
+
+// SRP entrypoint: build a 1-element / 1-tower CT and fill its NativePoly
+// with `values` (empty `values` produces a template).
+lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_ciphertext(const CachedContext &ctx,
+                                                          const std::vector<uint64_t> &values) {
+    auto ct = empty_one_element_ct(ctx);
+    if (values.empty())
+        return ct; // template
+    fill_native_poly(ct->GetElements()[0].GetAllElements()[0], values,
+                     "synthesize_haze_ciphertext");
     return ct;
 }
 
-// LOAD-BEARING. Synthesizes per-program OpenFHE artifacts the replay
-// path (in-process simulator or transport-side nbcc_fhetch_replay)
-// needs to consume haze's pure-FHETCH recording. Must run AFTER
-// trace_writer.stop_recording() — so for_each_captured_* sees the
-// final input/output sets — and BEFORE the replay path's reconstruct
-// step (so cereal type registrations resolve in libnbfhetch's TU).
-// Wired up via niobium::compiler().set_post_recording_hook(...).
-void on_post_recording() {
-    if (!g_ctx.cc) {
-        // No CC initialized for this session — bridge was never called,
-        // so there are no haze-style artifacts to materialize.
-        return;
+// Replace each tower's modulus with the user-requested value; OpenFHE picks
+// bits-near primes that are invisible to SRP readers but visible to MRP
+// (mrp.base() from GetModulus()), and the simulator preserves the
+// template's modulus when emitting probes, so the override has to happen here.
+void rewrite_tower_moduli(lbcrypto::DCRTPoly &dcrt, const std::vector<uint64_t> &user_moduli,
+                          uint32_t ring_dim) {
+    auto &towers = dcrt.GetAllElements();
+    if (towers.size() != user_moduli.size()) {
+        // CC was built for these moduli, so a mismatch means OpenFHE produced
+        // an unexpected chain; log it before the loop silently truncates.
+        std::ostringstream body;
+        body << "rewrite_tower_moduli: tower count " << towers.size() << " != user_moduli.size() "
+             << user_moduli.size();
+        haze::log_error("replay_bridge", body.str());
     }
-
-    // ---- Inputs ----
-    struct InputAccum {
-        std::vector<uint64_t> values; // first element's values
-        std::vector<uint64_t> addr_ids;
-        bool seen_first = false;
-    };
-    std::map<std::string, InputAccum> inputs_by_name;
-
-    niobium::detail::for_each_captured_input([&](const std::string &name, uint64_t addr_id,
-                                                 uint64_t /*mod*/,
-                                                 const std::vector<uint64_t> &values) {
-        if (name == "evalmult_key" || name == "automorphism_key")
-            return;
-        auto &acc = inputs_by_name[name];
-        acc.addr_ids.push_back(addr_id);
-        if (!acc.seen_first) {
-            acc.values = values;
-            acc.seen_first = true;
-        }
-    });
-
-    for (auto &[name, acc] : inputs_by_name) {
-        try {
-            auto ct = synthesize_haze_ciphertext(acc.values);
-            if (!niobium::detail::write_ciphertext_input_bin(name, ct, acc.addr_ids)) {
-                haze::log_error("replay_bridge",
-                                "write_ciphertext_input_bin failed for '" + name + "'");
-            }
-        } catch (const std::exception &e) {
-            haze::log_error("replay_bridge",
-                            "input bin synthesis for '" + name + "' threw: " + e.what());
-        }
+    for (size_t i = 0; i < towers.size() && i < user_moduli.size(); ++i) {
+        const auto fmt = towers[i].GetFormat();
+        auto params = std::make_shared<lbcrypto::ILNativeParams>(
+            2 * ring_dim, lbcrypto::NativeInteger(user_moduli[i]));
+        // initializeElementToZero=true populates a length-ring_dim NativeVector;
+        // a later fill_native_poly overwrites with simulator-fed values.
+        towers[i] = lbcrypto::NativePoly(params, fmt, /*initializeElementToZero=*/true);
     }
-
-    // ---- Outputs ----
-    // Auto-write a 1-element template for each named output. The replay
-    // path fills the first NativePoly with simulator output; templates
-    // are otherwise empty. This removes the burden from test code of
-    // having to call hazeReplayBridgeWriteTemplate per output — tests
-    // just D2H any output and the bridge handles it on the way through.
-    niobium::detail::for_each_captured_output([&](const std::string &name) {
-        try {
-            auto ct = synthesize_haze_ciphertext({});
-            if (!niobium::detail::write_ciphertext_template(name, ct)) {
-                haze::log_error("replay_bridge",
-                                "write_ciphertext_template failed for '" + name + "'");
-            }
-        } catch (const std::exception &e) {
-            haze::log_error("replay_bridge",
-                            "template synthesis for '" + name + "' threw: " + e.what());
-        }
-    });
 }
 
-// Push the bridge's CryptoContext into niobium::compiler() (libnbfhetch's
-// "dummy" compiler — NOT the niobium-compiler nbcc) via the existing
-// OpenFHE-aware capture path. capture_crypto_context lives inside
-// libnbfhetch (auto_facade.cpp), so the cereal polymorphic
-// registrations for CryptoContextImpl<DCRTPoly> resolve in the same
-// shared library where the cc.dat serialization runs.
-//
-// capture_crypto_context internally:
-//   - calls set_ring_dimension(N)
-//   - calls set_crypto_context_info(scheme, depth, ..., modulus_chain)
-//   - serializes the CC to <program_dir>/cryptocontext.dat
-//   - registers an auto_capture_at_stop hook that calls
-//     tag_bootstrap_precompute on the CC
-//
-// We want the first three but NOT the fourth — haze records pure
-// polynomial-level ops, no bootstrap precompute. Clear the hook
-// immediately after capture so stop() doesn't fire it. Set our own
-// post_recording_hook so on_post_recording fires on stop().
-void push_crypto_to_compiler() {
-    niobium::compiler().capture_crypto_context(g_ctx.cc);
+// Build a 1-element / N-tower CT for an MRP output (empty
+// per_residue_values → template shell). Tower moduli are rewritten to the
+// user base so result(name, MRP&) returns mrp.base() == moduli.
+lbcrypto::Ciphertext<DCRTPoly>
+synthesize_haze_mrp_ciphertext(const CachedContext &ctx, const std::vector<uint64_t> &moduli,
+                               const std::vector<std::vector<uint64_t>> &per_residue_values) {
+    auto ct = empty_one_element_ct(ctx);
+    auto &dcrt = ct->GetElements()[0];
+    if (dcrt.GetAllElements().size() != moduli.size()) {
+        // Throw rather than emit a wrong-shape template; on_post_recording
+        // catches and skips this output instead of corrupting the trace.
+        std::ostringstream body;
+        body << "synthesize_haze_mrp_ciphertext: tower count " << dcrt.GetAllElements().size()
+             << " != moduli.size() " << moduli.size() << " — CC was built with the wrong depth";
+        throw std::runtime_error(body.str());
+    }
+    rewrite_tower_moduli(dcrt, moduli, static_cast<uint32_t>(ctx.ring_dim));
+    if (per_residue_values.empty())
+        return ct; // template — moduli were just installed; values stay zero.
+    if (per_residue_values.size() != moduli.size()) {
+        std::ostringstream body;
+        body << "synthesize_haze_mrp_ciphertext: per_residue_values.size()="
+             << per_residue_values.size() << " != moduli.size()=" << moduli.size();
+        throw std::runtime_error(body.str());
+    }
+    auto &towers = dcrt.GetAllElements();
+    for (size_t i = 0; i < towers.size(); ++i) {
+        fill_native_poly(towers[i], per_residue_values[i],
+                         "synthesize_haze_mrp_ciphertext[tower " + std::to_string(i) + "]");
+    }
+    return ct;
+}
+
+// Build a K-element CT for SRPArray/MRPArray; heterogeneous per-element
+// bases are rejected since they'd need multi-CC stitching OpenFHE doesn't
+// support. K independent Encrypts (typically K=2) avoid shallow-aliasing
+// during fill and bypass the missing public no-key K-shell constructor.
+lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_array_ciphertext(
+    const CachedContext &ctx, const std::vector<std::vector<uint64_t>> &per_element_moduli,
+    const std::vector<std::vector<std::vector<uint64_t>>> &per_element_values) {
+    if (per_element_moduli.empty())
+        throw std::runtime_error("synthesize_haze_array_ciphertext: empty per_element_moduli");
+    for (size_t k = 1; k < per_element_moduli.size(); ++k) {
+        if (per_element_moduli[k] != per_element_moduli[0]) {
+            std::ostringstream body;
+            body << "synthesize_haze_array_ciphertext: heterogeneous "
+                    "per_element_moduli not yet implemented (element[0].size()="
+                 << per_element_moduli[0].size() << ", element[" << k
+                 << "].size()=" << per_element_moduli[k].size() << ")";
+            throw std::runtime_error(body.str());
+        }
+    }
+    const auto &shared_moduli = per_element_moduli[0];
+    const size_t k_count = per_element_moduli.size();
+
+    std::vector<DCRTPoly> elements;
+    elements.reserve(k_count);
+    for (size_t k = 0; k < k_count; ++k) {
+        auto ct_k = empty_one_element_ct(ctx);
+        if (shared_moduli.size() > 1) {
+            rewrite_tower_moduli(ct_k->GetElements()[0], shared_moduli,
+                                 static_cast<uint32_t>(ctx.ring_dim));
+        }
+        elements.push_back(std::move(ct_k->GetElements()[0]));
+    }
+    auto ct = empty_one_element_ct(ctx);
+    ct->SetElements(elements);
+
+    if (per_element_values.empty())
+        return ct; // template path: K-element shell, zeros in each tower
+    if (per_element_values.size() != k_count) {
+        std::ostringstream body;
+        body << "synthesize_haze_array_ciphertext: per_element_values.size()="
+             << per_element_values.size() << " != per_element_moduli.size()=" << k_count;
+        throw std::runtime_error(body.str());
+    }
+    auto &els = ct->GetElements();
+    for (size_t k = 0; k < els.size(); ++k) {
+        const auto &row = per_element_values[k];
+        if (row.size() != shared_moduli.size()) {
+            std::ostringstream body;
+            body << "synthesize_haze_array_ciphertext: element " << k << " has " << row.size()
+                 << " residues, expected " << shared_moduli.size();
+            throw std::runtime_error(body.str());
+        }
+        auto &towers = els[k].GetAllElements();
+        for (size_t i = 0; i < towers.size(); ++i) {
+            fill_native_poly(towers[i], row[i],
+                             "synthesize_haze_array_ciphertext[elem " + std::to_string(k) +
+                                 ", tower " + std::to_string(i) + "]");
+        }
+    }
+    return ct;
+}
+
+// Pick the CC for a shape; arrays require homogeneous per-element moduli,
+// rejected with a logged nullptr so callers needn't distinguish "TODO" from
+// "synthesis failure". Modulus-0 falls back to the primary single-tower CC
+// (TODO(niobium-fhetch:mod-map-tracking): fhetch's address_modulus_map
+// doesn't register every output before sync_fhetch_state_to_compiler).
+const CachedContext *context_for_shape(uint64_t ring_dim, const niobium::CapturedShape &shape) {
+    if (shape.per_element_moduli.empty())
+        return primary_ctx();
+    const auto &moduli = shape.per_element_moduli.front();
+    if (moduli.empty())
+        return primary_ctx();
+    for (auto q : moduli) {
+        if (q == 0)
+            return primary_ctx();
+    }
+    // Reject heterogeneous arrays here so the caller gets a structured
+    // nullptr (mirrors the check in synthesize_haze_array_ciphertext —
+    // change both together).
+    if (shape.kind == niobium::CapturedKind::SRPArray ||
+        shape.kind == niobium::CapturedKind::MRPArray) {
+        for (size_t k = 1; k < shape.per_element_moduli.size(); ++k) {
+            if (shape.per_element_moduli[k] != moduli) {
+                std::ostringstream body;
+                body << "context_for_shape: heterogeneous per_element_moduli "
+                        "(element[0].size()="
+                     << moduli.size() << ", element[" << k
+                     << "].size()=" << shape.per_element_moduli[k].size()
+                     << ") — array synthesis with non-uniform bases is not yet implemented";
+                haze::log_error("replay_bridge", body.str());
+                return nullptr;
+            }
+        }
+    }
+    auto built = get_or_build_context_locked(ring_dim, moduli);
+    if (!built) {
+        std::ostringstream body;
+        body << "context_for_shape: failed to build CC for ring_dim=" << ring_dim
+             << " (BridgeError=" << static_cast<int>(built.error()) << ")";
+        haze::log_error("replay_bridge", body.str());
+        // primary_ctx() here would silently emit a 1-tower template for an
+        // N-tower output; nullptr lets the caller skip this output instead.
+        return nullptr;
+    }
+    return *built;
+}
+
+// Reshape flat per-residue values into per-element rows using
+// per_element_moduli sizes as boundaries; used by the array dispatch below.
+std::vector<std::vector<std::vector<uint64_t>>>
+slice_array_values(const std::vector<std::vector<uint64_t>> &per_residue_values,
+                   const std::vector<std::vector<uint64_t>> &per_element_moduli) {
+    std::size_t expected = 0;
+    for (const auto &m : per_element_moduli)
+        expected += m.size();
+    if (per_residue_values.size() != expected) {
+        // Mismatch implies a bug in fhetch's CapturedInputRecord; surface
+        // it here so fill_native_poly's per-row warnings don't drown the cause.
+        std::ostringstream body;
+        body << "slice_array_values: per_residue_values.size()=" << per_residue_values.size()
+             << " != sum of per_element_moduli sizes (" << expected << ")";
+        haze::log_error("replay_bridge", body.str());
+    }
+    std::vector<std::vector<std::vector<uint64_t>>> out;
+    out.reserve(per_element_moduli.size());
+    size_t cursor = 0;
+    for (const auto &elem_moduli : per_element_moduli) {
+        std::vector<std::vector<uint64_t>> row;
+        row.reserve(elem_moduli.size());
+        for (size_t i = 0; i < elem_moduli.size(); ++i) {
+            if (cursor < per_residue_values.size())
+                row.push_back(per_residue_values[cursor]);
+            else
+                row.emplace_back();
+            ++cursor;
+        }
+        out.push_back(std::move(row));
+    }
+    return out;
+}
+
+// Build the CT shell for `shape`; empty per_residue_values yields a
+// template, non-empty fills with values flattened in encounter order.
+lbcrypto::Ciphertext<DCRTPoly>
+synthesize_for_shape(const CachedContext &ctx, const niobium::CapturedShape &shape,
+                     const std::vector<std::vector<uint64_t>> &per_residue_values) {
+    switch (shape.kind) {
+    case niobium::CapturedKind::SRP:
+        return synthesize_haze_ciphertext(
+            ctx, per_residue_values.empty() ? std::vector<uint64_t>{} : per_residue_values.front());
+    case niobium::CapturedKind::MRP:
+        return synthesize_haze_mrp_ciphertext(ctx, shape.per_element_moduli.front(),
+                                              per_residue_values);
+    case niobium::CapturedKind::SRPArray:
+    case niobium::CapturedKind::MRPArray:
+        return synthesize_haze_array_ciphertext(
+            ctx, shape.per_element_moduli,
+            per_residue_values.empty()
+                ? std::vector<std::vector<std::vector<uint64_t>>>{}
+                : slice_array_values(per_residue_values, shape.per_element_moduli));
+    }
+    std::unreachable();
+}
+
+// LOAD-BEARING. Synthesizes the OpenFHE artifacts the replay path needs;
+// runs after stop_recording (so for_each_captured_* sees the final sets)
+// and before reconstruct (so cereal registrations resolve).
+void on_post_recording() {
+    const auto *primary = primary_ctx();
+    if (primary == nullptr) {
+        // Bridge never called this session; nothing to materialize.
+        return;
+    }
+    const uint64_t ring_dim = primary->ring_dim;
+
+    // ---- Inputs ----
+    niobium::detail::for_each_captured_input([&](const niobium::CapturedInputRecord &rec) {
+        // Keys aren't shape-tagged yet (Tier 2 / FIDESlib); skip so we
+        // don't synthesize a key-shaped CT from per-poly tags.
+        if (rec.name == "evalmult_key" || rec.name == "automorphism_key")
+            return;
+        try {
+            const auto *ctx = context_for_shape(ring_dim, rec.shape);
+            if (ctx == nullptr) {
+                haze::log_error("replay_bridge",
+                                "input '" + rec.name + "': no CC available for shape");
+                return;
+            }
+            auto ct = synthesize_for_shape(*ctx, rec.shape, rec.per_residue_values);
+            if (!niobium::detail::write_ciphertext_input_bin(rec.name, ct, rec.addr_ids)) {
+                haze::log_error("replay_bridge",
+                                "write_ciphertext_input_bin failed for '" + rec.name + "'");
+            }
+        } catch (const std::exception &e) {
+            haze::log_error("replay_bridge",
+                            "input bin synthesis for '" + rec.name + "' threw: " + e.what());
+        }
+    });
+
+    // ---- Outputs ----
+    // Auto-write a template per output; the replay path fills in values
+    // when emitting serialized_probes/<name>.ct.
+    niobium::detail::for_each_captured_output(
+        [&](const std::string &name, const niobium::CapturedShape &shape) {
+            try {
+                const auto *ctx = context_for_shape(ring_dim, shape);
+                if (ctx == nullptr) {
+                    haze::log_error("replay_bridge",
+                                    "output '" + name + "': no CC available for shape");
+                    return;
+                }
+                auto ct = synthesize_for_shape(*ctx, shape, /*per_residue_values=*/{});
+                if (!niobium::detail::write_ciphertext_template(name, ct)) {
+                    haze::log_error("replay_bridge",
+                                    "write_ciphertext_template failed for '" + name + "'");
+                }
+            } catch (const std::exception &e) {
+                haze::log_error("replay_bridge",
+                                "template synthesis for '" + name + "' threw: " + e.what());
+            }
+        });
+}
+
+// Push the CC through libnbfhetch's capture path so cereal registrations
+// resolve in libnbfhetch's TU. Clear the auto_capture_at_stop bootstrap
+// hook (haze has no bootstrap precompute) and install on_post_recording
+// as the post_recording_hook.
+void push_crypto_to_compiler(const CachedContext &ctx) {
+    niobium::compiler().capture_crypto_context(ctx.cc);
     niobium::compiler().set_auto_capture_at_stop(nullptr);
     niobium::compiler().set_post_recording_hook(&on_post_recording);
+    // Snapshot the program directory while the compiler still holds it,
+    // so reset_bridge_caches's disk cleanup is ordering-independent.
+    g_program_dir = niobium::compiler().get_program_directory();
 }
 
 } // namespace
@@ -364,20 +596,21 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         return HAZE_ERROR_INVALID_VALUE;
 
     try {
-        auto rebuild = rebuild_context_locked(ring_dim, desired_modulus);
-        if (!rebuild)
-            return to_haze_error(rebuild.error());
+        // Seed the primary depth-0 CC used by SRP outputs and cryptocontext.dat;
+        // MRP / array CCs are added on-demand from on_post_recording.
+        std::vector<uint64_t> primary_moduli = {desired_modulus};
+        auto built = get_or_build_context_locked(ring_dim, primary_moduli);
+        if (!built)
+            return to_haze_error(built.error());
 
-        // capture_crypto_context populates ring dimension + modulus
-        // chain AND serializes <program_dir>/cryptocontext.dat from
-        // inside libnbfhetch's TU (where cereal type registrations
-        // resolve). Also registers our post_recording_hook so the
-        // bridge's input-bin / template synthesis runs at stop() time
-        // without libnbfhetch needing to know about haze-specific
-        // artifacts.
-        push_crypto_to_compiler();
+        g_primary_key = ContextKey{.ring_dim = ring_dim, .moduli = primary_moduli};
 
-        *picked_modulus = g_ctx.picked_modulus;
+        // capture_crypto_context populates ring/chain and serializes
+        // cryptocontext.dat inside libnbfhetch's TU; push_crypto_to_compiler
+        // also installs our post_recording_hook for stop()-time synthesis.
+        push_crypto_to_compiler(**built);
+
+        *picked_modulus = (*built)->picked_moduli.front();
         return HAZE_SUCCESS;
     } catch (const std::exception &e) {
         haze::log_error("replay_bridge", std::string{"init threw: "} + e.what());
@@ -386,13 +619,18 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         return HAZE_ERROR_LAUNCH_FAILURE;
     }
 }
+
+extern "C" void hazeReplayBridgeReset() noexcept {
+    // Drop the CC cache and primary key so prior (ring_dim, moduli) entries
+    // don't accumulate and stress OpenFHE's static CC<->Ciphertext registry;
+    // hooks are cleared separately via niobium::compiler().reset().
+    reset_bridge_caches();
+}
+
 // ============================================================================
-// fhetch::result() free-function overloads — read serialized_probes/<name>.ct
-// and pull the first polynomial residue out as a fhetch::Polynomial / MRP /
-// MRPArray for clients that record raw polynomial ops.
-//
-// Marked with default visibility because the bridge dylib is built with
-// CXX_VISIBILITY_PRESET=hidden; libhaze imports these symbols at link time.
+// fhetch::result() overloads — read serialized_probes/<name>.ct as
+// fhetch::Polynomial / MRP / MRPArray. Marked default visibility because the
+// bridge dylib is built with CXX_VISIBILITY_PRESET=hidden.
 // ============================================================================
 
 #define NIOBIUM_FHETCH_RESULT_API __attribute__((visibility("default")))

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -546,6 +546,11 @@ void on_post_recording() {
 // hook (haze has no bootstrap precompute) and install on_post_recording
 // as the post_recording_hook.
 void push_crypto_to_compiler(const CachedContext &ctx) {
+    // Plant program_name="haze" before capture writes cryptocontext.dat so
+    // it lands in the eventual haze/ program directory rather than the
+    // "niobium_trace" default fallback (libhaze's backend init runs later,
+    // on the first EpochSession, and sets the same value idempotently).
+    niobium::compiler().set_program_info("haze", "", "");
     niobium::compiler().capture_crypto_context(ctx.cc);
     niobium::compiler().set_auto_capture_at_stop(nullptr);
     niobium::compiler().set_post_recording_hook(&on_post_recording);

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -607,8 +607,8 @@ HAZE_API hazeError_t hazeReplayBridgeRegisterCryptoContext(
         if (!element_params || element_params->GetParams().empty())
             return HAZE_ERROR_INVALID_VALUE;
 
-        g_user_ctx = CachedContext{
-            .cc = cc, .keys = keys, .ring_dim = element_params->GetRingDimension()};
+        g_user_ctx =
+            CachedContext{.cc = cc, .keys = keys, .ring_dim = element_params->GetRingDimension()};
         push_crypto_to_compiler(*g_user_ctx);
         return HAZE_SUCCESS;
     } catch (const std::exception &e) {

--- a/scripts/test_haze_integration_standalone.sh
+++ b/scripts/test_haze_integration_standalone.sh
@@ -31,6 +31,7 @@ set -euo pipefail
 : "${NIOBIUM_COMPILER_ROOT:?NIOBIUM_COMPILER_ROOT must be set (path to niobium-compiler checkout)}"
 : "${OPENFHE_LIB:?OPENFHE_LIB must be set (OpenFHE shared-library dir)}"
 : "${HAZE_RUNS_DIR:?HAZE_RUNS_DIR must be set (per-test artifact root)}"
+: "${HAZE_TRANSPORT_TARGET:=FUNC_SIM}"
 
 NBCC_FHETCH_REPLAY="$NIOBIUM_COMPILER_ROOT/build/nbcc_fhetch_replay"
 
@@ -73,7 +74,10 @@ echo "    runs:   $HAZE_RUNS_DIR"
 
 # libnbfhetch's Compiler::replay() honors NBCC_FHETCH_REPLAY as an absolute
 # override before falling back to PATH lookup, which is what lets us bypass
-# the HTTP forwarder entirely.
+# the HTTP forwarder entirely. HAZE_TARGET must be a non-"local" value so
+# Compiler::replay actually dispatches to nbcc_fhetch_replay instead of
+# running the in-process simulator.
+HAZE_TARGET="$HAZE_TRANSPORT_TARGET" \
 NBCC_FHETCH_REPLAY="$NBCC_FHETCH_REPLAY" \
 DYLD_LIBRARY_PATH="$OPENFHE_LIB${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
 LD_LIBRARY_PATH="$OPENFHE_LIB${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \

--- a/src/api/lifecycle.cpp
+++ b/src/api/lifecycle.cpp
@@ -26,11 +26,14 @@
 
 #include <haze/haze.h>
 #include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
 #include <niobium/compiler.h>
 
 namespace haze {
 
 void reset_all() noexcept {
+    // Clear all internal state first, since we may depend on external object state when clearing
+    // otherwise.
     epoch().reset();
     backend().reset();
     allocator().reset();
@@ -38,12 +41,9 @@ void reset_all() noexcept {
     streams_reset();
     events_reset();
     device_reset();
-    // Wipe niobium::compiler()'s singleton state too — captured_inputs,
-    // captured_outputs, the trace writer's modulus table, and any hooks
-    // registered by the replay bridge would otherwise leak across tests
-    // (or across distinct programs running in the same process). reset()
-    // is generic to libnbfhetch; haze just calls it as part of "start
-    // fresh".
+    hazeReplayBridgeReset();
+
+    // Clear any external state next
     niobium::compiler().reset();
 }
 

--- a/src/common/errors.cpp
+++ b/src/common/errors.cpp
@@ -28,7 +28,11 @@ hazeError_t to_public_error(HazeInternalError err) noexcept {
     case HazeInternalError::NoData:
     case HazeInternalError::AllocTooSmall:
         return HAZE_ERROR_INVALID_VALUE;
-    case HazeInternalError::BackendError:
+    case HazeInternalError::BackendInitFailed:
+    case HazeInternalError::BackendReplayFailed:
+    case HazeInternalError::BackendShapeMismatch:
+    case HazeInternalError::MrpGroupAddrModuliMismatch:
+    case HazeInternalError::MissingPolyMapBinding:
         return HAZE_ERROR_LAUNCH_FAILURE;
     }
     return HAZE_ERROR_INVALID_VALUE;
@@ -48,8 +52,16 @@ const char *internal_error_name(HazeInternalError err) noexcept {
         return "no data";
     case HazeInternalError::AllocTooSmall:
         return "allocation too small";
-    case HazeInternalError::BackendError:
-        return "backend error";
+    case HazeInternalError::BackendInitFailed:
+        return "backend init failed";
+    case HazeInternalError::BackendReplayFailed:
+        return "backend replay failed";
+    case HazeInternalError::BackendShapeMismatch:
+        return "backend returned unexpected shape";
+    case HazeInternalError::MrpGroupAddrModuliMismatch:
+        return "MRP group addrs/moduli span size mismatch";
+    case HazeInternalError::MissingPolyMapBinding:
+        return "addr missing from poly_map_";
     }
     return "unknown";
 }

--- a/src/common/errors.hpp
+++ b/src/common/errors.hpp
@@ -26,26 +26,28 @@ extern thread_local hazeError_t g_last_error;
 
 namespace haze {
 
-// Internal error type. Multiple internal causes can map to the same
-// public hazeError_t code (e.g. UnknownAddress / NoData / AllocTooSmall
-// all surface as HAZE_ERROR_INVALID_VALUE), so the public type would
-// erase information internal callers and debug logs need. Keep the
-// typed enum for that discrimination; map at the C ABI boundary only.
+// Internal error type; several variants collapse to one public hazeError_t
+// (e.g. UnknownAddress/NoData/AllocTooSmall → INVALID_VALUE), so internal
+// callers keep the typed enum and map only at the C ABI boundary.
 enum class HazeInternalError : std::uint8_t {
-    InvalidArgument, // params struct field violates the API contract
-    NotConfigured,   // ring_dim / modulus not set when required
-    UnknownAddress,  // DevAddr not in the allocator's table
-    NoData,          // address allocated but no H2D / compute output present
-    AllocTooSmall,   // allocation size < polynomial size
-    BackendError,    // niobium::compiler() / fhetch returned failure
+    InvalidArgument,            // params struct field violates the API contract
+    NotConfigured,              // ring_dim / modulus not set when required
+    UnknownAddress,             // DevAddr not in the allocator's table
+    NoData,                     // address allocated but no H2D / compute output present
+    AllocTooSmall,              // allocation size < polynomial size
+    BackendInitFailed,          // niobium::compiler() initialization threw
+    BackendReplayFailed,        // niobium::compiler() stop_epoch / replay returned false or threw
+    BackendShapeMismatch,       // backend returned a result with unexpected shape / length
+    MrpGroupAddrModuliMismatch, // MRP group registration: addrs / moduli span lengths differ
+    MissingPolyMapBinding       // pending output / MRP group addr is not in poly_map_
 };
 
 // Map an internal error to the public hazeError_t the C ABI returns.
 // Adding a new internal error variant requires extending this table.
 hazeError_t to_public_error(HazeInternalError err) noexcept;
 
-// Record a failure reason for HAZE_DEBUG=1 logging. Prints to stderr
-// when the env var is set. The context string is unowned and short-lived.
+// Record a failure reason for HAZE_DEBUG=1 logging (prints to stderr when set).
+// The context string is unowned and short-lived.
 void record_internal_error(HazeInternalError err, const char *context = nullptr) noexcept;
 
 } // namespace haze

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -11,22 +11,10 @@
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
 //
-// CompilerBackend is the link-time-selected control surface for the
-// niobium::compiler() singleton (libnbfhetch). Recording happens
-// locally; replay is dispatched according to the configured target.
-//
-// libnbfhetch knows two tiers: "local" runs the in-process FHETCH
-// simulator, anything else is forwarded to nbcc_fhetch_replay over the
-// HTTP transport. Haze exposes the same two tiers and forwards the
-// configured target string verbatim:
-//
-//   - kLocalTarget — runs the in-process FHETCH simulator end-to-end.
-//   - other (e.g. "FUNC_SIM", "FPGA_TRI", "fhetch_sim") — HTTP dispatch;
-//                    the string selects a backend on the compiler side.
-//
-// Haze itself never compares against the libnbfhetch literal "local";
-// the kLocalTarget constant in core/config.hpp keeps target comparisons
-// symbolic.
+// Control surface for the niobium::compiler() singleton; recording is
+// local, replay is dispatched per the configured target. libnbfhetch treats
+// "local" as the in-process simulator and any other string as an HTTP target
+// for nbcc_fhetch_replay (haze keeps comparisons symbolic via kLocalTarget).
 
 #include "core/backend.hpp"
 
@@ -57,42 +45,26 @@ bool CompilerBackend::ensure_initialized() noexcept {
     if (initialized_.load(std::memory_order_relaxed))
         return true;
 
-    // niobium::compiler() can throw (e.g. std::bad_alloc from internal
-    // string handling, or compiler-side configuration errors). Catch
-    // here so the C ABI boundary stays exception-clean: a thrown init
-    // becomes a recorded BackendError, not a process termination.
+    // niobium::compiler() can throw (bad_alloc, config errors); catch here
+    // so a thrown init becomes BackendInitFailed, not a process termination.
     try {
         const std::string program_name = config().program_name();
         const std::string program_version = config().program_version();
         const std::string program_description = config().program_description();
         const std::string target = config().target();
 
-        // niobium::compiler().init() takes (int& argc, char** argv) — we
-        // synthesise minimal argv so the compiler's arg parser sees a
-        // well-formed invocation. niobium-fhetch's compiler.h does not
-        // expose a set_target() setter; the only way to configure the
-        // replay target is through init()'s --target= flag.
-        //
-        // The configured target is forwarded verbatim. libnbfhetch
-        // interprets "local" as the in-process simulator and treats
-        // anything else as an HTTP target string handed to
-        // nbcc_fhetch_replay.
-        //
-        // argv lifetime: fhetch's Compiler::init copies parsed values
-        // into impl_ (the target string lands as a std::string field) and
-        // does not retain argv past the call. Function-local storage is
-        // therefore safe and avoids the ownership ambiguity of holding
-        // these strings on the singleton.
+        // Synthesize a minimal argv to pass --target= to compiler().init()
+        // (no setter is exposed). init copies argv during the call, so
+        // function-local storage is safe.
         std::string prog_storage = program_name;
         std::string target_arg_storage = "--target=" + target;
         char *argv[3] = {prog_storage.data(), target_arg_storage.data(), nullptr};
-        // argc is 2 — the trailing nullptr is the C-standard argv
-        // terminator, not a counted argument.
+        // argc is 2; the trailing nullptr is the standard argv terminator.
         int argc = 2;
         niobium::compiler().init(argc, argv);
         niobium::compiler().set_program_info(program_name, program_version, program_description);
     } catch (...) {
-        record_internal_error(HazeInternalError::BackendError,
+        record_internal_error(HazeInternalError::BackendInitFailed,
                               "CompilerBackend::ensure_initialized");
         return false;
     }
@@ -114,28 +86,20 @@ void CompilerBackend::start_epoch() noexcept {
 }
 
 bool CompilerBackend::stop_epoch() noexcept {
-    // Use the canonical stop() rather than stop_epoch(). stop() writes
-    // both the .fhetch trace and fhetch_replay.json (via write_replay_json
-    // in compiler.cpp:209), which the compiler-side nbcc_fhetch_replay
-    // requires to dispatch. stop_epoch() only writes the per-epoch trace
-    // and does not produce replay.json — fine for libnbcc's intra-process
-    // multi-epoch flow (its stop_epoch does record+replay+reset internally),
-    // but breaks the transport hand-off used by libnbfhetch.
-    //
-    // Haze's recording lifecycle is single-epoch per haze::epoch().reset(),
-    // so the canonical stop() is the right semantic match.
+    // Use stop() (not stop_epoch()): stop() writes both the .fhetch trace
+    // and fhetch_replay.json that nbcc_fhetch_replay needs for HTTP dispatch.
+    // Haze is single-epoch per epoch().reset(), so stop() also matches
+    // semantically.
     return niobium::compiler().stop();
 }
 
 bool CompilerBackend::replay() noexcept {
-    // niobium::compiler().replay() can throw on resource-exhaustion paths
-    // inside the niobium-fhetch dispatch (e.g. std::system_error from a
-    // failed subprocess fork on the transport route). Catching here keeps
-    // the haze C ABI exception-clean and surfaces a coherent BackendError.
+    // replay() can throw on transport-route resource exhaustion (e.g. fork
+    // failure); catch so the C ABI surfaces BackendReplayFailed cleanly.
     try {
         return niobium::compiler().replay();
     } catch (...) {
-        record_internal_error(HazeInternalError::BackendError, "CompilerBackend::replay");
+        record_internal_error(HazeInternalError::BackendReplayFailed, "CompilerBackend::replay");
         return false;
     }
 }

--- a/src/core/basis_convert.cpp
+++ b/src/core/basis_convert.cpp
@@ -31,9 +31,8 @@ namespace fhetch = niobium::fhetch;
 
 namespace {
 
-// Validation helpers. Each returns InvalidArgument on the first failure
-// and records a debug-log breadcrumb. Pre-flight checks live here so
-// the C ABI shim stays a thin wrapper.
+// Validation helpers; each returns InvalidArgument with a debug-log
+// breadcrumb on the first failure, keeping the C ABI shim thin.
 
 std::expected<void, HazeInternalError> validate(const hazeBasisConvertParams &p) noexcept {
     if (p.src_base == nullptr || p.src_base_len == 0 || p.dst_base == nullptr ||
@@ -112,8 +111,7 @@ std::expected<void, HazeInternalError> basis_convert(void *const *dst, const voi
 
     const fhetch::ModuliBase target_base(p.dst_base, p.dst_base + p.dst_base_len);
     fhetch::MRP result = fhetch::fast_base_convert(*src_mrp, target_base);
-    store_mrp_locked(dst, result, p.dst_base, p.dst_base_len);
-    return {};
+    return store_mrp_locked(dst, result, p.dst_base, p.dst_base_len);
 }
 
 std::expected<void, HazeInternalError> mod_down(void *const *dst, const void *const *src,
@@ -135,8 +133,7 @@ std::expected<void, HazeInternalError> mod_down(void *const *dst, const void *co
     // (FhetchApi.cpp:1606-1617). Use it directly so HAZE-side and
     // backend-side never disagree on the dst layout.
     const auto &dst_base = result.base();
-    store_mrp_locked(dst, result, dst_base.data(), dst_base.size());
-    return {};
+    return store_mrp_locked(dst, result, dst_base.data(), dst_base.size());
 }
 
 std::expected<void, HazeInternalError> mod_up(void *const *dst, const void *const *src,
@@ -164,9 +161,9 @@ std::expected<void, HazeInternalError> mod_up(void *const *dst, const void *cons
     const fhetch::ModuliBase p_base(p.p_base, p.p_base + p.p_base_len);
     fhetch::MRPArray result = fhetch::dig_decomp(*src_mrp, digit_bases, p_base);
     if (result.length() != p.digit_count) {
-        record_internal_error(HazeInternalError::BackendError,
+        record_internal_error(HazeInternalError::BackendShapeMismatch,
                               "hazeModUp: dig_decomp returned wrong length");
-        return std::unexpected(HazeInternalError::BackendError);
+        return std::unexpected(HazeInternalError::BackendShapeMismatch);
     }
 
     // Each result[d].base() == src_base + p_base (FhetchApi.cpp:1704-1705)
@@ -174,7 +171,10 @@ std::expected<void, HazeInternalError> mod_up(void *const *dst, const void *cons
     // dst writes.
     for (size_t d = 0; d < p.digit_count; ++d) {
         const auto &d_base = result[d].base();
-        store_mrp_locked(dst + (d * d_base.size()), result[d], d_base.data(), d_base.size());
+        auto stored =
+            store_mrp_locked(dst + (d * d_base.size()), result[d], d_base.data(), d_base.size());
+        if (!stored)
+            return stored;
     }
     return {};
 }

--- a/src/core/compute.hpp
+++ b/src/core/compute.hpp
@@ -26,12 +26,10 @@
 
 namespace haze {
 
-// Each compute entry point shares the same prelude: open an EpochSession
-// (lock + ensure_recording), resolve the modulus, copy each source poly
-// out of the polymap, dispatch to the FHETCH operation, store the
-// result. The four templates below capture this shape parametrised by
-// the FHETCH function. Source polys are returned by value so in-place
-// operations (dst == src1 [== src2]) stay correct.
+// Each compute prelude opens an EpochSession, resolves the modulus, copies
+// sources from the polymap, dispatches the FHETCH op, and stores the result.
+// Sources are returned by value so in-place ops (dst == src1 [== src2]) stay
+// correct.
 
 // Polynomial-polynomial-modulus. Used by hazeAdd, hazeSub, hazeMul.
 template <auto OpFn>
@@ -88,10 +86,9 @@ template <auto OpFn> hazeError_t unary_pi_op(DevAddr dst, DevAddr src, uint64_t 
     return HAZE_SUCCESS;
 }
 
-// MRP compute templates. Same shape as the SRP templates above but
-// fan out across one DevAddr per residue via build_mrp_locked /
-// store_mrp_locked from core/mrp_polymap.hpp. In-place safety carries
-// over per-residue (the helpers' copy semantics are documented there).
+// MRP compute templates: same shape as the SRP templates, fanned out per
+// residue via build_mrp_locked / store_mrp_locked. In-place safety carries
+// over per-residue.
 
 // MRP polynomial-polynomial. Used by hazeAddMrp, hazeSubMrp, hazeMulMrp.
 template <auto OpFn>
@@ -105,12 +102,14 @@ hazeError_t binary_pp_op_mrp(void *const *dst, const void *const *src1, const vo
     if (!m2)
         return set_error(to_public_error(m2.error()));
     niobium::fhetch::MRP result = OpFn(*m1, *m2);
-    store_mrp_locked(dst, result, base, base_len);
+    auto stored = store_mrp_locked(dst, result, base, base_len);
+    if (!stored)
+        return set_error(to_public_error(stored.error()));
     return HAZE_SUCCESS;
 }
 
-// MRP polynomial-scalar. `scalars[i]` pairs with `base[i]`.
-// Used by hazeAddScalarMrp, hazeSubScalarMrp, hazeMulScalarMrp.
+// MRP polynomial-scalar (scalars[i] pairs with base[i]); used by
+// hazeAddScalarMrp, hazeSubScalarMrp, hazeMulScalarMrp.
 template <auto OpFn>
 hazeError_t binary_ps_op_mrp(void *const *dst, const void *const *src, const uint64_t *scalars,
                              const uint64_t *base, std::size_t base_len) noexcept {
@@ -119,14 +118,14 @@ hazeError_t binary_ps_op_mrp(void *const *dst, const void *const *src, const uin
     if (!m)
         return set_error(to_public_error(m.error()));
     niobium::fhetch::MRP result = OpFn(*m, build_mrs(scalars, base, base_len));
-    store_mrp_locked(dst, result, base, base_len);
+    auto stored = store_mrp_locked(dst, result, base, base_len);
+    if (!stored)
+        return set_error(to_public_error(stored.error()));
     return HAZE_SUCCESS;
 }
 
-// MRP polynomial-only (no per-modulus argument). The fhetch `mr_ntt` /
-// `mr_intt` ops carry their moduli base inside the MRP itself and take
-// no extra modulus parameter — so this shape cannot reuse `unary_pq_op`.
-// Used by hazeNTTMrp, hazeINTTMrp.
+// MRP polynomial-only: mr_ntt/mr_intt carry their moduli base inside the
+// MRP, so this can't reuse unary_pq_op. Used by hazeNTTMrp, hazeINTTMrp.
 template <auto OpFn>
 hazeError_t unary_p_op_mrp(void *const *dst, const void *const *src, const uint64_t *base,
                            std::size_t base_len) noexcept {
@@ -135,7 +134,9 @@ hazeError_t unary_p_op_mrp(void *const *dst, const void *const *src, const uint6
     if (!m)
         return set_error(to_public_error(m.error()));
     niobium::fhetch::MRP result = OpFn(*m);
-    store_mrp_locked(dst, result, base, base_len);
+    auto stored = store_mrp_locked(dst, result, base, base_len);
+    if (!stored)
+        return set_error(to_public_error(stored.error()));
     return HAZE_SUCCESS;
 }
 
@@ -149,7 +150,9 @@ hazeError_t unary_pi_op_mrp(void *const *dst, const void *const *src, uint64_t i
     if (!m)
         return set_error(to_public_error(m.error()));
     niobium::fhetch::MRP result = OpFn(*m, index);
-    store_mrp_locked(dst, result, base, base_len);
+    auto stored = store_mrp_locked(dst, result, base, base_len);
+    if (!stored)
+        return set_error(to_public_error(stored.error()));
     return HAZE_SUCCESS;
 }
 

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -29,6 +29,7 @@
 #include <ios>
 #include <niobium/compiler.h>
 #include <niobium/fhetch_api.h>
+#include <span>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -44,21 +45,13 @@ EpochState &EpochState::instance() noexcept {
 }
 
 void EpochState::ensure_recording_locked() {
-    // The session constructor calls backend().ensure_initialized() *before*
-    // taking the epoch lock, so by the time we get here the backend is
-    // already up. Defensively check is_initialized() — if the caller
-    // somehow reached us without that prelude (e.g. a future code path
-    // that bypasses EpochSession), staying out of the recording state
-    // makes the failure visible at the next lookup_or_create rather than
-    // crashing inside niobium::compiler().
+    // EpochSession initializes the backend before locking; this defensive
+    // check guards future code paths that might bypass EpochSession.
     if (!backend().is_initialized())
         return;
     if (!recording_) {
-        // start_epoch() before start(): first call memorizes the
-        // polynomial-ID base; later calls (after stop_epoch in
-        // do_materialize) reset the counter to that base. Without it,
-        // poly IDs drift forward across materializations and each epoch's
-        // compaction sees a different layout.
+        // start_epoch() before start() memorizes the polynomial-ID base so
+        // post-materialize resets snap back to it; without it, IDs drift.
         CompilerBackend::start_epoch();
         CompilerBackend::start_recording();
         recording_ = true;
@@ -72,9 +65,8 @@ bool EpochState::is_recording() noexcept {
 
 void EpochState::invalidate(DevAddr addr) noexcept {
     HazeLockGuard lock(mutex_);
-    // pending_outputs_ is a subset of poly_map_; erase-on-miss is O(1)
-    // (hash hit + immediate not-found return). Tagging addresses with
-    // their owning map would add complexity for no measurable benefit.
+    // pending_outputs_ is a subset of poly_map_; erase-on-miss is O(1), so
+    // unconditional double-erase is simpler than tagging addrs by owner.
     poly_map_.erase(addr);
     pending_outputs_.erase(addr);
 }
@@ -92,11 +84,8 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
     if (components) {
         poly = fhetch::Polynomial::from_data(*components, ring_dim, fhetch::Format::Evaluation);
     } else if (components.error() == HazeInternalError::NoData) {
-        // Address allocated but no bytes ever written. Construct a fresh
-        // zero polynomial via fhetch — its shared_ptr<MRPImpl> storage
-        // owns the data, so HAZE never fabricates zero bytes itself.
-        // Matches the FIDESlib pattern of using SPECIAL limb buffers
-        // before their explicit zero_out memset (per task-5 design).
+        // Address allocated but never written: build a fhetch zero polynomial
+        // so HAZE doesn't fabricate the bytes (matches FIDESlib's SPECIAL pattern).
         poly = fhetch::Polynomial::zeros(ring_dim);
     } else {
         return std::unexpected(components.error());
@@ -112,16 +101,41 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
 void EpochState::store_compute_result_locked(DevAddr addr,
                                              niobium::fhetch::Polynomial poly) noexcept {
     poly_map_.insert_or_assign(addr, std::move(poly));
-    // Authoritative output registration: every compute store gets a
-    // pending output name on first store. Re-stores at the same addr
-    // keep their original name (insert-no-overwrite); an intervening
-    // invalidate() wipes pending_outputs_, so a fresh store after H2D
-    // / memset gets a new name. Input polys created via
-    // lookup_or_create_locked never reach this path, so they are
-    // never tagged as fhetch outputs.
+    // First store at `addr` reserves a pending output name; re-stores keep
+    // it, and invalidate() wipes it so post-H2D/memset stores get a new one.
     if (!pending_outputs_.contains(addr)) {
         pending_outputs_.emplace(addr, "haze_out_" + std::to_string(output_counter_++));
     }
+}
+
+void EpochState::tag_mrp_input_if_new_locked(const std::string &name, const fhetch::MRP &mrp) {
+    // Dedup so each name reaches fhetch exactly once.
+    auto [it, inserted] = mrp_input_tagged_names_.insert(name);
+    if (!inserted)
+        return;
+    fhetch::tag_input(*it, mrp);
+}
+
+std::expected<void, HazeInternalError>
+EpochState::register_mrp_output_group_locked(std::span<const DevAddr> addrs,
+                                             std::span<const uint64_t> moduli, std::string &&name) {
+    // One device address per modulus; a mismatch is a programming bug in
+    // the fan-out helper, surfaced rather than dropped silently.
+    if (addrs.size() != moduli.size()) {
+        std::ostringstream body;
+        body << "register_mrp_output_group_locked('" << name << "'): addrs.size()=" << addrs.size()
+             << " != moduli.size()=" << moduli.size();
+        record_internal_error(HazeInternalError::MrpGroupAddrModuliMismatch, body.str().c_str());
+        return std::unexpected(HazeInternalError::MrpGroupAddrModuliMismatch);
+    }
+    // try_emplace dedups re-registrations for the same op (e.g. in-place
+    // hazeMulMrp called twice) since the leading-addr name is stable.
+    auto [it, inserted] = pending_mrp_groups_.try_emplace(std::move(name));
+    if (!inserted)
+        return {};
+    it->second.addrs.assign(addrs.begin(), addrs.end());
+    it->second.moduli.assign(moduli.begin(), moduli.end());
+    return {};
 }
 
 std::expected<void, HazeInternalError> EpochState::replay_and_populate() noexcept {
@@ -130,14 +144,39 @@ std::expected<void, HazeInternalError> EpochState::replay_and_populate() noexcep
         return {}; // nothing to replay
     }
 
-    // Tag every authoritative output for fhetch. Inputs already carry
-    // tag_input from lookup_or_create_locked; pending_outputs_ contains
-    // exactly the addresses that store_compute_result_locked emitted.
+    // pending_outputs_ and poly_map_ stay in lockstep via store + invalidate,
+    // so a missing binding here is a state-management bug, not recoverable.
     for (auto &[addr, name] : pending_outputs_) {
         auto it = poly_map_.find(addr);
-        if (it == poly_map_.end())
-            continue;
+        if (it == poly_map_.end()) {
+            std::ostringstream body;
+            body << "replay_and_populate: pending output '" << name << "' addr 0x" << std::hex
+                 << to_uintptr(addr) << std::dec << " missing from poly_map_";
+            record_internal_error(HazeInternalError::MissingPolyMapBinding, body.str().c_str());
+            return std::unexpected(HazeInternalError::MissingPolyMapBinding);
+        }
         fhetch::tag_output(name, it->second);
+    }
+
+    // Also tag each MRP group as a fhetch MRP output so external callers
+    // can pull the multi-residue view via fhetch::result(name, MRP&).
+    for (const auto &[name, g] : pending_mrp_groups_) {
+        std::vector<std::pair<fhetch::Polynomial, uint64_t>> pairs;
+        pairs.reserve(g.addrs.size());
+        for (size_t i = 0; i < g.addrs.size(); ++i) {
+            auto it = poly_map_.find(g.addrs[i]);
+            if (it == poly_map_.end()) {
+                // Group registered but its poly_map_ binding was invalidated before replay.
+                std::ostringstream body;
+                body << "replay_and_populate: MRP group '" << name << "' addr 0x" << std::hex
+                     << to_uintptr(g.addrs[i]) << std::dec << " missing from poly_map_";
+                record_internal_error(HazeInternalError::MissingPolyMapBinding, body.str().c_str());
+                return std::unexpected(HazeInternalError::MissingPolyMapBinding);
+            }
+            // Polynomial copy is a shared_ptr refcount bump, not a deep clone.
+            pairs.emplace_back(it->second, g.moduli[i]);
+        }
+        fhetch::tag_output(name, fhetch::MRP::from_pairs(pairs));
     }
 
     return do_materialize_locked();
@@ -153,21 +192,20 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
     const bool stop_ok = CompilerBackend::stop_epoch();
     if (!stop_ok) {
         clear_state_locked();
-        record_internal_error(HazeInternalError::BackendError,
+        record_internal_error(HazeInternalError::BackendReplayFailed,
                               "EpochState::replay_and_populate (stop_epoch)");
-        return std::unexpected(HazeInternalError::BackendError);
+        return std::unexpected(HazeInternalError::BackendReplayFailed);
     }
 
-    // Step 2: dispatch replay. kLocalTarget runs the in-process FHETCH
-    // simulator end-to-end inside libnbfhetch; other targets spawn
-    // nbcc_fhetch_replay over the HTTP transport. Both paths produce
-    // serialized_probes/<name>.ct for fhetch::result to read in step 3.
+    // Step 2: dispatch replay. kLocalTarget runs the in-process simulator;
+    // other targets spawn nbcc_fhetch_replay over HTTP — both produce
+    // serialized_probes/<name>.ct for step 3 to read.
     const bool replay_ok = CompilerBackend::replay();
     if (!replay_ok) {
         clear_state_locked();
-        record_internal_error(HazeInternalError::BackendError,
+        record_internal_error(HazeInternalError::BackendReplayFailed,
                               "EpochState::replay_and_populate (replay)");
-        return std::unexpected(HazeInternalError::BackendError);
+        return std::unexpected(HazeInternalError::BackendReplayFailed);
     }
 
     // Step 3: populate host shadow buffers from
@@ -201,14 +239,13 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
 void EpochState::clear_state_locked() noexcept {
     poly_map_.clear();
     pending_outputs_.clear();
+    pending_mrp_groups_.clear();
+    mrp_input_tagged_names_.clear();
     recording_ = false;
     input_counter_ = 0;
     output_counter_ = 0;
-    // Mirror to compiler-captured state so a failed materialise can't
-    // leak inputs/outputs into the next recording cycle. Pairs with
-    // EpochSession's start-of-cycle ensure_recording_locked() — both
-    // ends of the recording window are now responsible for keeping the
-    // libnbfhetch-side state in lockstep with haze-side epoch state.
+    // Mirror clears to libnbfhetch so a failed materialise can't leak
+    // captures into the next epoch; pairs with EpochSession's setup.
     niobium::compiler().clear_captured();
 }
 
@@ -218,26 +255,16 @@ void EpochState::reset() noexcept {
 }
 
 HazeMutex &EpochSession::init_then_get_mutex() noexcept {
-    // ensure_initialized() has its own atomic + init mutex; safe (and
-    // important) to call before acquiring the epoch lock so first-call
-    // compiler init doesn't block other epoch-lock acquirers. The
-    // bool return is intentionally not propagated here — failure is
-    // caught at ensure_recording_locked() via is_initialized(), which
-    // refuses to start recording if init didn't take. Subsequent
-    // compute calls then fail with a coherent error from
-    // lookup_or_create_locked rather than crashing inside niobium.
+    // Run ensure_initialized() before grabbing the epoch lock so first-call
+    // init doesn't serialize; failure surfaces later via is_initialized().
     [[maybe_unused]] const bool _ = backend().ensure_initialized();
     return epoch().mutex_;
 }
 
 hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept {
-    // D2H is the sole flush trigger: finalise any active recording,
-    // dispatch replay (potentially an HTTP round-trip to nbcc_fhetch_replay
-    // for non-local targets), and populate shadow buffers before reading.
-    // replay_and_populate() is a no-op when no recording is in flight, so
-    // plain H2D-then-D2H round-trips elide the cost, and subsequent D2H
-    // calls within the same epoch are free (the first D2H clears
-    // recording_).
+    // D2H is the sole flush trigger: finalize, replay, and populate shadows
+    // before reading. No-op when not recording, so H2D-then-D2H round-trips
+    // and follow-up D2H reads in the same epoch are free.
     auto replay_result = epoch().replay_and_populate();
     if (!replay_result)
         return to_public_error(replay_result.error());

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -21,82 +21,63 @@
 #include <expected>
 #include <haze/haze_types.h>
 #include <niobium/fhetch_api.h>
+#include <span>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace haze {
 
-// Epoch state is the single point of contact between the compute API
-// and the niobium compiler's recording window. It tracks the active
-// polymap (DevAddr → fhetch::Polynomial), pending output names for the
-// next D2H, and the recording lifecycle flags. The next D2H drives
-// replay_and_populate(), which finalises the trace and writes every
-// pending output back into the shadow buffer.
-//
-// Mutex contract: most public methods take `mutex_` themselves; the
-// `_locked` variants assume the caller has already taken it via an
-// EpochSession and skip internal locking. Single std::mutex (not
-// recursive) — the lock is held for tiny windows during instruction
-// emission. The single-mutex design preserves IR ordering as the
-// niobium target grows into multi-compute-unit configurations and
-// FIDESlib's OpenMP regions fan out with num_threads > 1.
-//
-// The mutex contract is enforced by clang's thread-safety analysis
-// (haze_thread_safety.hpp). Each `_locked` method requires the caller
-// to hold mutex_; each public method excludes it; each protected field
-// is guarded by it. Building with -Wthread-safety promotes any
-// violation to a compile-time error.
+// Singleton tracking the polymap, pending outputs, and recording flag for
+// the active epoch; replay_and_populate() drains it at D2H time. Public
+// methods take mutex_; _locked variants require it held via EpochSession
+// (enforced by clang -Wthread-safety).
 class EpochState {
   public:
     static EpochState &instance() noexcept;
 
-    // The mutex itself. EpochSession is the canonical caller; other
-    // callers take it via std::lock_guard (see is_recording, invalidate,
-    // replay_and_populate, reset).
+    // The mutex itself; EpochSession is the canonical acquirer.
     HazeMutex &mutex() noexcept HAZE_RETURN_CAPABILITY(mutex_) { return mutex_; }
 
     // ---- Public methods (take mutex_ internally) ----
 
     bool is_recording() noexcept HAZE_EXCLUDES(mutex_);
 
-    // Drop any polymap binding for `addr`. Called by the allocator paths
-    // (H2D, D2D, memset, free) so the next compute call rebuilds a fresh
-    // input from new shadow data.
+    // Drop any polymap binding for `addr`. Called by allocator paths
+    // (H2D, D2D, memset, free) so the next compute rebuilds from shadow.
     void invalidate(DevAddr addr) noexcept HAZE_EXCLUDES(mutex_);
 
-    // Finalize the current epoch: tag every bound compute result as a
-    // fhetch output, write the .fhetch trace via stop_epoch(), then
-    // dispatch replay (see hazeSetTarget docs for the three-tier table)
-    // and populate the host shadow buffer for each output address with
-    // the computed values.
-    //
-    // After this call returns, hazeMemcpy(D2H) on any bound output
-    // address reads the materialized value from the shadow buffer.
-    // No-op when not recording.
+    // Finalize the epoch: tag outputs, write the trace, dispatch replay,
+    // populate shadow buffers. No-op when not recording.
     std::expected<void, HazeInternalError> replay_and_populate() noexcept HAZE_EXCLUDES(mutex_);
 
     void reset() noexcept HAZE_EXCLUDES(mutex_);
 
     // ---- Locked methods (caller holds mutex_) ----
 
-    // Initialise the compiler backend (idempotent) and start recording
-    // if not already. EpochSession calls this after taking mutex_.
+    // Initialise the compiler backend (idempotent) and start recording.
     void ensure_recording_locked() HAZE_REQUIRES(mutex_);
 
-    // Resolve `addr` to a polynomial. Returns a *copy* — required for
-    // in-place compute operations (dst == src) where the destination
-    // mutation must not invalidate the source. On first reference,
-    // creates a Polynomial from the shadow buffer and tags it as input.
+    // Resolve `addr`; returns a copy so in-place compute doesn't invalidate
+    // the source. On first reference, builds from shadow and tags as input.
     std::expected<niobium::fhetch::Polynomial, HazeInternalError>
     lookup_or_create_locked(DevAddr addr) HAZE_REQUIRES(mutex_);
 
-    // Bind `addr` to `poly` (replacing any prior binding) and tag it as
-    // a compute output — every store of a freshly computed polynomial
-    // gets a pending-output name on first store. Re-stores at the same
-    // addr keep their original name (insert-no-overwrite); an
-    // intervening invalidate() wipes pending_outputs_, so a fresh store
-    // after H2D / memset gets a new name.
+    // Bind `addr` to `poly` and emit a pending-output name on first
+    // store. Re-stores keep the original name; invalidate() wipes it.
     void store_compute_result_locked(DevAddr addr, niobium::fhetch::Polynomial poly) noexcept
+        HAZE_REQUIRES(mutex_);
+
+    // Register an MRP-shaped grouping so replay can emit a single
+    // fhetch::tag_output(name, MRP); deduped by name on re-registration.
+    std::expected<void, HazeInternalError>
+    register_mrp_output_group_locked(std::span<const DevAddr> addrs,
+                                     std::span<const uint64_t> moduli, std::string &&name)
+        HAZE_REQUIRES(mutex_);
+
+    // Pass-through to fhetch::tag_input(name, MRP), deduped by name.
+    void tag_mrp_input_if_new_locked(const std::string &name, const niobium::fhetch::MRP &mrp)
         HAZE_REQUIRES(mutex_);
 
     EpochState(const EpochState &) = delete;
@@ -105,31 +86,33 @@ class EpochState {
   private:
     EpochState() = default;
 
-    // Internal helper: drain pending outputs through the backend. Caller
-    // holds mutex_. Always resets epoch state at the end (cleared on both
-    // success and failure to leave the next epoch with a clean slate).
+    // Drain pending outputs through the backend; always resets state at
+    // the end so the next epoch starts clean on success or failure.
     std::expected<void, HazeInternalError> do_materialize_locked() HAZE_REQUIRES(mutex_);
 
     void clear_state_locked() noexcept HAZE_REQUIRES(mutex_);
 
-    // mutex_ protects all state below. Lock order across HAZE: any caller
-    // holding mutex_ may call into DeviceAllocator (epoch → allocator).
-    // The reverse direction is forbidden; allocator-side code must never
-    // call back into EpochState while holding the allocator lock.
+    // Lock order: epoch → allocator only. Allocator-side code must
+    // never call back into EpochState while holding its own lock.
     HazeMutex mutex_;
-    // Authoritative bindings for every poly in flight this epoch. Inputs
-    // (lookup_or_create_locked) and outputs (store_compute_result_locked)
-    // both land here; the corresponding pending_outputs_ entry, present
-    // iff the binding is an output, names it for fhetch::tag_output.
+    // Every poly in flight this epoch (inputs and outputs land here).
+    // pending_outputs_ is the addr-keyed subset that names the outputs.
     std::unordered_map<DevAddr, niobium::fhetch::Polynomial> poly_map_ HAZE_GUARDED_BY(mutex_);
     std::unordered_map<DevAddr, std::string> pending_outputs_ HAZE_GUARDED_BY(mutex_);
+    // MRP-shaped output groupings, keyed by name so re-registration of
+    // the same op (same dst[0] → same name) is a free dedup.
+    struct PendingMrpGroup {
+        std::vector<DevAddr> addrs;   // residue addrs in encounter order
+        std::vector<uint64_t> moduli; // base[i] paired with addrs[i]
+    };
+    std::unordered_map<std::string, PendingMrpGroup> pending_mrp_groups_ HAZE_GUARDED_BY(mutex_);
+    // Dedup set for MRP input tags; reset by clear_state_locked.
+    std::unordered_set<std::string> mrp_input_tagged_names_ HAZE_GUARDED_BY(mutex_);
     uint64_t input_counter_ HAZE_GUARDED_BY(mutex_) = 0;
     uint64_t output_counter_ HAZE_GUARDED_BY(mutex_) = 0;
     bool recording_ HAZE_GUARDED_BY(mutex_) = false;
 
-    // Friendship so EpochSession's ACQUIRE/RELEASE attributes can name
-    // mutex_ directly — TSA needs the capability expression in the
-    // attribute to match the one used by the _locked methods.
+    // Friend so EpochSession's ACQUIRE/RELEASE attributes can name mutex_.
     friend class EpochSession;
 };
 
@@ -137,47 +120,34 @@ inline EpochState &epoch() noexcept {
     return EpochState::instance();
 }
 
-// RAII helper used by the compute API entry points: ensures the backend
-// is initialised, then takes the epoch mutex and ensures the recording
-// is active for the lifetime of the session. Compute helpers
-// (lookup_or_create_locked, store_compute_result_locked) are safe to call while an
-// EpochSession is in scope.
-//
-// `backend().ensure_initialized()` runs *before* the lock is taken so
-// concurrent compute callers don't serialise on the (one-time) compiler
-// init under the epoch mutex.
+// RAII guard for compute entry points: brings up the backend, takes the
+// epoch mutex, and enters recording mode for the session lifetime.
+// Backend init runs before the lock so concurrent callers don't
+// serialize on the one-time setup.
 class HAZE_SCOPED_CAPABILITY EpochSession {
   public:
     EpochSession() HAZE_ACQUIRE(epoch().mutex_) : guard_(init_then_get_mutex()) {
         epoch().ensure_recording_locked();
     }
-    // Defaulted destructor: the actual unlock runs in HazeLockGuard's
-    // destructor (member guard_). HAZE_RELEASE here just declares the
-    // capability hand-off to TSA; no body work is needed.
+    // The unlock runs in guard_'s destructor; HAZE_RELEASE just
+    // declares the capability hand-off to TSA.
     ~EpochSession() HAZE_RELEASE() = default;
 
     EpochSession(const EpochSession &) = delete;
     EpochSession &operator=(const EpochSession &) = delete;
 
   private:
-    // Side-effect helper: runs backend().ensure_initialized() (which has
-    // its own internal init mutex) BEFORE returning the epoch mutex
-    // reference. Sequencing matters — first-call compiler init must not
-    // happen under the epoch lock or concurrent callers serialize on it.
-    // Returning by reference to the very mutex that guard_ then locks
-    // lets TSA verify the ACQUIRE annotation on the constructor.
+    // Runs backend().ensure_initialized() before returning the mutex
+    // reference, so first-call compiler init isn't serialized under
+    // the epoch lock.
     static HazeMutex &init_then_get_mutex() noexcept HAZE_RETURN_CAPABILITY(epoch().mutex_);
 
     HazeLockGuard guard_;
 };
 
-// D2H-side helper: finalises any active recording via
-// replay_and_populate() (no-op when not recording), then copies bytes
-// from the device shadow buffer to a host destination. D2H is the
-// sole flush trigger; there is no separate explicit-replay entry point.
-// Returns a public hazeError_t (already translated via to_public_error);
-// the caller in src/api/ is responsible for routing the value through
-// set_error() so hazeGetLastError() reflects the failure.
+// D2H trigger: finalize any active recording (no-op otherwise), then
+// copy from the device shadow buffer to host. Returns a public
+// hazeError_t already translated for the C ABI.
 hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept;
 
 } // namespace haze

--- a/src/core/mrp_polymap.cpp
+++ b/src/core/mrp_polymap.cpp
@@ -21,6 +21,9 @@
 #include <cstdint>
 #include <expected>
 #include <niobium/fhetch_api.h>
+#include <span>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -28,25 +31,69 @@ namespace haze {
 
 namespace fhetch = niobium::fhetch;
 
+namespace {
+
+// Derive an MRP group name from dst[0] (16-hex-encoded): same op → same
+// leading addr → same name, so the EpochState dedup collapses redundant
+// tags. Trailing addrs aren't part of the name; haze's allocator doesn't
+// reuse dst[0] within a recording, so distinct ops can't collide.
+std::string mrp_signature_name(std::string_view prefix, DevAddr leading_addr) {
+    static constexpr char hex[] = "0123456789abcdef";
+    std::string out;
+    out.reserve(prefix.size() + 1 + 16);
+    out.append(prefix);
+    out.push_back('_');
+    const uint64_t v = to_uintptr(leading_addr);
+    for (int j = 15; j >= 0; --j)
+        out.push_back(hex[(v >> (j * 4)) & 0xFU]);
+    return out;
+}
+
+} // namespace
+
 std::expected<fhetch::MRP, HazeInternalError>
 build_mrp_locked(const void *const *polys, const uint64_t *base, std::size_t len) {
     std::vector<std::pair<fhetch::Polynomial, uint64_t>> pairs;
+    std::vector<DevAddr> addrs;
     pairs.reserve(len);
+    addrs.reserve(len);
     for (std::size_t i = 0; i < len; ++i) {
-        auto poly = epoch().lookup_or_create_locked(to_dev_addr(polys[i]));
+        DevAddr a = to_dev_addr(polys[i]);
+        auto poly = epoch().lookup_or_create_locked(a);
         if (!poly) {
             return std::unexpected(poly.error());
         }
         pairs.emplace_back(std::move(*poly), base[i]);
+        addrs.push_back(a);
     }
-    return fhetch::MRP::from_pairs(pairs);
+    auto mrp = fhetch::MRP::from_pairs(pairs);
+    // Additive MRP-input tag on top of the per-addr SRP inputs from
+    // lookup_or_create_locked; lets the bridge synthesize a multi-tower
+    // input CT and readers pull via fhetch::result(name, MRP&). Address-
+    // keyed name dedups when the same source MRP feeds multiple ops.
+    if (len > 1) {
+        auto group_name = mrp_signature_name("haze_mrp_in", addrs.front());
+        epoch().tag_mrp_input_if_new_locked(group_name, mrp);
+    }
+    return mrp;
 }
 
-void store_mrp_locked(void *const *dst_polys, const fhetch::MRP &mrp, const uint64_t *base,
-                      std::size_t len) {
+std::expected<void, HazeInternalError> store_mrp_locked(void *const *dst_polys,
+                                                        const fhetch::MRP &mrp,
+                                                        const uint64_t *base, std::size_t len) {
+    std::vector<DevAddr> addrs;
+    addrs.reserve(len);
     for (std::size_t i = 0; i < len; ++i) {
-        epoch().store_compute_result_locked(to_dev_addr(dst_polys[i]), mrp[base[i]]);
+        DevAddr a = to_dev_addr(dst_polys[i]);
+        epoch().store_compute_result_locked(a, mrp[base[i]]);
+        addrs.push_back(a);
     }
+    if (len > 1) {
+        auto group_name = mrp_signature_name("haze_mrp_out", addrs.front());
+        return epoch().register_mrp_output_group_locked(addrs, std::span(base, len),
+                                                        std::move(group_name));
+    }
+    return {};
 }
 
 } // namespace haze

--- a/src/core/mrp_polymap.hpp
+++ b/src/core/mrp_polymap.hpp
@@ -25,30 +25,18 @@
 
 namespace haze {
 
-// MRP polymap glue shared by the basis-convert family and the MRP compute
-// templates. The two helpers here are the contract between haze's per-residue
-// DevAddr layout and niobium-fhetch's MRP value type:
-//
-//   - build_mrp_locked: read K residues out of the polymap (or promote them
-//     from shadow buffers on first reference) and assemble an MRP carrying
-//     the supplied moduli base. Each lookup returns a *copy* of the bound
-//     Polynomial, so in-place compute (dst[i] == src1[i] / src2[i]) stays
-//     correct without further work.
-//
-//   - store_mrp_locked: decompose an MRP back into K per-residue DevAddrs,
-//     storing each residue via store_compute_result_locked so the standard
-//     output-tagging and replay-population paths apply uniformly to MRP
-//     results.
-//
-// Both helpers run under the EpochSession lock; the HAZE_REQUIRES annotation
-// keeps clang TSA enforcing that contract at every call site.
+// MRP polymap glue: build_mrp_locked assembles K per-addr residues into an
+// MRP; store_mrp_locked decomposes one back into per-addr stores. Both run
+// under the EpochSession lock (HAZE_REQUIRES enforces it via clang TSA).
 
 std::expected<niobium::fhetch::MRP, HazeInternalError>
 build_mrp_locked(const void *const *polys, const uint64_t *base, std::size_t len)
     HAZE_REQUIRES(epoch().mutex());
 
-void store_mrp_locked(void *const *dst_polys, const niobium::fhetch::MRP &mrp, const uint64_t *base,
-                      std::size_t len) HAZE_REQUIRES(epoch().mutex());
+std::expected<void, HazeInternalError> store_mrp_locked(void *const *dst_polys,
+                                                        const niobium::fhetch::MRP &mrp,
+                                                        const uint64_t *base, std::size_t len)
+    HAZE_REQUIRES(epoch().mutex());
 
 // Build an MRS from per-modulus uint64_t scalars + their primes. Pure-data
 // helper: does not touch the polymap, so no lock contract.

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -1,54 +1,30 @@
 // Copyright (C) 2026, All rights reserved by Niobium Microsystems.
 //
-// Helpers for [integration]-tagged Catch2 cases. Integration tests:
-//   1. Record FHETCH instructions through haze.
-//   2. Bridge auto-synthesizes a CryptoContext + per-input cereal-binary
-//      .bin files + per-output ciphertext templates at recording-finalize
-//      time (see haze_replay_bridge's post_recording_hook).
-//   3. The first hazeMemcpy(D2H) finalises the recording, dispatches the
-//      project to a niobium-compiler-built nbcc_fhetch_replay over the
-//      FHETCH HTTP transport, and reads the materialized values back.
-//   4. The simulator-computed values flow back as serialized_probes/*.ct,
-//      which fhetch::result reads and replay_and_populate writes into the
-//      haze shadow buffers; D2H then returns those values.
-//
-// Orchestration of the server + client-side forwarder lives in
-// scripts/test_haze_integration.sh.
+// Helpers for [integration]-tagged Catch2 cases: record through haze, the
+// bridge auto-synthesizes CC + .bin + templates, and D2H drives replay
+// back into the shadow buffers (see scripts/test_haze_integration.sh for
+// transport orchestration).
 
 #pragma once
 
+#include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <haze/haze.h>
 #include <haze/haze_types.h>
 #include <haze/replay_bridge.h>
+#include <niobium/compiler.h>
+#include <niobium/fhetch_api.h>
+#include <string>
 #include <vector>
 
 namespace haze::test {
 
-// Combined integration setup: reset, ring dim, bridge CryptoContext init
-// (which writes <program_dir>/cryptocontext.dat), align haze's ciphertext
-// modulus with OpenFHE's picked tower prime, then configure the device.
-// Returns the picked modulus so callers can keep using it consistently
-// with what haze recorded.
-//
-// Target selection: the test Makefile (test-sim / test-transport) sets
-// HAZE_TARGET to whichever string the surrounding suite needs. The
-// helper honours that env var; if unset, falls back to haze's own
-// default ("local" — in-process FHETCH simulator, per hazeSetTarget docs).
-//
-// Modulus alignment: OpenFHE's CKKS GenCryptoContext picks a prime near
-// 2^bits(desired). The picked value rarely matches `desired_modulus`
-// exactly. To keep haze's recording-side modulus arithmetic in lockstep
-// with the .ct round-trip, we feed the picked value back into
-// hazeSetCiphertextModulus before any compute.
-//
-// After this call returns, tests do compute + hazeMemcpy(D2H); the D2H
-// triggers replay before reading the shadow buffer. The bridge's
-// post_recording_hook auto-writes the .bin / .ids / .template artifacts
-// during stop(); tests do not need to call WriteTemplate or
-// WriteInputBin explicitly.
+// Combined integration setup: reset, ring dim, bridge CC init, align haze's
+// ciphertext modulus with OpenFHE's picked prime, configure device. Returns
+// the picked modulus so callers stay in lockstep with the .ct round-trip.
 inline uint64_t setup_integration_compute_config(uint64_t ring_dim = 4096,
                                                  uint64_t desired_modulus = 576460752303415297ULL,
                                                  int mod_idx = 0) {
@@ -75,10 +51,8 @@ inline std::vector<uint64_t> make_residue(uint64_t prime, uint64_t seed, std::si
     return r;
 }
 
-// Allocate one HAZE poly slot per residue and H2D each row of `residues`
-// into it. Returned vector is parallel to `residues`; ownership stays with
-// the caller (free with free_all_residues). Aborts the test on any HAZE
-// error to keep the body of the test linear.
+// Allocate one slot per residue and H2D each row; ownership stays with the
+// caller (free with free_all_residues, REQUIRE-aborts on any haze error).
 inline std::vector<void *>
 allocate_and_h2d_residues(const std::vector<std::vector<uint64_t>> &residues) {
     std::vector<void *> ptrs(residues.size(), nullptr);
@@ -106,24 +80,15 @@ inline void free_all_residues(const std::vector<void *> &ptrs) {
     }
 }
 
-// Convenience: produce a parallel vector<const void *> view over a
-// vector<void *>. Useful when passing dst slots as src in a chained
-// recording.
+// Parallel const view over a vector<void *>; useful for chaining dst slots
+// as src in a recording.
 inline std::vector<const void *> to_const(const std::vector<void *> &ptrs) {
     return {ptrs.begin(), ptrs.end()};
 }
 
-// Negacyclic convolution mod q: c(X) = a(X) * b(X) mod (X^N + 1, q).
-// O(N^2). Uses __uint128_t per-term so ~60-bit primes don't overflow the
-// product. X^N = -1 in this quotient ring, so a contribution at index
-// (i + j) wraps with a sign flip when i + j >= N. Intended as a host
-// oracle for NTT->hazeMul->INTT integration tests, not a hot path.
-//
-// Preconditions: a.size() == b.size(), all coefficients in [0, q).
-// Loop invariant: every c[k] stays in [0, q) after each update — the
-// branches below depend on this. If a future edit reorders or extends
-// the update logic, preserve this invariant or the modular arithmetic
-// will silently corrupt.
+// Negacyclic convolution mod q (host oracle for NTT/hazeMul/INTT tests, not
+// a hot path); X^N = -1 wraps with a sign flip when i+j ≥ N. Loop invariant:
+// each c[k] stays in [0, q) — the branches below rely on it.
 inline std::vector<uint64_t> negacyclic_conv_ref(const std::vector<uint64_t> &a,
                                                  const std::vector<uint64_t> &b, uint64_t q) {
     REQUIRE(a.size() == b.size());
@@ -154,6 +119,53 @@ inline std::vector<uint64_t> negacyclic_conv_ref(const std::vector<uint64_t> &a,
         }
     }
     return c;
+}
+
+// Cross-check an MRP output by content (not auto-generated name) so op-order
+// shifts don't break the test. SRP is the ground truth; this asserts the
+// MRP read path returns the same per-residue values.
+inline void check_mrp_against_per_residue(const std::vector<uint64_t> &base,
+                                          const std::vector<std::vector<uint64_t>> &expected) {
+    REQUIRE(expected.size() == base.size());
+    namespace fs = std::filesystem;
+    const auto probes_dir = niobium::compiler().get_program_directory() / "serialized_probes";
+    INFO("scanning " << probes_dir);
+    REQUIRE(fs::exists(probes_dir));
+
+    auto residue_matches = [&](const niobium::fhetch::MRP &mrp) -> bool {
+        if (mrp.num_residues() != base.size())
+            return false;
+        const auto &got_base = mrp.base();
+        for (std::size_t i = 0; i < base.size(); ++i) {
+            if (std::ranges::find(got_base, base[i]) == got_base.end())
+                return false;
+            if (mrp[base[i]].int_data() != expected[i])
+                return false;
+        }
+        return true;
+    };
+
+    // At least one captured group should match; multiple is fine since
+    // disk cleanup at hazeReplayBridgeReset prevents stale-file leaks.
+    bool found = false;
+    std::string matched_name;
+    for (const auto &entry : fs::directory_iterator(probes_dir)) {
+        if (!entry.is_regular_file())
+            continue;
+        const auto stem = entry.path().stem().string();
+        if (!stem.starts_with("haze_mrp_out_"))
+            continue;
+        niobium::fhetch::MRP mrp;
+        if (!niobium::fhetch::result(stem, mrp))
+            continue;
+        if (residue_matches(mrp)) {
+            found = true;
+            matched_name = stem;
+            break;
+        }
+    }
+    INFO("matched MRP group: " << (found ? matched_name : std::string{"<none>"}));
+    REQUIRE(found);
 }
 
 } // namespace haze::test

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -1,24 +1,9 @@
 // Copyright (C) 2026, All rights reserved by Niobium Microsystems.
 //
-// Compute API integration tests, parameterised over a per-shape "driver":
-//
-//   SrpDriver — single-residue (kNumResidues == 1). Wraps the SRP entry
-//               points (hazeAdd, hazeSub, hazeMul, hazeAddScalar,
-//               hazeSubScalar, hazeMulScalar, hazeNTT, hazeINTT).
-//
-//   MrpDriver — multi-residue (kNumResidues == 3). Wraps the MRP entry
-//               points (hazeAddMrp, hazeSubMrp, ..., hazeNTTMrp,
-//               hazeINTTMrp). Three NTT-friendly primes (kQ0/kQ1/kQ2)
-//               make every residue distinct, and assertions check every
-//               coefficient of every residue so single-residue regressions
-//               cannot hide.
-//
-// Each scenario lives in a Catch2 TEMPLATE_TEST_CASE that fans out across
-// both drivers, so the body is identical and the test names show up
-// per-driver in the runner output.
-//
-// Cases without an MRP counterpart (the modulus-index error path,
-// hazeAutomorph, the synchronization no-op) stay as plain TEST_CASE.
+// Compute API integration tests, parameterised over a per-shape Driver
+// (SrpDriver = 1 residue, MrpDriver = 3 distinct primes for every-coefficient
+// per-residue assertions). TEMPLATE_TEST_CASE fans out across both;
+// SRP-only cases (modulus-error, hazeAutomorph, sync no-op) stay TEST_CASE.
 
 #include "integration_helpers.hpp"
 
@@ -38,29 +23,26 @@ namespace {
 constexpr uint64_t kRingDim = 4096;
 constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
 
-// Three NTT-friendly primes (q ≡ 1 mod 2N) for N=4096. Same values used
-// by test_basis_convert.cpp's configure_three_moduli — keeps multi-residue
-// fixtures consistent across the suite.
+// Three NTT-friendly primes (q ≡ 1 mod 2N) for N=4096; matches
+// test_basis_convert.cpp::configure_three_moduli for suite consistency.
 constexpr uint64_t kQ0 = 576460752303415297ULL;
 constexpr uint64_t kQ1 = 576460752303439873ULL;
 constexpr uint64_t kQ2 = 576460752303702017ULL;
 
 // ---------------------------------------------------------------------------
-// SrpDriver: single-residue path. kNumResidues == 1 collapses every
-// vector<>-shaped argument to a single element and dispatches the SRP
-// entry points directly.
+// SrpDriver: single-residue path; vector args collapse to one element and
+// dispatch the SRP entry points directly.
 // ---------------------------------------------------------------------------
 
 struct SrpDriver {
     static constexpr std::size_t kNumResidues = 1;
     static constexpr const char *kShape = "SRP";
 
-    // Populated by setup(); the test body uses `base[i]` as the per-residue
-    // modulus when constructing inputs and per-residue oracles.
+    // Populated by setup(); test body uses base[i] as the per-residue modulus.
     std::vector<uint64_t> base;
 
-    // Returns the picked prime so callers that want q (e.g. for
-    // negacyclic_conv_ref) can grab it without re-deriving from `base`.
+    // Returns the picked prime so callers (e.g. negacyclic_conv_ref) get q
+    // without re-deriving from `base`.
     uint64_t setup() {
         const uint64_t q =
             haze::test::setup_integration_compute_config(kRingDim, kQ0, /*mod_idx=*/0);
@@ -68,10 +50,8 @@ struct SrpDriver {
         return q;
     }
 
-    // Op methods don't read `base` (the SRP entry points take a single
-    // mod_idx and pull the modulus from haze's config table), so they are
-    // static. The MrpDriver counterparts read `base` and stay instance
-    // methods. Catch2's `d.method(...)` call site syntax works for both.
+    // SRP ops are static (read modulus from config via mod_idx); the MRP
+    // counterparts read `base` and stay instance methods.
     static void add(const std::vector<void *> &dst, const std::vector<const void *> &s1,
                     const std::vector<const void *> &s2) {
         REQUIRE(hazeAdd(dst[0], s1[0], s2[0], 0, nullptr) == HAZE_SUCCESS);
@@ -109,12 +89,9 @@ struct SrpDriver {
 };
 
 // ---------------------------------------------------------------------------
-// MrpDriver: multi-residue path. Three explicit primes; each call goes
-// through the hazeXxxMrp entry points with the full (base, base_len)
-// pair. Mirrors test_basis_convert.cpp's pattern of feeding explicit
-// kQ0/kQ1/kQ2 into hazeSetCiphertextModulus rather than the OpenFHE-
-// picked single prime — the simulator reads moduli out of the trace's
-// modulus_table, so the picked prime is for bridge plumbing only.
+// MrpDriver: multi-residue path; three explicit primes feed the hazeXxxMrp
+// entry points (the OpenFHE-picked prime is bridge plumbing — the simulator
+// reads moduli from the trace's modulus_table).
 // ---------------------------------------------------------------------------
 
 struct MrpDriver {
@@ -223,9 +200,19 @@ void check_against_per_residue(const Driver &d, const std::vector<void *> &dst,
     }
 }
 
-// Build a parallel pair of per-residue inputs differentiated by both `seed`
-// and the residue index, then pre-compute the per-residue oracle for an
-// op that maps (a, b) → r mod q. Caller supplies the reducing function.
+// SRP-vs-MRP cross-check; locates the matching group by content, skips for
+// SRP drivers (degenerate 1-residue groups aren't registered).
+template <typename Driver>
+void check_against_per_residue_with_mrp(const Driver &d, const std::vector<void *> &dst,
+                                        const std::vector<std::vector<uint64_t>> &expected) {
+    check_against_per_residue(d, dst, expected);
+    if constexpr (Driver::kNumResidues > 1) {
+        haze::test::check_mrp_against_per_residue(d.base, expected);
+    }
+}
+
+// Build a parallel pair of per-residue inputs (seed differs per residue)
+// and the per-residue oracle for an op (a, b) → r mod q.
 template <typename Op>
 void make_two_residue_inputs(const std::vector<uint64_t> &base,
                              std::vector<std::vector<uint64_t>> &a_out,
@@ -271,7 +258,7 @@ TEMPLATE_TEST_CASE("hazeAdd: pointwise sum retrieved after D2H", "[integration]"
     auto dst = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
 
     d.add(dst, haze::test::to_const(da), haze::test::to_const(db));
-    check_against_per_residue(d, dst, expected);
+    check_against_per_residue_with_mrp(d, dst, expected);
 
     haze::test::free_all_residues(da);
     haze::test::free_all_residues(db);
@@ -294,7 +281,7 @@ TEMPLATE_TEST_CASE("hazeSub: pointwise difference retrieved after D2H", "[integr
     auto dst = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
 
     d.sub(dst, haze::test::to_const(da), haze::test::to_const(db));
-    check_against_per_residue(d, dst, expected);
+    check_against_per_residue_with_mrp(d, dst, expected);
 
     haze::test::free_all_residues(da);
     haze::test::free_all_residues(db);
@@ -317,7 +304,7 @@ TEMPLATE_TEST_CASE("hazeMul: pointwise product retrieved after D2H", "[integrati
     auto dst = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
 
     d.mul(dst, haze::test::to_const(da), haze::test::to_const(db));
-    check_against_per_residue(d, dst, expected);
+    check_against_per_residue_with_mrp(d, dst, expected);
 
     haze::test::free_all_residues(da);
     haze::test::free_all_residues(db);
@@ -332,9 +319,8 @@ TEMPLATE_TEST_CASE("hazeMul: pointwise product retrieved after D2H", "[integrati
 // ===========================================================================
 
 namespace {
-// Derive a non-trivial per-residue scalar that fits in the prime, exercising
-// reduction-on-input rather than a tiny constant that lives in [0, q) for
-// every prime.
+// Per-residue scalar that fits in each prime; exercises reduction-on-input
+// rather than a tiny constant that lives in [0, q) for every prime.
 inline std::vector<uint64_t> derive_scalars(const std::vector<uint64_t> &base, uint64_t k_base) {
     std::vector<uint64_t> s(base.size());
     for (std::size_t i = 0; i < base.size(); ++i) {
@@ -364,7 +350,7 @@ TEMPLATE_TEST_CASE("hazeAddScalar: pointwise scalar addition retrieved after D2H
     auto dst = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
 
     d.add_scalar(dst, haze::test::to_const(da), scalars);
-    check_against_per_residue(d, dst, expected);
+    check_against_per_residue_with_mrp(d, dst, expected);
 
     haze::test::free_all_residues(da);
     haze::test::free_all_residues(dst);
@@ -390,7 +376,7 @@ TEMPLATE_TEST_CASE("hazeSubScalar: pointwise scalar subtraction retrieved after 
     auto dst = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
 
     d.sub_scalar(dst, haze::test::to_const(da), scalars);
-    check_against_per_residue(d, dst, expected);
+    check_against_per_residue_with_mrp(d, dst, expected);
 
     haze::test::free_all_residues(da);
     haze::test::free_all_residues(dst);
@@ -416,18 +402,16 @@ TEMPLATE_TEST_CASE("hazeMulScalar: pointwise scalar product retrieved after D2H"
     auto dst = haze::test::allocate_dst_residues(TestType::kNumResidues, kBytes);
 
     d.mul_scalar(dst, haze::test::to_const(da), scalars);
-    check_against_per_residue(d, dst, expected);
+    check_against_per_residue_with_mrp(d, dst, expected);
 
     haze::test::free_all_residues(da);
     haze::test::free_all_residues(dst);
 }
 
 // ===========================================================================
-// NTT round-trip per residue. INTT(NTT(x)) must recover the original
-// coefficients exactly for every residue.
-//
-// Constants are eigenvectors of NTT and survive even pathological twiddle /
-// scaling bugs, so each residue uses a deterministic non-constant input.
+// NTT round-trip per residue: INTT(NTT(x)) must recover the input exactly.
+// Each residue uses a deterministic non-constant input — constants are NTT
+// eigenvectors and would mask twiddle/scaling bugs.
 // ===========================================================================
 
 TEMPLATE_TEST_CASE("NTT round-trip: INTT(NTT(x)) == x", "[integration]", SrpDriver, MrpDriver) {
@@ -451,6 +435,11 @@ TEMPLATE_TEST_CASE("NTT round-trip: INTT(NTT(x)) == x", "[integration]", SrpDriv
     d.intt(d_intt, haze::test::to_const(d_ntt));
 
     check_against_per_residue(d, d_intt, src);
+    if constexpr (TestType::kNumResidues > 1) {
+        // Bulk-MRP read agrees with the SRP D2H above; content match means
+        // a second MRP group in the same recording doesn't confuse it.
+        haze::test::check_mrp_against_per_residue(d.base, src);
+    }
 
     haze::test::free_all_residues(d_src);
     haze::test::free_all_residues(d_ntt);
@@ -458,35 +447,18 @@ TEMPLATE_TEST_CASE("NTT round-trip: INTT(NTT(x)) == x", "[integration]", SrpDriv
 }
 
 // ===========================================================================
-// Galois automorphism (eval form) round-trip.
-//
-// The op X -> X^k is a permutation of the 2N-th-root-of-unity evaluation
-// slots, so applying automorph(k) followed by automorph(k_inv) where
-// k * k_inv ≡ 1 (mod 2N) recovers the input exactly. This tests the Galois
-// action — NOT a coefficient-form negacyclic rotation (which is the
-// separate IR op sr_rot_automorph_coeff and has no MRP variant).
-//
-// The round-trip is bracketed by NTT / INTT so the trace's modulus_table
-// carries a real prime (sr_automorph_eval itself uses COPY_MODULUS as a
-// sentinel; without an accompanying real-modulus op, the replay bridge has
-// no prime to bind the H2D input bytes to). This also matches how
-// rotation is used in real CKKS workloads: ciphertexts are produced in
-// evaluation form, automorph is applied there, and the result stays in
-// evaluation form — INTT here is just to compare against the original
-// coefficient-form input.
+// Galois automorphism (eval form) round-trip: automorph(k) ∘ automorph(k_inv)
+// with k*k_inv ≡ 1 (mod 2N) is identity. Bracketed with NTT/INTT so the
+// trace's modulus_table carries a real prime (sr_automorph_eval uses
+// COPY_MODULUS).
 // ===========================================================================
 
 TEMPLATE_TEST_CASE("automorph impulse: X^1 -> X^k under automorph(_, k)", "[integration]",
                    SrpDriver, MrpDriver) {
-    // Direction-sensitive check for the eval-form Galois automorphism.
-    // Spec: output_slot[i] = +src_slot[((k*(2i+1) - 1) mod 2N) / 2]
-    // (signs[i] = 1; pure permutation, no sign flip in the op itself).
-    // Acting on a coefficient-form impulse f(X) = X^1, the round-trip
-    // ntt → automorph(_, k) → intt produces the polynomial X^(j*k mod 2N)
-    // reduced mod X^N+1 (i.e. with a sign flip if j*k mod 2N >= N).
-    // Choose k=5, j=1 so j*k = 5 < N → no wrap, expected coefficient is
-    // +1 at position 5. The round-trip test below is direction-symmetric
-    // and would not catch a substitution-direction bug here.
+    // Direction-sensitive check: ntt → automorph(_, k) → intt on impulse X^j
+    // lands at X^(j*k mod 2N) (sign-flipped if ≥ N). With k=5, j=1, j*k=5<N,
+    // expected is +1 at position 5; the round-trip test alone is symmetric
+    // and wouldn't catch a substitution-direction bug.
     TestType d;
     d.setup();
 
@@ -518,6 +490,9 @@ TEMPLATE_TEST_CASE("automorph impulse: X^1 -> X^k under automorph(_, k)", "[inte
     d.intt(d_back, haze::test::to_const(d_aut));
 
     check_against_per_residue(d, d_back, expected);
+    if constexpr (TestType::kNumResidues > 1) {
+        haze::test::check_mrp_against_per_residue(d.base, expected);
+    }
 
     haze::test::free_all_residues(d_src);
     haze::test::free_all_residues(d_eval);
@@ -556,6 +531,9 @@ TEMPLATE_TEST_CASE("automorph round-trip: automorph(k) then automorph(k_inv) == 
     d.intt(d_back, haze::test::to_const(d_aut2));
 
     check_against_per_residue(d, d_back, src);
+    if constexpr (TestType::kNumResidues > 1) {
+        haze::test::check_mrp_against_per_residue(d.base, src);
+    }
 
     haze::test::free_all_residues(d_src);
     haze::test::free_all_residues(d_eval);
@@ -565,37 +543,16 @@ TEMPLATE_TEST_CASE("automorph round-trip: automorph(k) then automorph(k_inv) == 
 }
 
 // ===========================================================================
-// Negacyclic-coefficient rotation: rot(_, k) is multiplication by X^k in
-// R_q = Z_q[X]/(X^N+1). Composing rot(_, k) ∘ rot(_, N-k) is multiplication
-// by X^N, which equals -1 in R_q — so the result is -x per coefficient
-// per residue. This single property exercises both the coefficient shift
-// itself and the sign flip on wraparound (without it, the test would
-// produce +x instead of -x).
-//
-// As with the automorph_eval round-trip, the test brackets the rotations
-// with an ntt/intt round-trip so the bridge captures the input addresses
-// (sr_rot_automorph_coeff alone does not register inputs into the bridge's
-// haze.inputs.json manifest, so the simulator sees uninitialized data;
-// the ntt acts as the "approved" op that pulls the input through). The
-// ntt+intt pair is identity per the NTT round-trip test, so the rotation
-// property is preserved.
-//
-// MrpDriver-only (haze does not expose a coefficient-form rotation in
-// the SRP API, so there is no SrpDriver::rot_automorph_coeff to dispatch
-// against from a TEMPLATE_TEST_CASE).
+// Negacyclic-coefficient rotation: rot(_, k) ∘ rot(_, N-k) = X^N = -1, so
+// the result is -x per coefficient. Bracketed with NTT/INTT so the bridge
+// captures the input addresses (rot alone doesn't register inputs);
+// MRP-only (no SRP rot_automorph_coeff entry point exists).
 // ===========================================================================
 
 TEST_CASE("hazeRotAutomorphCoeffMrp: impulse lands at the spec-defined position", "[integration]") {
-    // Direction-sensitive check. The round-trip property below
-    // (rot(_, k) ∘ rot(_, N-k) == -x) is symmetric under inversion of
-    // the rotation direction, so it cannot catch a left-vs-right swap
-    // in the simulator's exec_rot_automorph_coeff. Pin the direction by
-    // feeding a sparse input and asserting the spec's exact landing
-    // position per FHETCH spec:
-    //   output[i] = signs[i] * src[(i + offset) mod N],
-    //   signs[i] = (-1)^((i + offset) // N).
-    // For src = [1, 2, 0, 0, ..., 0] and offset = 1, the only nonzero
-    // outputs are output[0] = +src[1] = 2 and output[N-1] = -src[0] = q-1.
+    // Direction-sensitive: feed a sparse input so the spec's landing
+    // (output[i] = signs[i] * src[(i+offset) mod N]) is asymmetric. With
+    // src=[1,2,0,...] and offset=1, output[0]=+src[1]=2 and output[N-1]=q-1.
     MrpDriver d;
     d.setup();
 
@@ -683,25 +640,15 @@ TEST_CASE("hazeRotAutomorphCoeffMrp: rot(_, k) ∘ rot(_, N-k) == -x", "[integra
 }
 
 // ===========================================================================
-// Polynomial product via NTT.Mul.INTT, per residue.
-//
-// Each residue independently does negacyclic convolution: the host oracle
-// negacyclic_conv_ref runs once per (residue, base[i]) pair, and every
-// coefficient must agree with what hazeMul-on-evaluation-form-then-INTT
-// produces in coefficient form.
-//
-// The four sub-cases cover: monomial * monomial across the X^N=-1 boundary,
-// linear * constant, deterministic small coefficients, and full-range
-// random coefficients.
+// Polynomial product via NTT.Mul.INTT per residue: every coefficient must
+// agree with negacyclic_conv_ref. Sub-cases cover monomial*monomial across
+// the X^N=-1 boundary, linear*constant, small coefficients, and full-range.
 // ===========================================================================
 
 namespace {
 
-// Per-driver helper: H2D each residue of `a` and `b`, run NTT on each,
-// MUL on each (per-residue or via mr_mulp), then INTT on each. Returns
-// the per-residue coefficient-form result. Mirrors the original SRP-only
-// run_ntt_mul_intt but folds into the driver dispatch so SRP and MRP
-// share the same orchestration.
+// H2D, NTT, MUL, INTT each residue of (a, b); returns per-residue
+// coefficient-form result via the driver dispatch.
 template <typename Driver>
 std::vector<std::vector<uint64_t>> run_ntt_mul_intt(const Driver &d,
                                                     const std::vector<std::vector<uint64_t>> &a,
@@ -822,9 +769,8 @@ TEMPLATE_TEST_CASE("polynomial product: random small coefficients via NTT.Mul.IN
     TestType d;
     d.setup();
 
-    // Deterministic small coefficients (< 1024). The pattern differs per
-    // residue (via base index) so each residue genuinely runs a different
-    // convolution.
+    // Deterministic small coefficients (< 1024) with a per-residue pattern
+    // so each residue runs a distinct convolution.
     std::vector<std::vector<uint64_t>> a(TestType::kNumResidues);
     std::vector<std::vector<uint64_t>> b(TestType::kNumResidues);
     for (std::size_t r = 0; r < TestType::kNumResidues; ++r) {
@@ -852,9 +798,8 @@ TEMPLATE_TEST_CASE("polynomial product: random full-range coefficients via NTT.M
     TestType d;
     d.setup();
 
-    // Full-range coefficients uniform over [0, q). Exercises modular
-    // reduction in the convolution. Pattern mirrors test_basis_convert.cpp's
-    // make_residue but uses different seeds per residue.
+    // Full-range coefficients in [0, q) to exercise modular reduction;
+    // per-residue seeds mirror test_basis_convert.cpp's make_residue.
     std::vector<std::vector<uint64_t>> a(TestType::kNumResidues);
     std::vector<std::vector<uint64_t>> b(TestType::kNumResidues);
     for (std::size_t r = 0; r < TestType::kNumResidues; ++r) {
@@ -885,10 +830,8 @@ TEMPLATE_TEST_CASE("polynomial product: random full-range coefficients via NTT.M
 }
 
 // ===========================================================================
-// In-place operations. dst[i] aliasing src1[i] / src2[i] / both must
-// produce the right answer per residue. The lookup_or_create_locked copy
-// semantics on each residue make this safe whether the IR op is sr_* or
-// mr_*; the templated coverage proves it.
+// In-place ops: dst aliasing src1/src2/both must still produce the right
+// answer per residue (lookup_or_create_locked's copy semantics make it safe).
 // ===========================================================================
 
 TEMPLATE_TEST_CASE("hazeAdd in-place (dst == src1) produces correct result", "[integration]",
@@ -1017,10 +960,9 @@ TEMPLATE_TEST_CASE("hazeMul in-place squaring-style (dst == src1 == src2)", "[in
 }
 
 // ===========================================================================
-// Multi-operation chains and lazy-recording semantics. These verify that
-// the EpochSession bundles multiple compute calls into one recording and
-// that polymap invalidation paths (H2D / memset) work in the MRP fan-out
-// just as they do for SRP.
+// Multi-op chains and lazy-recording semantics: EpochSession bundles
+// multiple calls into one recording, and polymap invalidation (H2D / memset)
+// works in the MRP fan-out as it does for SRP.
 // ===========================================================================
 
 TEMPLATE_TEST_CASE("multi-operation chain: add then mulscalar in one recording", "[integration]",
@@ -1421,4 +1363,44 @@ TEST_CASE("hazeAutomorphMrp rejects null arrays / zero base length", "[unit]") {
     REQUIRE(hazeAutomorphMrp(dst_polys, src_polys, 5, base, 0, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
+}
+
+// ============================================================================
+// MRP-shape output round-trip: dedicated coverage for the bulk MRP read path
+// across an explicit 3-tower hazeMulMrp. The single-op cross-checks above
+// (check_against_per_residue_with_mrp) already exercise the SRP-vs-MRP
+// agreement path; this test is a focused regression locking in num_residues,
+// base, and per-residue values for a known input pair.
+// ============================================================================
+
+TEST_CASE("MRP output round-trip: hazeMulMrp result via fhetch::result(name, MRP&)",
+          "[integration]") {
+    MrpDriver d;
+    d.setup();
+
+    std::vector<std::vector<uint64_t>> a;
+    std::vector<std::vector<uint64_t>> b;
+    std::vector<std::vector<uint64_t>> expected;
+    make_two_residue_inputs(d.base, a, b, expected, /*seed_a=*/0xFACEFEEDULL,
+                            /*seed_b=*/0xDEADC0DEULL, mul_mod);
+
+    auto da = haze::test::allocate_and_h2d_residues(a);
+    auto db = haze::test::allocate_and_h2d_residues(b);
+    auto dst = haze::test::allocate_dst_residues(MrpDriver::kNumResidues, kBytes);
+
+    d.mul(dst, haze::test::to_const(da), haze::test::to_const(db));
+
+    // Trigger replay via the SRP path so the bridge writes the multi-tower
+    // template and the simulator emits the corresponding
+    // serialized_probes/haze_mrp_out_<addr-derived>.ct.
+    check_against_per_residue(d, dst, expected);
+
+    // Pull the MRP-shape view directly. Asserts num_residues, base, and
+    // per-residue values; cross-checks that SRP ground truth and MRP view
+    // agree exactly. Helper locates the group by content, no name needed.
+    haze::test::check_mrp_against_per_residue(d.base, expected);
+
+    haze::test::free_all_residues(da);
+    haze::test::free_all_residues(db);
+    haze::test::free_all_residues(dst);
 }

--- a/test/test_mul_rotation.cpp
+++ b/test/test_mul_rotation.cpp
@@ -104,13 +104,9 @@ inline uint64_t bit_rev(uint64_t x, unsigned bits) {
     return r;
 }
 
-// hazeAutomorph's docstring describes σ_k in slot space (output slot i
-// reads from input slot j where 2j+1 ≡ k*(2i+1) mod 2N), but the
-// FHETCH simulator stores eval-form values in bit-reversed positions
-// (NTL's ForwardTransformToBitReverse, simulator.cpp:266-296). Both
-// the output and source indices therefore need bit_rev to translate
-// between slot space and storage space — reversing only one direction
-// is the trap a naive read of the docstring falls into.
+// hazeAutomorph spec is in slot space, but the FHETCH simulator stores
+// eval-form values bit-reversed; bit_rev both indices to translate (one-way
+// translation is the docstring trap).
 inline std::vector<uint64_t> sigma(const std::vector<uint64_t> &in_storage, uint64_t k) {
     const uint64_t two_n = 2ULL * kRingDim;
     std::vector<uint64_t> out_storage(kRingDim);
@@ -177,6 +173,13 @@ TEMPLATE_TEST_CASE("mul→automorph→automorph: two rotations sharing one produ
 
     check_against_per_residue(d, d_r1, r1_expected);
     check_against_per_residue(d, d_r2, r2_expected);
+
+    // Cross-check MRP path against SRP ground truth (both end up reading
+    // the same simulator output); helper matches by content, not name.
+    if constexpr (TestType::kNumResidues > 1) {
+        haze::test::check_mrp_against_per_residue(d.base, r1_expected);
+        haze::test::check_mrp_against_per_residue(d.base, r2_expected);
+    }
 
     haze::test::free_all_residues(d_a);
     haze::test::free_all_residues(d_b);

--- a/test/test_user_crypto_context.cpp
+++ b/test/test_user_crypto_context.cpp
@@ -95,6 +95,10 @@ TEST_CASE("user-registered CC: hazeAddMrp round-trips through FIXEDAUTO", "[inte
         }
     }
 
+    // MRP read path: fhetch::result(name, MRP&) should report the same
+    // per-residue values as the SRP D2H above, under the user CC's moduli.
+    haze::test::check_mrp_against_per_residue(base, expected);
+
     haze::test::free_all_residues(da);
     haze::test::free_all_residues(db);
     haze::test::free_all_residues(dst);

--- a/test/test_user_crypto_context.cpp
+++ b/test/test_user_crypto_context.cpp
@@ -1,0 +1,101 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// Integration test for the bridge's user-provided CryptoContext path.
+// Builds a CC with a non-default scaling technique (FIXEDAUTO) and feeds
+// it to the bridge via hazeReplayBridgeRegisterCryptoContext, then runs an
+// MRP add and verifies the per-residue result via D2H.
+
+#include "integration_helpers.hpp"
+#include "openfhe.h"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
+#include <haze/replay_bridge_cc.hpp>
+#include <vector>
+
+namespace {
+
+constexpr uint64_t kRingDim = 4096;
+constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
+
+inline uint64_t add_mod(uint64_t a, uint64_t b, uint64_t q) {
+    const uint64_t s = a + b;
+    return (s >= q) ? s - q : s;
+}
+
+} // namespace
+
+TEST_CASE("user-registered CC: hazeAddMrp round-trips through FIXEDAUTO", "[integration]") {
+    using namespace lbcrypto;
+
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+
+    // Caller-built CC with a scaling technique the bridge's default path
+    // (hazeReplayBridgeInitCryptoContext) would force to FIXEDMANUAL.
+    CCParams<CryptoContextCKKSRNS> params;
+    params.SetSecurityLevel(HEStd_NotSet);
+    params.SetRingDim(static_cast<uint32_t>(kRingDim));
+    params.SetMultiplicativeDepth(2); // 3-tower chain
+    params.SetFirstModSize(60);
+    params.SetScalingModSize(59);
+    params.SetScalingTechnique(FIXEDAUTO);
+    auto cc = GenCryptoContext(params);
+    REQUIRE(cc);
+    cc->Enable(PKE);
+    cc->Enable(KEYSWITCH);
+    cc->Enable(LEVELEDSHE);
+    auto keys = cc->KeyGen();
+    REQUIRE(keys.publicKey);
+    REQUIRE(keys.secretKey);
+
+    REQUIRE(haze::hazeReplayBridgeRegisterCryptoContext(cc, keys) == HAZE_SUCCESS);
+
+    // Pull OpenFHE's picked primes out of the CC and seed haze's modulus
+    // table with them so the trace and the templates use the same moduli.
+    const auto &eparams = cc->GetCryptoParameters()->GetElementParams()->GetParams();
+    REQUIRE(eparams.size() >= 3);
+    std::vector<uint64_t> base;
+    base.reserve(3);
+    for (std::size_t i = 0; i < 3; ++i) {
+        base.push_back(eparams[i]->GetModulus().ConvertToInt());
+        REQUIRE(hazeSetCiphertextModulus(static_cast<int>(i), base[i]) == HAZE_SUCCESS);
+    }
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+
+    // Build per-residue inputs + expected output for hazeAddMrp.
+    std::vector<std::vector<uint64_t>> a(3), b(3), expected(3);
+    for (std::size_t i = 0; i < 3; ++i) {
+        a[i] = haze::test::make_residue(base[i], 0xAAAAULL + i, kRingDim);
+        b[i] = haze::test::make_residue(base[i], 0xBBBBULL + i, kRingDim);
+        expected[i].resize(kRingDim);
+        for (std::size_t k = 0; k < kRingDim; ++k)
+            expected[i][k] = add_mod(a[i][k], b[i][k], base[i]);
+    }
+
+    auto da = haze::test::allocate_and_h2d_residues(a);
+    auto db = haze::test::allocate_and_h2d_residues(b);
+    auto dst = haze::test::allocate_dst_residues(3, kBytes);
+
+    auto da_const = haze::test::to_const(da);
+    auto db_const = haze::test::to_const(db);
+    REQUIRE(hazeAddMrp(dst.data(), da_const.data(), db_const.data(), base.data(), base.size(),
+                       nullptr) == HAZE_SUCCESS);
+
+    for (std::size_t i = 0; i < 3; ++i) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), dst[i], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        for (std::size_t k = 0; k < kRingDim; ++k) {
+            INFO("residue " << i << " (mod " << base[i] << ") slot " << k);
+            REQUIRE(got[k] == expected[i][k]);
+        }
+    }
+
+    haze::test::free_all_residues(da);
+    haze::test::free_all_residues(db);
+    haze::test::free_all_residues(dst);
+}

--- a/test/test_user_crypto_context.cpp
+++ b/test/test_user_crypto_context.cpp
@@ -8,12 +8,12 @@
 #include "integration_helpers.hpp"
 #include "openfhe.h"
 
+#include <catch2/catch_message.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <cstddef>
 #include <cstdint>
 #include <haze/haze.h>
 #include <haze/haze_types.h>
-#include <haze/replay_bridge.h>
 #include <haze/replay_bridge_cc.hpp>
 #include <vector>
 
@@ -68,7 +68,9 @@ TEST_CASE("user-registered CC: hazeAddMrp round-trips through FIXEDAUTO", "[inte
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     // Build per-residue inputs + expected output for hazeAddMrp.
-    std::vector<std::vector<uint64_t>> a(3), b(3), expected(3);
+    std::vector<std::vector<uint64_t>> a(3);
+    std::vector<std::vector<uint64_t>> b(3);
+    std::vector<std::vector<uint64_t>> expected(3);
     for (std::size_t i = 0; i < 3; ++i) {
         a[i] = haze::test::make_residue(base[i], 0xAAAAULL + i, kRingDim);
         b[i] = haze::test::make_residue(base[i], 0xBBBBULL + i, kRingDim);


### PR DESCRIPTION
Stand up the haze side of multi-residue MRP/MRPArray support so fhetch::result(name, MRP&) returns a real N-residue polynomial instead of a 1-residue degenerate. The bridge synthesizes per-shape OpenFHE templates, epoch tags an additive MRP group alongside the per-addr SRP probes, and reset_bridge_caches cleans on-disk probes order-independently.

Also splits BackendError into 5 specific HazeInternalError variants for sharper diagnostics, consolidates pending_mrp_groups_ into a name-keyed map (the keys absorb the dedup set), and trims every comment in the touched files to ≤2 concise sentences.