### PR TITLE
core: migrate shadow buffer to vector<uint64_t>; zero-copy input promotion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,10 +246,12 @@ add_executable(haze_tests
   test/test_ring_dim_consistency.cpp
   test/test_integration_helpers.cpp
   test/test_user_crypto_context.cpp
+  test/test_zero_copy_promotion.cpp
 )
 
 target_include_directories(haze_tests PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
   ${CMAKE_CURRENT_SOURCE_DIR}/test
 )
 # OpenFHE BigInteger headers — used by test_basis_convert.cpp's reference

--- a/src/common/errors.cpp
+++ b/src/common/errors.cpp
@@ -33,6 +33,7 @@ hazeError_t to_public_error(HazeInternalError err) noexcept {
     case HazeInternalError::BackendShapeMismatch:
     case HazeInternalError::MrpGroupAddrModuliMismatch:
     case HazeInternalError::MissingPolyMapBinding:
+    case HazeInternalError::ShadowSizeMismatch:
         return HAZE_ERROR_LAUNCH_FAILURE;
     }
     return HAZE_ERROR_INVALID_VALUE;
@@ -62,6 +63,8 @@ const char *internal_error_name(HazeInternalError err) noexcept {
         return "MRP group addrs/moduli span size mismatch";
     case HazeInternalError::MissingPolyMapBinding:
         return "addr missing from poly_map_";
+    case HazeInternalError::ShadowSizeMismatch:
+        return "shadow buffer length != ring_dim";
     }
     return "unknown";
 }

--- a/src/common/errors.hpp
+++ b/src/common/errors.hpp
@@ -39,7 +39,8 @@ enum class HazeInternalError : std::uint8_t {
     BackendReplayFailed,        // niobium::compiler() stop_epoch / replay returned false or threw
     BackendShapeMismatch,       // backend returned a result with unexpected shape / length
     MrpGroupAddrModuliMismatch, // MRP group registration: addrs / moduli span lengths differ
-    MissingPolyMapBinding       // pending output / MRP group addr is not in poly_map_
+    MissingPolyMapBinding,      // pending output / MRP group addr is not in poly_map_
+    ShadowSizeMismatch          // shadow buffer length disagrees with ring_dim invariant
 };
 
 // Map an internal error to the public hazeError_t the C ABI returns.

--- a/src/core/allocator.cpp
+++ b/src/core/allocator.cpp
@@ -16,11 +16,11 @@
 #include "common/handle.hpp"
 #include "common/thread_safety.hpp"
 
-#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <expected>
 #include <haze/haze_types.h>
+#include <utility>
 #include <vector>
 
 namespace haze {
@@ -143,21 +143,26 @@ DeviceAllocator::extract_polynomial_components(DevAddr addr, uint64_t ring_dim) 
                               "DeviceAllocator::extract_polynomial_components");
         return std::unexpected(HazeInternalError::AllocTooSmall);
     }
-    auto data_it = shadow_data_.find(addr);
-    if (data_it == shadow_data_.end()) {
-        // Address allocated but no bytes ever written — caller decides
-        // whether to fall through to a zero polynomial via fhetch.
+    auto node = shadow_data_.extract(addr);
+    if (!node) {
+        // Address allocated but never written; caller may fall back to
+        // a zero polynomial via fhetch.
         record_internal_error(HazeInternalError::NoData,
                               "DeviceAllocator::extract_polynomial_components");
         return std::unexpected(HazeInternalError::NoData);
     }
-    std::vector<uint64_t> components(ring_dim);
-    std::memcpy(components.data(), data_it->second.data(), expected_bytes);
-    // Evict the shadow — fhetch::Polynomial::from_data (the caller's
-    // next move) takes ownership of the bytes via shared_ptr<MRPImpl>.
-    // The HAZE-side shadow becomes redundant; releasing it here frees
-    // memory mid-program, before hazeFree.
-    shadow_data_.erase(data_it);
+    // Detach the shadow's storage so the caller's from_data() can move
+    // it straight into a Polynomial; frees the HAZE-side entry
+    // mid-program, before hazeFree.
+    auto components = std::move(node.mapped());
+    if (components.size() != ring_dim) {
+        // Invariant break: every write path sizes the shadow to
+        // elems_for_allocation, which equals ring_dim under allocate()'s
+        // single-poly-size contract. Surface, don't paper over.
+        record_internal_error(HazeInternalError::ShadowSizeMismatch,
+                              "DeviceAllocator::extract_polynomial_components");
+        return std::unexpected(HazeInternalError::ShadowSizeMismatch);
+    }
     return components;
 }
 
@@ -174,10 +179,11 @@ hazeError_t DeviceAllocator::copy_h2d(DevAddr dst, const void *src, size_t count
     // allocation so partial writes leave the tail at zero (matches
     // prior eager-zero semantics for the unwritten tail).
     auto &shadow = shadow_data_[dst];
-    if (shadow.size() != it->second.size) {
-        shadow.assign(it->second.size, uint8_t{0});
+    const size_t want_elems = elems_for_allocation(it->second);
+    if (shadow.size() != want_elems) {
+        shadow.assign(want_elems, uint64_t{0});
     }
-    std::memcpy(shadow.data(), src, count);
+    std::memcpy(reinterpret_cast<uint8_t *>(shadow.data()), src, count);
     return HAZE_SUCCESS;
 }
 
@@ -197,10 +203,14 @@ hazeError_t DeviceAllocator::copy_d2d(DevAddr dst, DevAddr src, size_t count) no
         return HAZE_SUCCESS;
     }
     auto &dst_shadow = shadow_data_[dst];
-    if (dst_shadow.size() != dst_it->second.size) {
-        dst_shadow.assign(dst_it->second.size, uint8_t{0});
+    // Size from the dst allocation, not src; equal today under the
+    // single-poly-size invariant in allocate() but flagged for clarity.
+    const size_t want_elems = elems_for_allocation(dst_it->second);
+    if (dst_shadow.size() != want_elems) {
+        dst_shadow.assign(want_elems, uint64_t{0});
     }
-    std::memcpy(dst_shadow.data(), src_data->second.data(), count);
+    std::memcpy(reinterpret_cast<uint8_t *>(dst_shadow.data()),
+                reinterpret_cast<const uint8_t *>(src_data->second.data()), count);
     return HAZE_SUCCESS;
 }
 
@@ -212,10 +222,11 @@ hazeError_t DeviceAllocator::memset(DevAddr addr, int value, size_t count) noexc
     if (count > it->second.size)
         return HAZE_ERROR_INVALID_VALUE;
     auto &shadow = shadow_data_[addr];
-    if (shadow.size() != it->second.size) {
-        shadow.assign(it->second.size, uint8_t{0});
+    const size_t want_elems = elems_for_allocation(it->second);
+    if (shadow.size() != want_elems) {
+        shadow.assign(want_elems, uint64_t{0});
     }
-    std::memset(shadow.data(), value, count);
+    std::memset(reinterpret_cast<uint8_t *>(shadow.data()), value, count);
     return HAZE_SUCCESS;
 }
 
@@ -236,22 +247,23 @@ hazeError_t DeviceAllocator::copy_to_host(void *dst, DevAddr src, size_t count) 
         std::memset(dst, 0, count);
         return HAZE_SUCCESS;
     }
-    std::memcpy(dst, data_it->second.data(), count);
+    std::memcpy(dst, reinterpret_cast<const uint8_t *>(data_it->second.data()), count);
     return HAZE_SUCCESS;
 }
 
-hazeError_t DeviceAllocator::update_shadow(DevAddr addr,
-                                           const std::vector<uint8_t> &bytes) noexcept {
+hazeError_t DeviceAllocator::update_shadow(DevAddr addr, std::vector<uint64_t> &&values) noexcept {
     HazeLockGuard lock(mutex_);
     auto it = map_.find(addr);
-    if (it == map_.end())
-        return HAZE_ERROR_INVALID_VALUE;
-    auto &shadow = shadow_data_[addr];
-    if (shadow.size() != it->second.size) {
-        shadow.assign(it->second.size, uint8_t{0});
+    if (it == map_.end()) {
+        record_internal_error(HazeInternalError::UnknownAddress, "DeviceAllocator::update_shadow");
+        return to_public_error(HazeInternalError::UnknownAddress);
     }
-    const size_t copy_len = std::min(bytes.size(), shadow.size());
-    std::memcpy(shadow.data(), bytes.data(), copy_len);
+    const size_t want_elems = elems_for_allocation(it->second);
+    if (values.size() != want_elems) {
+        // Truncate-or-pad to allocation size, in uint64_t units.
+        values.resize(want_elems, uint64_t{0});
+    }
+    shadow_data_.insert_or_assign(addr, std::move(values));
     return HAZE_SUCCESS;
 }
 

--- a/src/core/allocator.hpp
+++ b/src/core/allocator.hpp
@@ -26,12 +26,19 @@
 
 namespace haze {
 
-// Per-DevAddr metadata. Pure liveness + pool-recycling info — no byte
-// payload. Byte storage lives in DeviceAllocator::shadow_data_, which
-// is sparse (an entry exists only for addresses that currently hold
-// user-written or materialized bytes). Most addresses in a typical
-// FHE program are intermediate compute results that flow entirely
-// inside fhetch::Polynomial storage and never need a HAZE shadow.
+namespace test {
+// Forward declaration for the test peer (Attorney pattern); definition
+// lives under test/ and is never linked into production.
+class AllocatorTestAccess;
+} // namespace test
+
+// Per-DevAddr metadata. Pure liveness + pool-recycling info — no
+// payload. Component storage lives in DeviceAllocator::shadow_data_,
+// which is sparse (an entry exists only for addresses that currently
+// hold user-written or materialized uint64_t components). Most
+// addresses in a typical FHE program are intermediate compute results
+// that flow entirely inside fhetch::Polynomial storage and never need
+// a HAZE shadow.
 struct Allocation {
     DevAddr addr{};      ///< Virtual device address handed to the user.
     size_t size = 0;     ///< Allocation size in bytes (== poly_bytes_ under strict contract).
@@ -48,13 +55,17 @@ struct Allocation {
 // is needed).
 //
 // Storage model. Each DevAddr has metadata in `map_` (size, pool flag).
-// Byte payloads live in a separate sparse map `shadow_data_` keyed by
-// DevAddr. An entry exists only when the address currently carries
-// user-written or materialized bytes; addresses without an entry hold
-// zero shadow memory. Reads of an entry-less address return zero
+// Component payloads live in a separate sparse map `shadow_data_`
+// keyed by DevAddr, with each entry a `vector<uint64_t>` sized to the
+// allocation. An entry exists only when the address currently carries
+// user-written or materialized components; addresses without an entry
+// hold zero shadow memory. Reads of an entry-less address return zero
 // (D2H) or NoData (compute extract). Writes (H2D / memset / D2D /
 // update_shadow) create or overwrite the entry; consumption by
-// compute (extract_polynomial_components) evicts it.
+// compute (extract_polynomial_components) evicts it. Byte-granular
+// reads/writes from the C ABI go through `reinterpret_cast<uint8_t*>`
+// over the vector's storage — well-defined; `vector<uint64_t>::data()`
+// is over-aligned for `uint8_t*`.
 //
 // Contract:
 //  - `Config::set_ring_dimension` must be called before the first
@@ -76,7 +87,11 @@ struct Allocation {
 // order and would deadlock.
 class DeviceAllocator {
   public:
-    static DeviceAllocator &instance() noexcept;
+    // HAZE_API on this and `extract_polynomial_components` exports the
+    // symbols from libhaze's hidden-visibility .so so the test binary
+    // can resolve them; encapsulation rests on allocator.hpp living in
+    // src/ (private include path), not on the visibility attribute.
+    HAZE_API static DeviceAllocator &instance() noexcept;
 
     // Configure the pool's polynomial size. Calling with a size different
     // from the current configuration drains the pool. Calling with size 0
@@ -101,7 +116,7 @@ class DeviceAllocator {
     // shadow entry on success** — the caller now owns the bytes via
     // fhetch's Polynomial storage; the HAZE-side shadow is freed
     // mid-program. Non-const for that reason.
-    std::expected<std::vector<uint64_t>, HazeInternalError>
+    HAZE_API std::expected<std::vector<uint64_t>, HazeInternalError>
     extract_polynomial_components(DevAddr addr, uint64_t ring_dim) noexcept HAZE_EXCLUDES(mutex_);
 
     // Read shadow bytes into a host buffer. Caller is responsible for
@@ -109,10 +124,11 @@ class DeviceAllocator {
     hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) const noexcept
         HAZE_EXCLUDES(mutex_);
 
-    // Write bytes into the shadow buffer from a host vector. Used by
-    // the materialization engine to publish replayed compute outputs.
-    // Truncates to allocation size; sets has_data on success.
-    hazeError_t update_shadow(DevAddr addr, const std::vector<uint8_t> &bytes) noexcept
+    // Full-replace write of the shadow buffer; the existing entry is
+    // replaced by `values` after truncation/zero-padding to
+    // `elems_for_allocation`. Rvalue-only so ownership transfer is
+    // explicit at the (single) call site in `do_materialize_locked`.
+    hazeError_t update_shadow(DevAddr addr, std::vector<uint64_t> &&values) noexcept
         HAZE_EXCLUDES(mutex_);
 
     // Pointer-attribute query. Reports DEVICE for hazeMalloc-allocated
@@ -138,6 +154,15 @@ class DeviceAllocator {
   private:
     DeviceAllocator() = default;
 
+    friend class test::AllocatorTestAccess;
+
+    // Byte→element conversion shared by every shadow write path
+    // (copy_h2d, copy_d2d, memset, update_shadow). One place so a new
+    // write path can't drift from the formula.
+    static constexpr size_t elems_for_allocation(const Allocation &a) noexcept {
+        return a.size / sizeof(uint64_t);
+    }
+
     // Helper (caller holds mutex_).
     void clear_pool_locked() noexcept HAZE_REQUIRES(mutex_);
 
@@ -149,11 +174,10 @@ class DeviceAllocator {
     // Per-address metadata. Entry exists for the lifetime of the
     // hazeMalloc/hazeFree contract.
     std::unordered_map<DevAddr, Allocation> map_ HAZE_GUARDED_BY(mutex_);
-    // Sparse byte storage. An entry exists only when the address
-    // currently holds a user-written or materialized payload.
-    // H2D/memset/D2D/update_shadow create it; extract / hazeFree /
-    // set_polynomial_size / reset evict it.
-    std::unordered_map<DevAddr, std::vector<uint8_t>> shadow_data_ HAZE_GUARDED_BY(mutex_);
+    // Sparse uint64_t component storage, vector sized to
+    // `elems_for_allocation`. Created by H2D/memset/D2D/update_shadow,
+    // evicted by extract / hazeFree / set_polynomial_size / reset.
+    std::unordered_map<DevAddr, std::vector<uint64_t>> shadow_data_ HAZE_GUARDED_BY(mutex_);
     std::vector<DevAddr>
         pool_free_ HAZE_GUARDED_BY(mutex_); // free list for poly_bytes_-sized allocations
     std::unordered_set<const void *>

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -23,7 +23,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <expected>
 #include <haze/haze_types.h>
 #include <ios>
@@ -82,7 +81,8 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
 
     fhetch::Polynomial poly;
     if (components) {
-        poly = fhetch::Polynomial::from_data(*components, ring_dim, fhetch::Format::Evaluation);
+        poly = fhetch::Polynomial::from_data(std::move(*components), ring_dim,
+                                             fhetch::Format::Evaluation);
     } else if (components.error() == HazeInternalError::NoData) {
         // Address allocated but never written: build a fhetch zero polynomial
         // so HAZE doesn't fabricate the bytes (matches FIDESlib's SPECIAL pattern).
@@ -227,9 +227,7 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
             log_error("epoch", body.str());
             continue;
         }
-        std::vector<uint8_t> bytes(values.size() * sizeof(uint64_t));
-        std::memcpy(bytes.data(), values.data(), bytes.size());
-        allocator().update_shadow(addr, bytes);
+        allocator().update_shadow(addr, std::move(values));
     }
 
     clear_state_locked(); // also clears captured inputs/outputs (E7).

--- a/test/allocator_test_access.hpp
+++ b/test/allocator_test_access.hpp
@@ -1,0 +1,32 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// Test peer for DeviceAllocator (Attorney pattern); lives under test/
+// and never compiles into the production library. Forward decl + friend
+// grant live in src/core/allocator.hpp.
+#pragma once
+
+#include "core/allocator.hpp"
+
+#include <cstdint>
+#include <utility>
+
+namespace haze::test {
+
+class AllocatorTestAccess {
+  public:
+    // Runs `f(data, size)` over the shadow buffer for `addr` while
+    // holding the allocator mutex; returns true iff a shadow entry
+    // exists. The pointer is only valid inside the callback.
+    template <typename F>
+    static bool with_shadow_data(const DeviceAllocator &a, DevAddr addr, F &&f) noexcept {
+        HazeLockGuard lock(a.mutex_);
+        auto it = a.shadow_data_.find(addr);
+        if (it == a.shadow_data_.end()) {
+            return false;
+        }
+        std::forward<F>(f)(it->second.data(), it->second.size());
+        return true;
+    }
+};
+
+} // namespace haze::test

--- a/test/test_zero_copy_promotion.cpp
+++ b/test/test_zero_copy_promotion.cpp
@@ -1,0 +1,65 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// Pointer-equality test for shadow → Polynomial zero-copy input
+// promotion; mirrors lookup_or_create_locked without compute/replay so
+// the asserts depend only on move semantics in extract + from_data.
+#include "allocator_test_access.hpp"
+#include "common/handle.hpp"
+#include "core/allocator.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <niobium/fhetch_api.h>
+#include <utility>
+#include <vector>
+
+TEST_CASE("zero-copy input promotion: shadow buffer flows into Polynomial without realloc",
+          "[unit]") {
+    constexpr uint64_t ring_dim = 4096;
+    constexpr size_t bytes = ring_dim * sizeof(uint64_t);
+
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
+
+    void *dev = nullptr;
+    REQUIRE(hazeMalloc(&dev, bytes) == HAZE_SUCCESS);
+
+    std::vector<uint64_t> host(ring_dim);
+    for (size_t i = 0; i < ring_dim; ++i) {
+        host[i] = (i * 17U) + 3U;
+    }
+    REQUIRE(hazeMemcpy(dev, host.data(), bytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    const haze::DevAddr addr = haze::to_dev_addr(dev);
+    // Snapshot the shadow address under the lock; only used below as a
+    // value-comparison landmark, never dereferenced.
+    const uint64_t *shadow_before = nullptr;
+    const bool had_shadow = haze::test::AllocatorTestAccess::with_shadow_data(
+        haze::allocator(), addr,
+        [&](const uint64_t *data, size_t /*size*/) { shadow_before = data; });
+    REQUIRE(had_shadow);
+    REQUIRE(shadow_before != nullptr);
+
+    // Mirror lookup_or_create_locked's promotion sequence directly so
+    // a regression in either step shows up at the matching REQUIRE.
+    auto components = haze::allocator().extract_polynomial_components(addr, ring_dim);
+    REQUIRE(components.has_value());
+    REQUIRE(components->data() == shadow_before); // step 2: extract is a move
+
+    auto poly = niobium::fhetch::Polynomial::from_data(std::move(*components), ring_dim,
+                                                       niobium::fhetch::Format::Evaluation);
+
+    // step 3: from_data(rvalue) — same buffer end-to-end. Relies on
+    // vector move-assignment being a pointer-swap; true on libc++ and
+    // libstdc++ today, not a standards guarantee.
+    REQUIRE(poly.int_data().data() == shadow_before);
+    REQUIRE(poly.int_data().size() == ring_dim);
+    for (size_t i = 0; i < ring_dim; ++i) {
+        REQUIRE(poly.int_data()[i] == (i * 17U) + 3U);
+    }
+
+    REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
+}


### PR DESCRIPTION
DeviceAllocator::shadow_data_ now stores uint64_t components directly, eliminating the byte->uint64 staging copy on input promotion and the reverse uint64->byte staging on result writes. Byte-granular C-ABI operations (H2D, D2D, memset, D2H) reinterpret_cast<uint8_t*> over the vector's storage; vector<uint64_t>::data() is over-aligned for uint8_t* so the cast is well-defined.

extract_polynomial_components now detaches the shadow with unordered_map::extract and hands the storage to the caller by move. update_shadow takes vector<uint64_t>&& and moves into the map. EpochState::lookup_or_create_locked passes std::move(*components) to fhetch::Polynomial::from_data, which binds to the new rvalue overload in niobium-fhetch (submodule pointer bump lands separately once that PR merges; this commit builds against the working tree).

Adds an Attorney-pattern test peer (test/allocator_test_access.hpp) and a pointer-equality regression test (test/test_zero_copy_promotion.cpp) that mirrors the promotion sequence and asserts the same buffer flows through shadow -> expected -> Polynomial without reallocation. The peer exposes shadow data under a callback held under the allocator mutex so the test cannot leak a pointer past a concurrent mutation.

HAZE_API on DeviceAllocator::instance() and extract_polynomial_components() exports the symbols from libhaze's hidden-visibility .so so the test binary can resolve them. The header is in src/ (private include path), so external consumers still cannot reach the class through the C++ ABI.