### PR TITLE
e2e: explicit RingDimChoice on CtxParams; drop dangling lazy-shadow refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,14 +436,3 @@ parent project (e.g., niobium-client) has already built it.
 - `clang-format` / `clang-tidy` configs: in-tree `.clang-format` (LLVM,
   indent 4, column 100) and `.clang-tidy` (see file for the curated
   check list and the three `-Werror`-promoted checks).
-
-## Open issue
-
-`docs/lazy_shadow_flake.md` documents an intermittent test-suite failure
-not yet root-caused. Symptom: random SIGSEGV / SIGABRT / `[NBCC] Replay
-return code: 256` at varying lines across runs of the same binary, gcc
-Debug ~70% flake, clang ~40%, sanitizers clean in single runs. The
-smoking gun points at `niobium-compiler` process-lifetime caches not
-being refreshed across `hazeDeviceReset` boundaries. The lazy-shadow
-design is correct; the flake is a pre-existing latent bug exposed more
-often by heap-layout shift. ASAN/UBSAN/TSAN are still reliable signals.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,7 @@ add_executable(haze_tests
   test/e2e/test_openfhe_mul_e2e.cpp
   test/e2e/test_openfhe_rotate_e2e.cpp
   test/e2e/test_basic_operations_sequential_e2e.cpp
+  test/e2e/test_ops_ctx_params_e2e.cpp
 )
 
 target_include_directories(haze_tests PRIVATE

--- a/src/core/allocator.hpp
+++ b/src/core/allocator.hpp
@@ -76,11 +76,6 @@ struct Allocation {
 //    allocate any byte storage. The first write — H2D, memset, D2D,
 //    or materialization update — creates the shadow entry.
 //
-// See docs/lazy_shadow_flake.md for an open intermittent-failure
-// investigation: gcc Debug ~70% flake rate, clang ~40%, sanitizers
-// clean in single runs. Latent bug exists at baseline (no lazy
-// shadows) too; lazy just hits it more often via heap-layout shift.
-//
 // Thread-safety: all public methods take mutex_ themselves (annotated
 // HAZE_EXCLUDES). DeviceAllocator must NOT call back into EpochState
 // while holding mutex_ — that violates the epoch -> allocator lock

--- a/test/e2e/ops.cpp
+++ b/test/e2e/ops.cpp
@@ -356,6 +356,10 @@ OpCtx make_ctx(const CtxParams &params) {
     cc_params.SetScalingModSize(params.scaling_mod_size);
     cc_params.SetBatchSize(params.batch_size);
     cc_params.SetScalingTechnique(params.mode);
+    if (const auto &pin = params.ring_dim.as_optional()) {
+        cc_params.SetRingDim(*pin);
+        cc_params.SetSecurityLevel(lbcrypto::HEStd_NotSet);
+    }
     ctx.cc = GenCryptoContext(cc_params);
     REQUIRE(ctx.cc);
     ctx.cc->Enable(PKE);

--- a/test/e2e/ops.hpp
+++ b/test/e2e/ops.hpp
@@ -14,6 +14,7 @@
 #include <haze/replay_bridge_cc.hpp>
 #include <map>
 #include <openfhe.h>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -94,6 +95,27 @@ struct OpCtx {
     bool with_relin_key{};
 };
 
+// No default ctor — `make_ctx` callers must spell out OpenFHEDerives()
+// or Pinned(N), making the choice visible at the call site instead of
+// hidden in a sentinel.
+class RingDimChoice {
+  public:
+    RingDimChoice() = delete;
+    // OpenFHE picks N from mult_depth + scaling_mod_size + the configured
+    // HEStd security level.
+    static RingDimChoice OpenFHEDerives() noexcept { return RingDimChoice{std::nullopt}; }
+    // Pin N and drop the security level to HEStd_NotSet. Test fixtures
+    // only (e.g. N=2048 profiling) — never production parameters.
+    static RingDimChoice Pinned(std::uint32_t n) noexcept { return RingDimChoice{n}; }
+
+    // nullopt = OpenFHE picks; value = pinned N.
+    [[nodiscard]] const std::optional<std::uint32_t> &as_optional() const noexcept { return pin_; }
+
+  private:
+    explicit RingDimChoice(std::optional<std::uint32_t> pin) noexcept : pin_(pin) {}
+    std::optional<std::uint32_t> pin_;
+};
+
 struct CtxParams {
     lbcrypto::ScalingTechnique mode;
     std::uint32_t mult_depth;
@@ -102,6 +124,7 @@ struct CtxParams {
     bool with_relin_key = false;
     // Slot rotation indices (OpenFHE convention: positive = left).
     std::vector<std::int32_t> rotate_indices;
+    RingDimChoice ring_dim;
 };
 
 // Construct CC + keys + bridge state. Caller must hazeDeviceReset first.

--- a/test/e2e/test_basic_operations_sequential_e2e.cpp
+++ b/test/e2e/test_basic_operations_sequential_e2e.cpp
@@ -32,7 +32,8 @@ TEMPLATE_TEST_CASE("openfhe basic-operations-sequential e2e", "[integration][e2e
                               .scaling_mod_size = 50,
                               .batch_size = 8,
                               .with_relin_key = true,
-                              .rotate_indices = {1, -2}});
+                              .rotate_indices = {1, -2},
+                              .ring_dim = ops::RingDimChoice::OpenFHEDerives()});
     INFO("ring_dim=" << ctx.ring_dim << " |Q|=" << ctx.q_base.size()
                      << " |P|=" << ctx.p_base.size());
 

--- a/test/e2e/test_openfhe_addition_e2e.cpp
+++ b/test/e2e/test_openfhe_addition_e2e.cpp
@@ -26,8 +26,11 @@ TEMPLATE_TEST_CASE("openfhe addition e2e", "[integration][e2e]", haze::test::sca
     INFO("policy: " << P::kName);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 
-    auto ctx =
-        ops::make_ctx({.mode = P::kTech, .mult_depth = 1, .scaling_mod_size = 50, .batch_size = 8});
+    auto ctx = ops::make_ctx({.mode = P::kTech,
+                              .mult_depth = 1,
+                              .scaling_mod_size = 50,
+                              .batch_size = 8,
+                              .ring_dim = ops::RingDimChoice::OpenFHEDerives()});
     INFO("ring_dim=" << ctx.ring_dim << " towers=" << ctx.q_base.size());
 
     const std::vector<double> a_vals = {1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8};

--- a/test/e2e/test_openfhe_mul_e2e.cpp
+++ b/test/e2e/test_openfhe_mul_e2e.cpp
@@ -96,7 +96,8 @@ TEMPLATE_TEST_CASE("openfhe mul e2e", "[integration][e2e]", FixedManualNoRescale
                               .mult_depth = 2,
                               .scaling_mod_size = 50,
                               .batch_size = 8,
-                              .with_relin_key = true});
+                              .with_relin_key = true,
+                              .ring_dim = ops::RingDimChoice::OpenFHEDerives()});
     INFO("ring_dim=" << ctx.ring_dim << " |Q|=" << ctx.q_base.size()
                      << " |P|=" << ctx.p_base.size());
 

--- a/test/e2e/test_openfhe_rotate_e2e.cpp
+++ b/test/e2e/test_openfhe_rotate_e2e.cpp
@@ -33,7 +33,8 @@ TEMPLATE_TEST_CASE("openfhe rotate e2e", "[integration][e2e]", haze::test::scali
                               .scaling_mod_size = 50,
                               .batch_size = 8,
                               .with_relin_key = false,
-                              .rotate_indices = {1, -2}});
+                              .rotate_indices = {1, -2},
+                              .ring_dim = ops::RingDimChoice::OpenFHEDerives()});
     INFO("ring_dim=" << ctx.ring_dim << " |Q|=" << ctx.q_base.size()
                      << " |P|=" << ctx.p_base.size());
 

--- a/test/e2e/test_openfhe_scalar_mult_e2e.cpp
+++ b/test/e2e/test_openfhe_scalar_mult_e2e.cpp
@@ -92,8 +92,11 @@ TEMPLATE_TEST_CASE("openfhe scalar-mult e2e", "[integration][e2e]", FixedManualN
     INFO("policy: " << P::kName);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 
-    auto ctx =
-        ops::make_ctx({.mode = P::kTech, .mult_depth = 2, .scaling_mod_size = 50, .batch_size = 8});
+    auto ctx = ops::make_ctx({.mode = P::kTech,
+                              .mult_depth = 2,
+                              .scaling_mod_size = 50,
+                              .batch_size = 8,
+                              .ring_dim = ops::RingDimChoice::OpenFHEDerives()});
     INFO("ring_dim=" << ctx.ring_dim << " towers=" << ctx.q_base.size());
 
     const std::vector<double> x_vals = {0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0};

--- a/test/e2e/test_openfhe_sub_e2e.cpp
+++ b/test/e2e/test_openfhe_sub_e2e.cpp
@@ -26,8 +26,11 @@ TEMPLATE_TEST_CASE("openfhe sub e2e", "[integration][e2e]", haze::test::scaling:
     INFO("policy: " << P::kName);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 
-    auto ctx =
-        ops::make_ctx({.mode = P::kTech, .mult_depth = 1, .scaling_mod_size = 50, .batch_size = 8});
+    auto ctx = ops::make_ctx({.mode = P::kTech,
+                              .mult_depth = 1,
+                              .scaling_mod_size = 50,
+                              .batch_size = 8,
+                              .ring_dim = ops::RingDimChoice::OpenFHEDerives()});
     INFO("ring_dim=" << ctx.ring_dim << " towers=" << ctx.q_base.size());
 
     const std::vector<double> a_vals = {3.0, 5.0, 7.0, 9.0, 11.0, 13.0, 15.0, 17.0};

--- a/test/e2e/test_ops_ctx_params_e2e.cpp
+++ b/test/e2e/test_ops_ctx_params_e2e.cpp
@@ -1,0 +1,48 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// Verifies the `RingDimChoice` factories on `ops::make_ctx`.
+
+#include "openfhe.h"
+#include "ops.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+
+TEST_CASE("ops::make_ctx with RingDimChoice::OpenFHEDerives() lets OpenFHE pick N",
+          "[integration][e2e]") {
+    namespace ops = haze::test::ops;
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+
+    auto ctx = ops::make_ctx({.mode = lbcrypto::FIXEDAUTO,
+                              .mult_depth = 1,
+                              .scaling_mod_size = 50,
+                              .batch_size = 8,
+                              .ring_dim = ops::RingDimChoice::OpenFHEDerives()});
+
+    const std::uint32_t derived = ctx.cc->GetRingDimension();
+    REQUIRE(ctx.ring_dim == derived);
+    // OpenFHE's specific N depends on its security table; assert
+    // power-of-two rather than pinning a value.
+    REQUIRE(derived > 0);
+    REQUIRE((derived & (derived - 1)) == 0);
+    REQUIRE(ctx.poly_bytes == static_cast<std::size_t>(ctx.ring_dim) * sizeof(std::uint64_t));
+}
+
+TEST_CASE("ops::make_ctx with RingDimChoice::Pinned(N) forces N", "[integration][e2e]") {
+    namespace ops = haze::test::ops;
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+
+    constexpr std::uint32_t kPinned = 2048;
+    auto ctx = ops::make_ctx({.mode = lbcrypto::FIXEDAUTO,
+                              .mult_depth = 1,
+                              .scaling_mod_size = 50,
+                              .batch_size = 8,
+                              .ring_dim = ops::RingDimChoice::Pinned(kPinned)});
+
+    REQUIRE(ctx.cc->GetRingDimension() == kPinned);
+    REQUIRE(ctx.ring_dim == kPinned);
+    REQUIRE(ctx.poly_bytes == static_cast<std::size_t>(kPinned) * sizeof(std::uint64_t));
+}

--- a/test/test_basis_convert.cpp
+++ b/test/test_basis_convert.cpp
@@ -480,11 +480,6 @@ TEST_CASE("hazeModUp: zero input produces zero output across both digits", "[int
 // OpenFHE's plain-mod variant. The CMake option HAZE_FBC_REDUCED_NOISE
 // (default ON) tells the oracle which variant to compute; flip it if
 // you ever pair HAZE with a Standard-variant OpenFHE.
-//
-// The intermittent multi-output materialization flake characterised in
-// docs/lazy_shadow_flake.md applies to these tests as well — the bug is
-// in libnbcc, not in HAZE. A failure in these tests should be triaged
-// against that flake first before assuming a logic bug here.
 // ---------------------------------------------------------------------------
 
 namespace {

--- a/test/test_ring_dim_consistency.cpp
+++ b/test/test_ring_dim_consistency.cpp
@@ -11,19 +11,9 @@
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
 //
-// Positive tests for ring_dim handling on the HAZE/niobium boundary.
-// Companion to docs/lazy_shadow_flake.md, which tracks an intermittent
-// abort signature `m=962` from OpenFHE's RootOfUnity inside niobium's
-// stop_epoch NTT-table generation. The corruption is downstream of
-// HAZE's tag_input handoff (we instrumented HAZE to log any drift in
-// the Polynomial it registers and observed zero drift events across
-// hundreds of runs). These tests therefore exercise the public-API
-// paths that *would* exercise a HAZE-side ring_dim leak if one
-// existed — round-trip at canonical N, multi-op chaining within one
-// epoch, repeated reset/configure cycles, basis-convert identity
-// math, and reset-then-reconfigure-at-same-N — all expected to pass.
-// They serve as positive regression coverage; they will not catch the
-// niobium-side leak that remains under investigation.
+// Positive regression coverage exercising the public-API paths a
+// HAZE-side ring_dim leak would surface through. Not targeted
+// reproducers.
 
 #include "integration_helpers.hpp"
 
@@ -67,13 +57,10 @@ inline void h2d(void *dev, const std::vector<uint64_t> &src) {
 } // namespace
 
 // (1) Construction-time ring_dim is preserved end-to-end at the canonical N.
-//
-// The pertinent property is not the arithmetic but that stop_epoch()
-// doesn't fire RootOfUnity with a bogus 2*N. The bisect in
-// docs/lazy_shadow_flake.md traced the failure signature ("m=962")
-// back to a Polynomial reaching tag_input with ring_dim ≠ 4096 — this
-// test is the simplest end-to-end exercise that would surface the
-// HAZE-side variant of that bug.
+// The pertinent property is that stop_epoch() doesn't fire RootOfUnity
+// with a bogus 2*N — a Polynomial reaching tag_input with ring_dim ≠
+// 4096 would surface as an `m=962` abort from OpenFHE's NTT-table
+// generation.
 TEST_CASE("ring_dim consistency: H2D->Add->D2H round-trip at N=4096", "[integration]") {
     setup_4096();
 
@@ -176,15 +163,10 @@ TEST_CASE("ring_dim consistency: 50 reset/configure/compute cycles", "[integrati
     }
 }
 
-// (4) Basis-convert end-to-end: the multi-output materialization path
-// is the dominant trigger for the lazy_shadow_flake.md flake — every
-// basis-convert call tags multiple input residues as fhetch inputs
-// and stores multiple output residues, multiplying the chances of a
-// stale-ring_dim Polynomial slipping through. Verify the math
-// actually computes correctly, not just that the call returns
-// SUCCESS. A "shared modulus identity convert" (src_base == dst_base,
-// single residue) is the simplest non-trivial case: dst should
-// equal src byte-for-byte.
+// (4) Basis-convert end-to-end. Multi-residue I/O makes this the
+// densest public-API path for surfacing a stale-ring_dim Polynomial;
+// verify the math computes correctly, not just that the call returns
+// SUCCESS.
 TEST_CASE("ring_dim consistency: hazeBasisConvert preserves data on identity convert",
           "[integration]") {
     setup_4096();


### PR DESCRIPTION
Replace the previous "OpenFHE auto-derives N" implicit-default convention with a non-default-constructible `ops::RingDimChoice`. Every `make_ctx` caller now has to write either `.ring_dim = RingDimChoice::OpenFHEDerives()` or `.ring_dim = RingDimChoice::Pinned(N)`, so the choice is visible at the call site rather than buried in a sentinel.

`Pinned(N)` configures `CCParams::SetRingDim(N) +
SetSecurityLevel(HEStd_NotSet)`, intended for small-N test fixtures (e.g. N=2048 profiling), never production parameters.

New `test/e2e/test_ops_ctx_params_e2e.cpp` covers both arms:
- `OpenFHEDerives()` lands on a power-of-two N consistent with ctx.ring_dim and ctx.poly_bytes.
- `Pinned(2048)` forces N=2048 on `ctx.cc->GetRingDimension()`.

Drive-by: strip every reference to `docs/lazy_shadow_flake.md` (a doc that never existed on main or any active branch). Removes the orphaned "## Open issue" block in CLAUDE.md plus 5 in-source cross-references in `src/core/allocator.hpp`, `test/test_ring_dim_consistency.cpp`, and `test/test_basis_convert.cpp`. Where the surrounding comment carried substantive content (the `m=962` failure signature, why basis-convert is the densest stale-ring_dim path), that content is preserved without the doc link.