### PR TITLE
core: propagate silent errors in replay / post-recording hook

### DIFF
--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -35,6 +35,10 @@ HAZE_API hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim, uint64
 /// hazeDeviceReset; idempotent and safe to call before init.
 HAZE_API void hazeReplayBridgeReset(void) HAZE_NOEXCEPT;
 
+/// Return 1 iff the post-recording hook reported any failure since the
+/// last call, then reset the flag. Per-failure detail is in the log.
+HAZE_API int hazeReplayBridgeTakeHookHadError(void) HAZE_NOEXCEPT;
+
 #ifdef __cplusplus
 }
 #endif

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -17,6 +17,7 @@
 #include "scheme/ckksrns/ckksrns-ser.h"
 
 #include <algorithm>
+#include <atomic>
 #include <bit>
 #include <cstddef>
 #include <cstdint>
@@ -72,6 +73,18 @@ enum class BridgeError : uint8_t {
     InvalidModulus,
     OpenFheUnavailable,
 };
+
+// Flag the post-recording hook sets on any per-record failure; haze
+// drains it via hazeReplayBridgeTakeHookHadError after stop_epoch.
+std::atomic<bool> &hook_had_error_flag() noexcept {
+    static std::atomic<bool> flag{false};
+    return flag;
+}
+
+void log_hook_error(const std::string &body) noexcept {
+    haze::log_error("replay_bridge", body);
+    hook_had_error_flag().store(true, std::memory_order_relaxed);
+}
 
 // Just the CC and its ring_dim; moduli come from the captured shape at
 // hook time, picked primes are read off the CC when needed.
@@ -278,11 +291,10 @@ slice_array_values(const std::vector<std::vector<uint64_t>> &per_residue_values,
     for (const auto &m : per_element_moduli)
         expected += m.size();
     if (per_residue_values.size() != expected) {
-        // Surfaced here so fill_native_poly's per-row warnings don't drown the cause.
         std::ostringstream body;
         body << "slice_array_values: per_residue_values.size()=" << per_residue_values.size()
              << " != sum of per_element_moduli sizes (" << expected << ")";
-        haze::log_error("replay_bridge", body.str());
+        throw std::runtime_error(body.str());
     }
     std::vector<std::vector<std::vector<uint64_t>>> out;
     out.reserve(per_element_moduli.size());
@@ -291,10 +303,7 @@ slice_array_values(const std::vector<std::vector<uint64_t>> &per_residue_values,
         std::vector<std::vector<uint64_t>> row;
         row.reserve(elem_moduli.size());
         for (size_t i = 0; i < elem_moduli.size(); ++i) {
-            if (cursor < per_residue_values.size())
-                row.push_back(per_residue_values[cursor]);
-            else
-                row.emplace_back();
+            row.push_back(per_residue_values[cursor]);
             ++cursor;
         }
         out.push_back(std::move(row));
@@ -362,7 +371,7 @@ const Context *context_for_shape(const HookCtx &hctx,
                      << moduli.size() << ", element[" << k
                      << "].size()=" << shape.per_element_moduli[k].size()
                      << ") — array synthesis with non-uniform bases is not yet implemented";
-                haze::log_error("replay_bridge", body.str());
+                log_hook_error(body.str());
                 return nullptr;
             }
         }
@@ -375,9 +384,7 @@ const Context *context_for_shape(const HookCtx &hctx,
         std::ostringstream body;
         body << "context_for_shape: failed to build CC for ring_dim=" << hctx.ring_dim
              << " (BridgeError=" << static_cast<int>(built.error()) << ")";
-        haze::log_error("replay_bridge", body.str());
-        // nullptr lets the caller skip; falling back to primary would emit
-        // a 1-tower template for an N-tower output.
+        log_hook_error(body.str());
         return nullptr;
     }
     auto [ins, _] = local_cache.emplace(moduli, std::move(*built));
@@ -397,40 +404,32 @@ void on_post_recording(const HookCtx &hctx) {
         try {
             const auto *ctx = context_for_shape(hctx, local_cache, rec.shape);
             if (ctx == nullptr) {
-                haze::log_error("replay_bridge",
-                                "input '" + rec.name + "': no CC available for shape");
+                log_hook_error("input '" + rec.name + "': no CC available for shape");
                 return;
             }
             auto ct = synthesize_for_shape(*ctx, rec.shape, rec.per_residue_values);
             if (!niobium::detail::write_ciphertext_input_bin(rec.name, ct, rec.addr_ids)) {
-                haze::log_error("replay_bridge",
-                                "write_ciphertext_input_bin failed for '" + rec.name + "'");
+                log_hook_error("write_ciphertext_input_bin failed for '" + rec.name + "'");
             }
         } catch (const std::exception &e) {
-            haze::log_error("replay_bridge",
-                            "input bin synthesis for '" + rec.name + "' threw: " + e.what());
+            log_hook_error("input bin synthesis for '" + rec.name + "' threw: " + e.what());
         }
     });
 
-    // ---- Outputs ----
-    // Write one template per output; the replay path fills values.
     niobium::detail::for_each_captured_output(
         [&](const std::string &name, const niobium::CapturedShape &shape) {
             try {
                 const auto *ctx = context_for_shape(hctx, local_cache, shape);
                 if (ctx == nullptr) {
-                    haze::log_error("replay_bridge",
-                                    "output '" + name + "': no CC available for shape");
+                    log_hook_error("output '" + name + "': no CC available for shape");
                     return;
                 }
                 auto ct = synthesize_for_shape(*ctx, shape, /*per_residue_values=*/{});
                 if (!niobium::detail::write_ciphertext_template(name, ct)) {
-                    haze::log_error("replay_bridge",
-                                    "write_ciphertext_template failed for '" + name + "'");
+                    log_hook_error("write_ciphertext_template failed for '" + name + "'");
                 }
             } catch (const std::exception &e) {
-                haze::log_error("replay_bridge",
-                                "template synthesis for '" + name + "' threw: " + e.what());
+                log_hook_error("template synthesis for '" + name + "' threw: " + e.what());
             }
         });
 }
@@ -443,9 +442,9 @@ void install_post_recording_hook(HookCtx hctx) {
         try {
             on_post_recording(hctx);
         } catch (const std::exception &e) {
-            haze::log_error("replay_bridge", std::string{"post_recording_hook threw: "} + e.what());
+            log_hook_error(std::string{"post_recording_hook threw: "} + e.what());
         } catch (...) {
-            haze::log_error("replay_bridge", "post_recording_hook threw (unknown)");
+            log_hook_error("post_recording_hook threw (unknown)");
         }
     });
 }
@@ -485,6 +484,10 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
 }
 
 extern "C" void hazeReplayBridgeReset() noexcept {
+    // Clear first so any early-return below still honors the "prior
+    // failures don't leak forward" contract.
+    hook_had_error_flag().store(false, std::memory_order_relaxed);
+
     // Disk-only cleanup so stale template/probe names from prior tests don't
     // pollute MRP lookups; the hook lambda is freed by compiler().reset().
     // program_dir is queried live — reset_all() runs us before compiler().reset().
@@ -514,6 +517,10 @@ extern "C" void hazeReplayBridgeReset() noexcept {
     } catch (...) {
         haze::log_error("replay_bridge", "hazeReplayBridgeReset: disk cleanup threw (unknown)");
     }
+}
+
+extern "C" int hazeReplayBridgeTakeHookHadError() noexcept {
+    return hook_had_error_flag().exchange(false, std::memory_order_relaxed) ? 1 : 0;
 }
 
 namespace haze {

--- a/src/common/errors.cpp
+++ b/src/common/errors.cpp
@@ -34,6 +34,10 @@ hazeError_t to_public_error(HazeInternalError err) noexcept {
     case HazeInternalError::MrpGroupAddrModuliMismatch:
     case HazeInternalError::MissingPolyMapBinding:
     case HazeInternalError::ShadowSizeMismatch:
+    case HazeInternalError::BackendOutputMissing:
+    case HazeInternalError::BackendOutputDecodeFailed:
+    case HazeInternalError::BridgeHookFailed:
+    case HazeInternalError::PoolMapDesync:
         return HAZE_ERROR_LAUNCH_FAILURE;
     }
     return HAZE_ERROR_INVALID_VALUE;
@@ -65,6 +69,14 @@ const char *internal_error_name(HazeInternalError err) noexcept {
         return "addr missing from poly_map_";
     case HazeInternalError::ShadowSizeMismatch:
         return "shadow buffer length != ring_dim";
+    case HazeInternalError::BackendOutputMissing:
+        return "backend output missing";
+    case HazeInternalError::BackendOutputDecodeFailed:
+        return "backend output decode failed";
+    case HazeInternalError::BridgeHookFailed:
+        return "post-recording hook reported failures";
+    case HazeInternalError::PoolMapDesync:
+        return "pool/map desync";
     }
     return "unknown";
 }

--- a/src/common/errors.hpp
+++ b/src/common/errors.hpp
@@ -40,7 +40,11 @@ enum class HazeInternalError : std::uint8_t {
     BackendShapeMismatch,       // backend returned a result with unexpected shape / length
     MrpGroupAddrModuliMismatch, // MRP group registration: addrs / moduli span lengths differ
     MissingPolyMapBinding,      // pending output / MRP group addr is not in poly_map_
-    ShadowSizeMismatch          // shadow buffer length disagrees with ring_dim invariant
+    ShadowSizeMismatch,         // shadow buffer length disagrees with ring_dim invariant
+    BackendOutputMissing,       // fhetch::result(name, ...) returned false
+    BackendOutputDecodeFailed,  // extract_polynomial_values returned false
+    BridgeHookFailed,           // replay_bridge post-recording hook reported failures
+    PoolMapDesync               // pool_free_ entry has no map_ peer
 };
 
 // Map an internal error to the public hazeError_t the C ABI returns.

--- a/src/core/allocator.cpp
+++ b/src/core/allocator.cpp
@@ -83,8 +83,11 @@ std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate(size_t bytes
         if (map_.contains(addr)) {
             return addr;
         }
-        // Pool free list out of sync with the map — fall through to a
-        // fresh allocation. Should not happen in practice.
+        // pool_free_ entry without a map_ peer means internal state is
+        // corrupt; fail rather than mint a fresh DevAddr on top.
+        record_internal_error(HazeInternalError::PoolMapDesync,
+                              "DeviceAllocator::allocate (pool_free_ -> map_)");
+        return std::unexpected(HazeInternalError::PoolMapDesync);
     }
 
     // Fresh allocation: bump the address counter by exactly poly_bytes_.
@@ -251,20 +254,20 @@ hazeError_t DeviceAllocator::copy_to_host(void *dst, DevAddr src, size_t count) 
     return HAZE_SUCCESS;
 }
 
-hazeError_t DeviceAllocator::update_shadow(DevAddr addr, std::vector<uint64_t> &&values) noexcept {
+std::expected<void, HazeInternalError>
+DeviceAllocator::update_shadow(DevAddr addr, std::vector<uint64_t> &&values) noexcept {
     HazeLockGuard lock(mutex_);
     auto it = map_.find(addr);
     if (it == map_.end()) {
         record_internal_error(HazeInternalError::UnknownAddress, "DeviceAllocator::update_shadow");
-        return to_public_error(HazeInternalError::UnknownAddress);
+        return std::unexpected(HazeInternalError::UnknownAddress);
     }
     const size_t want_elems = elems_for_allocation(it->second);
     if (values.size() != want_elems) {
-        // Truncate-or-pad to allocation size, in uint64_t units.
         values.resize(want_elems, uint64_t{0});
     }
     shadow_data_.insert_or_assign(addr, std::move(values));
-    return HAZE_SUCCESS;
+    return {};
 }
 
 bool DeviceAllocator::is_device_pointer(const void *ptr) const noexcept {

--- a/src/core/allocator.hpp
+++ b/src/core/allocator.hpp
@@ -124,11 +124,10 @@ class DeviceAllocator {
     hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) const noexcept
         HAZE_EXCLUDES(mutex_);
 
-    // Full-replace write of the shadow buffer; the existing entry is
-    // replaced by `values` after truncation/zero-padding to
-    // `elems_for_allocation`. Rvalue-only so ownership transfer is
-    // explicit at the (single) call site in `do_materialize_locked`.
-    hazeError_t update_shadow(DevAddr addr, std::vector<uint64_t> &&values) noexcept
+    // Full-replace write of the shadow buffer; `values` is truncated
+    // or zero-padded to `elems_for_allocation` then moved in.
+    std::expected<void, HazeInternalError> update_shadow(DevAddr addr,
+                                                         std::vector<uint64_t> &&values) noexcept
         HAZE_EXCLUDES(mutex_);
 
     // Pointer-attribute query. Reports DEVICE for hazeMalloc-allocated

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -14,7 +14,6 @@
 
 #include "common/errors.hpp"
 #include "common/handle.hpp"
-#include "common/log.hpp"
 #include "common/thread_safety.hpp"
 #include "core/allocator.hpp"
 #include "core/backend.hpp"
@@ -25,6 +24,7 @@
 #include <cstdint>
 #include <expected>
 #include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
 #include <ios>
 #include <niobium/compiler.h>
 #include <niobium/fhetch_api.h>
@@ -187,14 +187,21 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         return {};
     }
 
-    // Step 1: write the per-epoch .fhetch trace and reset the recording
-    // bookkeeping in libnbfhetch.
+    // Step 1: write the trace. The replay_bridge post-recording hook
+    // runs inside stop_epoch; we drain its failure flag right after.
     const bool stop_ok = CompilerBackend::stop_epoch();
     if (!stop_ok) {
         clear_state_locked();
         record_internal_error(HazeInternalError::BackendReplayFailed,
                               "EpochState::replay_and_populate (stop_epoch)");
         return std::unexpected(HazeInternalError::BackendReplayFailed);
+    }
+    if (hazeReplayBridgeTakeHookHadError() != 0) {
+        clear_state_locked();
+        record_internal_error(
+            HazeInternalError::BridgeHookFailed,
+            "post_recording_hook reported per-input/output failures (see prior log entries)");
+        return std::unexpected(HazeInternalError::BridgeHookFailed);
     }
 
     // Step 2: dispatch replay. kLocalTarget runs the in-process simulator;
@@ -208,26 +215,31 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         return std::unexpected(HazeInternalError::BackendReplayFailed);
     }
 
-    // Step 3: populate host shadow buffers from
-    // <program_dir>/serialized_probes/<name>.ct.
+    // Step 3: per-output shadow population. Any failure aborts the
+    // epoch so a stale shadow can't surface as a silent wrong-value D2H.
     for (auto &[addr, name] : pending_outputs_) {
         fhetch::Polynomial result_poly;
         if (!fhetch::result(name, result_poly)) {
             std::ostringstream body;
-            body << "result('" << name << "') unavailable; shadow at addr 0x" << std::hex
-                 << to_uintptr(addr) << std::dec << " is stale";
-            log_error("epoch", body.str());
-            continue;
+            body << "result('" << name << "') unavailable for addr 0x" << std::hex
+                 << to_uintptr(addr) << std::dec;
+            clear_state_locked();
+            record_internal_error(HazeInternalError::BackendOutputMissing, body.str().c_str());
+            return std::unexpected(HazeInternalError::BackendOutputMissing);
         }
         std::vector<uint64_t> values;
         if (!extract_polynomial_values(result_poly, name, values)) {
             std::ostringstream body;
             body << "failed to extract values for output '" << name << "' at addr 0x" << std::hex
                  << to_uintptr(addr) << std::dec;
-            log_error("epoch", body.str());
-            continue;
+            clear_state_locked();
+            record_internal_error(HazeInternalError::BackendOutputDecodeFailed, body.str().c_str());
+            return std::unexpected(HazeInternalError::BackendOutputDecodeFailed);
         }
-        allocator().update_shadow(addr, std::move(values));
+        if (auto r = allocator().update_shadow(addr, std::move(values)); !r) {
+            clear_state_locked();
+            return std::unexpected(r.error());
+        }
     }
 
     clear_state_locked(); // also clears captured inputs/outputs (E7).


### PR DESCRIPTION
EpochState::do_materialize_locked's per-output loop previously logged fhetch::result and extract_polynomial_values failures and continued, returning success while leaving stale shadow buffers that the next D2H would read as zeros or pre-replay bytes. The MRP loop directly above it already propagated similar failures via std::unexpected — same function, two opposite error policies. The SRP loop now matches: each failure mode returns a typed error (BackendOutputMissing,
BackendOutputDecodeFailed) and the discarded update_shadow return value is checked.

replay_bridge's on_post_recording lambdas had the same problem one layer down: per-input CC build / write_ciphertext_input_bin / template-synthesis failures (and the wrapping post_recording_hook exception handlers) logged + returned-void, leaving the program directory with missing template / bin files that broke replay opaquely. Added a uint64_t hook-error counter that every per-record log site increments through a log_hook_error helper. libhaze drains it via the new hazeReplayBridgeTakeHookErrorCount() export right after stop_epoch and converts a non-zero count into BridgeHookFailed before trying to replay. hazeReplayBridgeReset resets the counter so prior test failures don't leak into the next recording.

slice_array_values's size-mismatch path previously logged and fell through to produce a partial result; now throws std::runtime_error to match the rest of synthesize_*_ciphertext, caught by on_post_recording's per-record try/catch.