### PR TITLE
Simpify memory, fix D2D

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -336,16 +336,18 @@ and events exist for CUDA-shape parity but do not model ordering.
 
 ### Shadow storage model
 
-`DeviceAllocator` keeps two maps keyed by `DevAddr`:
+`DeviceAllocator` keeps two `DevAddr`-keyed structures:
 
-- `map_`: per-allocation metadata (`size`, `pooled`). Lives for the entire
-  `hazeMalloc` / `hazeFree` lifetime.
+- `alloc_set_`: set membership covering the lifetime of the
+  `hazeMalloc` / `hazeFree` contract. Allocation size is implicit
+  (always `poly_bytes_`) under the single-size invariant.
 - `shadow_data_`: sparse byte payload. Entry exists only when the address
   carries user-written or materialized bytes. H2D / memset / D2D /
   `update_shadow` create entries; `extract_polynomial_components` (used
   when promoting bytes to a FHETCH input) and `hazeFree` evict them.
-  Reads from a missing entry return zero (D2H) or `NoData` (compute
-  extract path, falling back to a zero polynomial).
+  Reads from a missing entry return zero (D2H) or `SourceUnavailable`
+  (compute / D2D extract path — using an addr that was never written
+  is a contract violation).
 
 Every `hazeMalloc` allocation must equal the configured polynomial size
 (`ring_dim * sizeof(uint64_t)`). `hazeSetRingDimension` is required before

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ add_executable(haze_tests
   test/test_user_crypto_context.cpp
   test/test_zero_copy_promotion.cpp
   test/test_bridge_key_extract.cpp
+  test/test_d2d_copy.cpp
   # End-to-end OpenFHE-pipeline tests (real encrypt/decrypt around haze ops).
   # Tagged [integration][e2e] in Catch2 so they run under haze_sim_tests.
   # `ops.cpp` is the shared per-mode operation library these tests build on.

--- a/include/haze/haze_types.h
+++ b/include/haze/haze_types.h
@@ -63,8 +63,6 @@ typedef struct haze_exec_s *hazeGraphExec_t;
 
 // ---------------------------------------------------------------------------
 // Error codes
-// Hardware status register bit mappings: dmemerr, imemerr, instrerr,
-// configerr, iseqerr.
 // ---------------------------------------------------------------------------
 
 // The four typedef-enum types below are the public C ABI. C does not
@@ -76,17 +74,30 @@ typedef struct haze_exec_s *hazeGraphExec_t;
 
 typedef enum {
     HAZE_SUCCESS = 0,
-    HAZE_ERROR_INVALID_HANDLE,
-    HAZE_ERROR_INVALID_VALUE,
-    HAZE_ERROR_OUT_OF_MEMORY,
-    HAZE_ERROR_NOT_SUPPORTED,
-    HAZE_ERROR_NOT_READY,
-    HAZE_ERROR_LAUNCH_FAILURE,
-    HAZE_ERROR_DMEMERR,
-    HAZE_ERROR_IMEMERR,
-    HAZE_ERROR_INSTRERR,
-    HAZE_ERROR_CONFIGERR,
-    HAZE_ERROR_ISEQERR,
+    HAZE_ERROR_INVALID_HANDLE,          // opaque handle (stream / event / graph) is null or stale
+    HAZE_ERROR_INVALID_VALUE,           // argument violated the documented contract
+    HAZE_ERROR_OUT_OF_MEMORY,           // allocator could not satisfy the request
+    HAZE_ERROR_NOT_SUPPORTED,           // operation is not implemented for this build / target
+    HAZE_ERROR_NOT_READY,               // CUDA-shape parity: device or async result not ready
+    HAZE_ERROR_LAUNCH_FAILURE,          // compilation or execution failure on the backend
+    HAZE_ERROR_DMEMERR,                 // hardware data-memory error (FPGA / silicon target)
+    HAZE_ERROR_IMEMERR,                 // hardware instruction-memory error
+    HAZE_ERROR_INSTRERR,                // hardware instruction error
+    HAZE_ERROR_CONFIGERR,               // ring_dim / modulus / target not configured
+    HAZE_ERROR_ISEQERR,                 // hardware instruction-sequence error
+    HAZE_ERROR_UNKNOWN_ADDRESS,         // DevAddr not in the allocator's table
+    HAZE_ERROR_NO_DATA,                 // address allocated but never written
+    HAZE_ERROR_ALLOC_TOO_SMALL,         // allocation size < polynomial size
+    HAZE_ERROR_SOURCE_UNAVAILABLE,      // compute / D2D source has no shadow + no poly_map_
+    HAZE_ERROR_BACKEND_INIT_FAILED,     // niobium::compiler().init() threw
+    HAZE_ERROR_BACKEND_REPLAY_FAILED,   // stop_epoch / replay returned false / threw
+    HAZE_ERROR_BACKEND_SHAPE_MISMATCH,  // backend result / MRP-group shape mismatch
+    HAZE_ERROR_MISSING_POLYMAP_BINDING, // pending output / MRP group addr missing
+    HAZE_ERROR_SHADOW_SIZE_MISMATCH,    // shadow buffer length disagrees with ring_dim
+    HAZE_ERROR_BACKEND_OUTPUT_MISSING,  // fhetch::result(name, ...) returned false
+    HAZE_ERROR_BACKEND_OUTPUT_DECODE_FAILED, // extract_polynomial_values returned false
+    HAZE_ERROR_BRIDGE_HOOK_FAILED,           // post-recording hook reported failures
+    HAZE_ERROR_POOL_MAP_DESYNC,              // pool_free_ entry has no alloc_set_ peer
 } hazeError_t;
 
 // ---------------------------------------------------------------------------

--- a/src/api/error.cpp
+++ b/src/api/error.cpp
@@ -49,6 +49,32 @@ extern "C" const char *hazeGetErrorString(hazeError_t error) noexcept {
         return "configuration error";
     case HAZE_ERROR_ISEQERR:
         return "instruction sequence error";
+    case HAZE_ERROR_UNKNOWN_ADDRESS:
+        return "unknown device address";
+    case HAZE_ERROR_NO_DATA:
+        return "no data at device address";
+    case HAZE_ERROR_ALLOC_TOO_SMALL:
+        return "allocation size below polynomial size";
+    case HAZE_ERROR_SOURCE_UNAVAILABLE:
+        return "compute / D2D source has no shadow data and no poly_map_ binding";
+    case HAZE_ERROR_BACKEND_INIT_FAILED:
+        return "backend init failed";
+    case HAZE_ERROR_BACKEND_REPLAY_FAILED:
+        return "backend replay failed";
+    case HAZE_ERROR_BACKEND_SHAPE_MISMATCH:
+        return "backend result shape mismatch";
+    case HAZE_ERROR_MISSING_POLYMAP_BINDING:
+        return "address missing from poly_map_";
+    case HAZE_ERROR_SHADOW_SIZE_MISMATCH:
+        return "shadow buffer length disagrees with ring_dim";
+    case HAZE_ERROR_BACKEND_OUTPUT_MISSING:
+        return "backend output missing";
+    case HAZE_ERROR_BACKEND_OUTPUT_DECODE_FAILED:
+        return "backend output decode failed";
+    case HAZE_ERROR_BRIDGE_HOOK_FAILED:
+        return "replay bridge post-recording hook failed";
+    case HAZE_ERROR_POOL_MAP_DESYNC:
+        return "allocator pool / alloc_set_ desync";
     default:
         return "unknown error";
     }

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -86,9 +86,11 @@ extern "C" hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
     if (kind == HAZE_MEMCPY_HOST_TO_DEVICE) {
         const haze::DevAddr dev = haze::to_dev_addr(dst);
         const hazeError_t err = alloc.copy_h2d(dev, src, count);
-        if (err == HAZE_SUCCESS)
-            haze::epoch().invalidate(dev);
-        return set_error(err);
+        if (err != HAZE_SUCCESS)
+            return set_error(err);
+        if (auto tag = haze::tag_h2d_input(dev); !tag)
+            return set_error(haze::to_public_error(tag.error()));
+        return set_error(HAZE_SUCCESS);
     }
 
     if (kind == HAZE_MEMCPY_DEVICE_TO_HOST) {
@@ -99,12 +101,11 @@ extern "C" hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
     }
 
     if (kind == HAZE_MEMCPY_DEVICE_TO_DEVICE) {
-        const haze::DevAddr dev_dst = haze::to_dev_addr(dst);
-        const haze::DevAddr dev_src = haze::to_dev_addr(src);
-        const hazeError_t err = alloc.copy_d2d(dev_dst, dev_src, count);
-        if (err == HAZE_SUCCESS)
-            haze::epoch().invalidate(dev_dst);
-        return set_error(err);
+        auto result =
+            haze::copy_device_to_device(haze::to_dev_addr(dst), haze::to_dev_addr(src), count);
+        if (!result)
+            return set_error(haze::to_public_error(result.error()));
+        return set_error(HAZE_SUCCESS);
     }
 
     return set_error(HAZE_ERROR_INVALID_VALUE);

--- a/src/common/errors.cpp
+++ b/src/common/errors.cpp
@@ -21,24 +21,37 @@ namespace haze {
 
 hazeError_t to_public_error(HazeInternalError err) noexcept {
     switch (err) {
+    case HazeInternalError::InvalidArgument:
+        return HAZE_ERROR_INVALID_VALUE;
     case HazeInternalError::NotConfigured:
         return HAZE_ERROR_CONFIGERR;
-    case HazeInternalError::InvalidArgument:
     case HazeInternalError::UnknownAddress:
+        return HAZE_ERROR_UNKNOWN_ADDRESS;
     case HazeInternalError::NoData:
+        return HAZE_ERROR_NO_DATA;
     case HazeInternalError::AllocTooSmall:
-        return HAZE_ERROR_INVALID_VALUE;
+        return HAZE_ERROR_ALLOC_TOO_SMALL;
+    case HazeInternalError::SourceUnavailable:
+        return HAZE_ERROR_SOURCE_UNAVAILABLE;
     case HazeInternalError::BackendInitFailed:
+        return HAZE_ERROR_BACKEND_INIT_FAILED;
     case HazeInternalError::BackendReplayFailed:
+        return HAZE_ERROR_BACKEND_REPLAY_FAILED;
     case HazeInternalError::BackendShapeMismatch:
     case HazeInternalError::MrpGroupAddrModuliMismatch:
+        return HAZE_ERROR_BACKEND_SHAPE_MISMATCH;
     case HazeInternalError::MissingPolyMapBinding:
+        return HAZE_ERROR_MISSING_POLYMAP_BINDING;
     case HazeInternalError::ShadowSizeMismatch:
+        return HAZE_ERROR_SHADOW_SIZE_MISMATCH;
     case HazeInternalError::BackendOutputMissing:
+        return HAZE_ERROR_BACKEND_OUTPUT_MISSING;
     case HazeInternalError::BackendOutputDecodeFailed:
+        return HAZE_ERROR_BACKEND_OUTPUT_DECODE_FAILED;
     case HazeInternalError::BridgeHookFailed:
+        return HAZE_ERROR_BRIDGE_HOOK_FAILED;
     case HazeInternalError::PoolMapDesync:
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_POOL_MAP_DESYNC;
     }
     return HAZE_ERROR_INVALID_VALUE;
 }
@@ -77,6 +90,8 @@ const char *internal_error_name(HazeInternalError err) noexcept {
         return "post-recording hook reported failures";
     case HazeInternalError::PoolMapDesync:
         return "pool/map desync";
+    case HazeInternalError::SourceUnavailable:
+        return "compute / D2D source has no shadow data and no poly_map_ binding";
     }
     return "unknown";
 }

--- a/src/common/errors.hpp
+++ b/src/common/errors.hpp
@@ -26,9 +26,9 @@ extern thread_local hazeError_t g_last_error;
 
 namespace haze {
 
-// Internal error type; several variants collapse to one public hazeError_t
-// (e.g. UnknownAddress/NoData/AllocTooSmall → INVALID_VALUE), so internal
-// callers keep the typed enum and map only at the C ABI boundary.
+// Internal error type. `to_public_error` maps each variant to a granular
+// `hazeError_t`; internal callers keep the typed enum and translate only
+// at the C ABI boundary.
 enum class HazeInternalError : std::uint8_t {
     InvalidArgument,            // params struct field violates the API contract
     NotConfigured,              // ring_dim / modulus not set when required
@@ -44,7 +44,8 @@ enum class HazeInternalError : std::uint8_t {
     BackendOutputMissing,       // fhetch::result(name, ...) returned false
     BackendOutputDecodeFailed,  // extract_polynomial_values returned false
     BridgeHookFailed,           // replay_bridge post-recording hook reported failures
-    PoolMapDesync               // pool_free_ entry has no map_ peer
+    PoolMapDesync,              // pool_free_ entry has no `alloc_set_` peer
+    SourceUnavailable           // compute / D2D source has no shadow data and no poly_map_ binding
 };
 
 // Map an internal error to the public hazeError_t the C ABI returns.

--- a/src/core/allocator.cpp
+++ b/src/core/allocator.cpp
@@ -32,7 +32,7 @@ DeviceAllocator &DeviceAllocator::instance() noexcept {
 
 void DeviceAllocator::clear_pool_locked() noexcept {
     for (DevAddr addr : pool_free_) {
-        map_.erase(addr);
+        alloc_set_.erase(addr);
         shadow_data_.erase(addr);
     }
     pool_free_.clear();
@@ -80,13 +80,13 @@ std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate(size_t bytes
     if (!pool_free_.empty()) {
         DevAddr addr = pool_free_.back();
         pool_free_.pop_back();
-        if (map_.contains(addr)) {
+        if (alloc_set_.contains(addr)) {
             return addr;
         }
-        // pool_free_ entry without a map_ peer means internal state is
-        // corrupt; fail rather than mint a fresh DevAddr on top.
+        // pool_free_ entry without an alloc_set_ peer means internal
+        // state is corrupt; fail rather than mint a fresh DevAddr.
         record_internal_error(HazeInternalError::PoolMapDesync,
-                              "DeviceAllocator::allocate (pool_free_ -> map_)");
+                              "DeviceAllocator::allocate (pool_free_ -> alloc_set_)");
         return std::unexpected(HazeInternalError::PoolMapDesync);
     }
 
@@ -95,12 +95,7 @@ std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate(size_t bytes
     // DevAddr until the first H2D / memset / D2D / update_shadow.
     DevAddr addr{next_addr_};
     next_addr_ += poly_bytes_;
-
-    Allocation a{};
-    a.addr = addr;
-    a.size = poly_bytes_;
-    a.pooled = true;
-    map_.emplace(addr, a);
+    alloc_set_.insert(addr);
     return addr;
 }
 
@@ -109,20 +104,15 @@ hazeError_t DeviceAllocator::free(DevAddr addr) noexcept {
         return HAZE_SUCCESS; // hazeFree(nullptr) matches CUDA semantics
 
     HazeLockGuard lock(mutex_);
-    auto it = map_.find(addr);
-    if (it == map_.end()) {
+    if (!alloc_set_.contains(addr)) {
         record_internal_error(HazeInternalError::UnknownAddress, "DeviceAllocator::free");
         return HAZE_ERROR_INVALID_VALUE;
     }
-    // Always evict the shadow on free — the bytes (if any) are no
-    // longer the user's to read. For pooled addresses the metadata
-    // stays in map_ for recycling; for non-pooled it goes too.
+    // Evict the shadow — those bytes are no longer the user's to read.
+    // The DevAddr stays in alloc_set_ and goes onto the free list for
+    // the next allocate() to recycle.
     shadow_data_.erase(addr);
-    if (it->second.pooled) {
-        pool_free_.push_back(addr);
-    } else {
-        map_.erase(it);
-    }
+    pool_free_.push_back(addr);
     return HAZE_SUCCESS;
 }
 
@@ -134,14 +124,13 @@ DeviceAllocator::extract_polynomial_components(DevAddr addr, uint64_t ring_dim) 
         return std::unexpected(HazeInternalError::NotConfigured);
     }
     HazeLockGuard lock(mutex_);
-    auto it = map_.find(addr);
-    if (it == map_.end()) {
+    if (!alloc_set_.contains(addr)) {
         record_internal_error(HazeInternalError::UnknownAddress,
                               "DeviceAllocator::extract_polynomial_components");
         return std::unexpected(HazeInternalError::UnknownAddress);
     }
     const size_t expected_bytes = ring_dim * sizeof(uint64_t);
-    if (it->second.size < expected_bytes) {
+    if (poly_bytes_ < expected_bytes) {
         record_internal_error(HazeInternalError::AllocTooSmall,
                               "DeviceAllocator::extract_polynomial_components");
         return std::unexpected(HazeInternalError::AllocTooSmall);
@@ -160,8 +149,8 @@ DeviceAllocator::extract_polynomial_components(DevAddr addr, uint64_t ring_dim) 
     auto components = std::move(node.mapped());
     if (components.size() != ring_dim) {
         // Invariant break: every write path sizes the shadow to
-        // elems_for_allocation, which equals ring_dim under allocate()'s
-        // single-poly-size contract. Surface, don't paper over.
+        // poly_bytes_/sizeof(uint64_t), which equals ring_dim under
+        // allocate()'s single-poly-size contract. Surface, don't paper over.
         record_internal_error(HazeInternalError::ShadowSizeMismatch,
                               "DeviceAllocator::extract_polynomial_components");
         return std::unexpected(HazeInternalError::ShadowSizeMismatch);
@@ -169,20 +158,52 @@ DeviceAllocator::extract_polynomial_components(DevAddr addr, uint64_t ring_dim) 
     return components;
 }
 
+std::expected<std::vector<uint64_t>, HazeInternalError>
+DeviceAllocator::read_polynomial_components(DevAddr addr, uint64_t ring_dim) const noexcept {
+    if (ring_dim == 0) {
+        record_internal_error(HazeInternalError::NotConfigured,
+                              "DeviceAllocator::read_polynomial_components: ring_dim == 0");
+        return std::unexpected(HazeInternalError::NotConfigured);
+    }
+    HazeLockGuard lock(mutex_);
+    if (!alloc_set_.contains(addr)) {
+        record_internal_error(HazeInternalError::UnknownAddress,
+                              "DeviceAllocator::read_polynomial_components");
+        return std::unexpected(HazeInternalError::UnknownAddress);
+    }
+    const size_t expected_bytes = ring_dim * sizeof(uint64_t);
+    if (poly_bytes_ < expected_bytes) {
+        record_internal_error(HazeInternalError::AllocTooSmall,
+                              "DeviceAllocator::read_polynomial_components");
+        return std::unexpected(HazeInternalError::AllocTooSmall);
+    }
+    auto data_it = shadow_data_.find(addr);
+    if (data_it == shadow_data_.end()) {
+        record_internal_error(HazeInternalError::NoData,
+                              "DeviceAllocator::read_polynomial_components");
+        return std::unexpected(HazeInternalError::NoData);
+    }
+    if (data_it->second.size() != ring_dim) {
+        record_internal_error(HazeInternalError::ShadowSizeMismatch,
+                              "DeviceAllocator::read_polynomial_components");
+        return std::unexpected(HazeInternalError::ShadowSizeMismatch);
+    }
+    return data_it->second;
+}
+
 hazeError_t DeviceAllocator::copy_h2d(DevAddr dst, const void *src, size_t count) noexcept {
     if (src == nullptr)
         return HAZE_ERROR_INVALID_VALUE;
     HazeLockGuard lock(mutex_);
-    auto it = map_.find(dst);
-    if (it == map_.end())
+    if (!alloc_set_.contains(dst))
         return HAZE_ERROR_INVALID_VALUE;
-    if (count > it->second.size)
+    if (count > poly_bytes_)
         return HAZE_ERROR_INVALID_VALUE;
     // Lazy-create or overwrite the shadow entry. Sized to the full
     // allocation so partial writes leave the tail at zero (matches
     // prior eager-zero semantics for the unwritten tail).
     auto &shadow = shadow_data_[dst];
-    const size_t want_elems = elems_for_allocation(it->second);
+    const size_t want_elems = poly_bytes_ / sizeof(uint64_t);
     if (shadow.size() != want_elems) {
         shadow.assign(want_elems, uint64_t{0});
     }
@@ -192,11 +213,9 @@ hazeError_t DeviceAllocator::copy_h2d(DevAddr dst, const void *src, size_t count
 
 hazeError_t DeviceAllocator::copy_d2d(DevAddr dst, DevAddr src, size_t count) noexcept {
     HazeLockGuard lock(mutex_);
-    auto src_it = map_.find(src);
-    auto dst_it = map_.find(dst);
-    if (src_it == map_.end() || dst_it == map_.end())
+    if (!alloc_set_.contains(src) || !alloc_set_.contains(dst))
         return HAZE_ERROR_INVALID_VALUE;
-    if (count > src_it->second.size || count > dst_it->second.size)
+    if (count > poly_bytes_)
         return HAZE_ERROR_INVALID_VALUE;
     auto src_data = shadow_data_.find(src);
     if (src_data == shadow_data_.end()) {
@@ -206,9 +225,7 @@ hazeError_t DeviceAllocator::copy_d2d(DevAddr dst, DevAddr src, size_t count) no
         return HAZE_SUCCESS;
     }
     auto &dst_shadow = shadow_data_[dst];
-    // Size from the dst allocation, not src; equal today under the
-    // single-poly-size invariant in allocate() but flagged for clarity.
-    const size_t want_elems = elems_for_allocation(dst_it->second);
+    const size_t want_elems = poly_bytes_ / sizeof(uint64_t);
     if (dst_shadow.size() != want_elems) {
         dst_shadow.assign(want_elems, uint64_t{0});
     }
@@ -219,13 +236,12 @@ hazeError_t DeviceAllocator::copy_d2d(DevAddr dst, DevAddr src, size_t count) no
 
 hazeError_t DeviceAllocator::memset(DevAddr addr, int value, size_t count) noexcept {
     HazeLockGuard lock(mutex_);
-    auto it = map_.find(addr);
-    if (it == map_.end())
+    if (!alloc_set_.contains(addr))
         return HAZE_ERROR_INVALID_VALUE;
-    if (count > it->second.size)
+    if (count > poly_bytes_)
         return HAZE_ERROR_INVALID_VALUE;
     auto &shadow = shadow_data_[addr];
-    const size_t want_elems = elems_for_allocation(it->second);
+    const size_t want_elems = poly_bytes_ / sizeof(uint64_t);
     if (shadow.size() != want_elems) {
         shadow.assign(want_elems, uint64_t{0});
     }
@@ -237,10 +253,9 @@ hazeError_t DeviceAllocator::copy_to_host(void *dst, DevAddr src, size_t count) 
     if (dst == nullptr)
         return HAZE_ERROR_INVALID_VALUE;
     HazeLockGuard lock(mutex_);
-    auto it = map_.find(src);
-    if (it == map_.end())
+    if (!alloc_set_.contains(src))
         return HAZE_ERROR_INVALID_VALUE;
-    if (count > it->second.size)
+    if (count > poly_bytes_)
         return HAZE_ERROR_INVALID_VALUE;
     auto data_it = shadow_data_.find(src);
     if (data_it == shadow_data_.end()) {
@@ -257,12 +272,11 @@ hazeError_t DeviceAllocator::copy_to_host(void *dst, DevAddr src, size_t count) 
 std::expected<void, HazeInternalError>
 DeviceAllocator::update_shadow(DevAddr addr, std::vector<uint64_t> &&values) noexcept {
     HazeLockGuard lock(mutex_);
-    auto it = map_.find(addr);
-    if (it == map_.end()) {
+    if (!alloc_set_.contains(addr)) {
         record_internal_error(HazeInternalError::UnknownAddress, "DeviceAllocator::update_shadow");
         return std::unexpected(HazeInternalError::UnknownAddress);
     }
-    const size_t want_elems = elems_for_allocation(it->second);
+    const size_t want_elems = poly_bytes_ / sizeof(uint64_t);
     if (values.size() != want_elems) {
         values.resize(want_elems, uint64_t{0});
     }
@@ -274,7 +288,7 @@ bool DeviceAllocator::is_device_pointer(const void *ptr) const noexcept {
     if (ptr == nullptr)
         return false;
     HazeLockGuard lock(mutex_);
-    return map_.contains(to_dev_addr(ptr));
+    return alloc_set_.contains(to_dev_addr(ptr));
 }
 
 hazeError_t DeviceAllocator::pointer_attributes(hazePointerAttributes *attrs,
@@ -290,7 +304,7 @@ hazeError_t DeviceAllocator::pointer_attributes(hazePointerAttributes *attrs,
     auto classification = Classification::Unknown;
     if (ptr != nullptr) {
         HazeLockGuard lock(mutex_);
-        if (map_.contains(to_dev_addr(ptr))) {
+        if (alloc_set_.contains(to_dev_addr(ptr))) {
             classification = Classification::Device;
         } else if (host_set_.contains(ptr)) {
             classification = Classification::Host;
@@ -334,7 +348,7 @@ void DeviceAllocator::unregister_host_pointer(const void *ptr) noexcept {
 
 void DeviceAllocator::reset() noexcept {
     HazeLockGuard lock(mutex_);
-    map_.clear();
+    alloc_set_.clear();
     shadow_data_.clear();
     pool_free_.clear();
     host_set_.clear();

--- a/src/core/allocator.hpp
+++ b/src/core/allocator.hpp
@@ -39,12 +39,6 @@ class AllocatorTestAccess;
 // addresses in a typical FHE program are intermediate compute results
 // that flow entirely inside fhetch::Polynomial storage and never need
 // a HAZE shadow.
-struct Allocation {
-    DevAddr addr{};      ///< Virtual device address handed to the user.
-    size_t size = 0;     ///< Allocation size in bytes (== poly_bytes_ under strict contract).
-    bool pooled = false; ///< True iff this allocation participates in pool recycling.
-};
-
 // Single-size device allocator with sparse-map shadow storage.
 //
 // HAZE's device address space is FHETCH-addressable storage — every
@@ -54,7 +48,8 @@ struct Allocation {
 // host allocations (or `hazeHostMalloc` when page-aligned host memory
 // is needed).
 //
-// Storage model. Each DevAddr has metadata in `map_` (size, pool flag).
+// Storage model. Live DevAddrs are tracked as set membership in
+// `alloc_set_` — allocation size is implicit (always `poly_bytes_`).
 // Component payloads live in a separate sparse map `shadow_data_`
 // keyed by DevAddr, with each entry a `vector<uint64_t>` sized to the
 // allocation. An entry exists only when the address currently carries
@@ -119,13 +114,20 @@ class DeviceAllocator {
     HAZE_API std::expected<std::vector<uint64_t>, HazeInternalError>
     extract_polynomial_components(DevAddr addr, uint64_t ring_dim) noexcept HAZE_EXCLUDES(mutex_);
 
+    // Non-evicting copy of the shadow components. Used by the H2D eager-tag
+    // path that must leave shadow_data_ intact (a subsequent compute-free
+    // D2H still reads the original H2D bytes).
+    HAZE_API std::expected<std::vector<uint64_t>, HazeInternalError>
+    read_polynomial_components(DevAddr addr, uint64_t ring_dim) const noexcept
+        HAZE_EXCLUDES(mutex_);
+
     // Read shadow bytes into a host buffer. Caller is responsible for
     // any compute materialization; this only touches the staging buffer.
     hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) const noexcept
         HAZE_EXCLUDES(mutex_);
 
     // Full-replace write of the shadow buffer; `values` is truncated
-    // or zero-padded to `elems_for_allocation` then moved in.
+    // or zero-padded to `poly_bytes_ / sizeof(uint64_t)` then moved in.
     std::expected<void, HazeInternalError> update_shadow(DevAddr addr,
                                                          std::vector<uint64_t> &&values) noexcept
         HAZE_EXCLUDES(mutex_);
@@ -155,13 +157,6 @@ class DeviceAllocator {
 
     friend class test::AllocatorTestAccess;
 
-    // Byte→element conversion shared by every shadow write path
-    // (copy_h2d, copy_d2d, memset, update_shadow). One place so a new
-    // write path can't drift from the formula.
-    static constexpr size_t elems_for_allocation(const Allocation &a) noexcept {
-        return a.size / sizeof(uint64_t);
-    }
-
     // Helper (caller holds mutex_).
     void clear_pool_locked() noexcept HAZE_REQUIRES(mutex_);
 
@@ -170,11 +165,12 @@ class DeviceAllocator {
     // allocator). Allocator-side code must NOT call into EpochState
     // while holding this lock — the reverse direction is forbidden.
     mutable HazeMutex mutex_;
-    // Per-address metadata. Entry exists for the lifetime of the
-    // hazeMalloc/hazeFree contract.
-    std::unordered_map<DevAddr, Allocation> map_ HAZE_GUARDED_BY(mutex_);
+    // Live DevAddrs. Set membership covers the lifetime of the
+    // hazeMalloc/hazeFree contract; allocation size is implicit
+    // (== poly_bytes_) under the single-size invariant.
+    std::unordered_set<DevAddr> alloc_set_ HAZE_GUARDED_BY(mutex_);
     // Sparse uint64_t component storage, vector sized to
-    // `elems_for_allocation`. Created by H2D/memset/D2D/update_shadow,
+    // `poly_bytes_ / sizeof(uint64_t)`. Created by H2D/memset/D2D/update_shadow,
     // evicted by extract / hazeFree / set_polynomial_size / reset.
     std::unordered_map<DevAddr, std::vector<uint64_t>> shadow_data_ HAZE_GUARDED_BY(mutex_);
     std::vector<DevAddr>

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -98,22 +98,22 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
 
     const uint64_t ring_dim = config().ring_dim();
     auto components = allocator().extract_polynomial_components(addr, ring_dim);
-
-    fhetch::Polynomial poly;
-    if (components) {
-        poly = fhetch::Polynomial::from_data(std::move(*components), ring_dim,
-                                             fhetch::Format::Evaluation);
-    } else if (components.error() == HazeInternalError::NoData) {
-        // Address allocated but never written: build a fhetch zero polynomial
-        // so HAZE doesn't fabricate the bytes (matches FIDESlib's SPECIAL pattern).
-        poly = fhetch::Polynomial::zeros(ring_dim);
-    } else {
+    if (!components) {
+        // Compute / D2D on an addr with neither shadow data nor a
+        // poly_map_ binding is undefined under the record-and-replay
+        // model — there's no value to read. Translate NoData into the
+        // sharper SourceUnavailable; pass other errors through.
+        if (components.error() == HazeInternalError::NoData) {
+            record_internal_error(HazeInternalError::SourceUnavailable,
+                                  "lookup_or_create_locked: no shadow and no poly_map_ binding");
+            return std::unexpected(HazeInternalError::SourceUnavailable);
+        }
         return std::unexpected(components.error());
     }
-
+    fhetch::Polynomial poly =
+        fhetch::Polynomial::from_data(std::move(*components), ring_dim, fhetch::Format::Evaluation);
     const std::string name = "haze_in_" + std::to_string(input_counter_++);
     fhetch::tag_input(name, poly);
-
     poly_map_.emplace(addr, poly);
     return poly;
 }
@@ -126,6 +126,33 @@ void EpochState::store_compute_result_locked(DevAddr addr,
     if (!pending_outputs_.contains(addr)) {
         pending_outputs_.emplace(addr, "haze_out_" + std::to_string(output_counter_++));
     }
+}
+
+std::expected<void, HazeInternalError> EpochState::tag_h2d_input_locked(DevAddr addr) noexcept {
+    // Both guards below cover invariants that the H2D entry point has
+    // already enforced (copy_h2d requires alloc_set_ membership and a
+    // configured poly_bytes_, so by the time this runs ring_dim is set
+    // and shadow bytes exist). Treat hits as broken-haze internal
+    // errors so we don't silently drop the input tag.
+    const uint64_t ring_dim = config().ring_dim();
+    if (ring_dim == 0) {
+        record_internal_error(HazeInternalError::NotConfigured,
+                              "tag_h2d_input_locked: ring_dim == 0 after copy_h2d");
+        return std::unexpected(HazeInternalError::NotConfigured);
+    }
+    auto components = allocator().read_polynomial_components(addr, ring_dim);
+    if (!components)
+        return std::unexpected(components.error());
+    fhetch::Polynomial poly =
+        fhetch::Polynomial::from_data(std::move(*components), ring_dim, fhetch::Format::Evaluation);
+    const std::string name = "haze_in_" + std::to_string(input_counter_++);
+    fhetch::tag_input(name, poly);
+    // Overwrite any prior binding — the new H2D bytes are the truth at addr.
+    // Prior MRP-group entries naming addr stay valid (the group's claim is
+    // addr-bound; the new poly is just the residue's new value).
+    poly_map_.insert_or_assign(addr, std::move(poly));
+    pending_outputs_.erase(addr);
+    return {};
 }
 
 void EpochState::tag_mrp_input_if_new_locked(const std::string &name, const fhetch::MRP &mrp) {
@@ -164,6 +191,15 @@ std::expected<void, HazeInternalError> EpochState::replay_and_populate() noexcep
     HazeLockGuard lock(mutex_);
     if (!recording_) {
         return {}; // nothing to replay
+    }
+
+    // No outputs to materialize — recording was opened (e.g., by H2D's
+    // eager-tag) but no compute followed. The shadow buffer holds the
+    // current bytes; skip the replay entirely so the bridge crypto context
+    // isn't a prerequisite for compute-free D2H reads.
+    if (pending_outputs_.empty() && pending_mrp_groups_.empty()) {
+        clear_state_locked();
+        return {};
     }
 
     // pending_outputs_ and poly_map_ stay in lockstep via store + invalidate,
@@ -302,6 +338,32 @@ hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept {
     if (!replay_result)
         return to_public_error(replay_result.error());
     return allocator().copy_to_host(dst, src, count);
+}
+
+std::expected<void, HazeInternalError> copy_device_to_device(DevAddr dst, DevAddr src,
+                                                             size_t /*count*/) noexcept {
+    // D2D is a recorded polynomial copy under the first configured ciphertext
+    // modulus. sr_addps with imm=0 and a real modulus is a normalize-and-copy
+    // — identity for any well-formed CKKS residue and the right contract for
+    // record-and-replay; an "unbounded" copy isn't meaningful in CKKS. The
+    // real modulus also triggers remember_modulus, which is what makes a
+    // freshly-tagged input visible to sync_fhetch_state_to_compiler at
+    // replay time.
+    const uint64_t q = config().modulus(0);
+    if (q == 0)
+        return std::unexpected(HazeInternalError::NotConfigured);
+    EpochSession session;
+    auto src_poly = epoch().lookup_or_create_locked(src);
+    if (!src_poly)
+        return std::unexpected(src_poly.error());
+    fhetch::Polynomial result = fhetch::sr_addps(*src_poly, fhetch::Scalar::from_int(0), q);
+    epoch().store_compute_result_locked(dst, std::move(result));
+    return {};
+}
+
+std::expected<void, HazeInternalError> tag_h2d_input(DevAddr addr) noexcept {
+    EpochSession session;
+    return epoch().tag_h2d_input_locked(addr);
 }
 
 } // namespace haze

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -69,6 +69,15 @@ class EpochState {
     void store_compute_result_locked(DevAddr addr, niobium::fhetch::Polynomial poly) noexcept
         HAZE_REQUIRES(mutex_);
 
+    // Eagerly tag the H2D'd shadow bytes at `addr` as a fhetch input.
+    // Builds the Polynomial via a non-evicting read (shadow stays intact
+    // for subsequent compute-free D2H), tag_inputs it, and binds it in
+    // poly_map_. Modulus tracking is left to the first real op that
+    // consumes the address. Returns an internal error if the H2D
+    // post-conditions (ring_dim set, shadow populated) are violated.
+    std::expected<void, HazeInternalError> tag_h2d_input_locked(DevAddr addr) noexcept
+        HAZE_REQUIRES(mutex_);
+
     // Register an MRP-shaped grouping so replay can emit a single
     // fhetch::tag_output(name, MRP); deduped by name on re-registration.
     std::expected<void, HazeInternalError>
@@ -153,5 +162,18 @@ class HAZE_SCOPED_CAPABILITY EpochSession {
 // copy from the device shadow buffer to host. Returns a public
 // hazeError_t already translated for the C ABI.
 hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept;
+
+// D2D as a recorded copy: promotes `src` if needed (via
+// `lookup_or_create_locked`), emits a pass-through fhetch IR node, and
+// binds `dst` to the result. Always starts an epoch — there is no
+// pre-recording byte-copy escape hatch. Returns the internal error type
+// so the api/ shim does the public-code translation at the C ABI edge.
+std::expected<void, HazeInternalError> copy_device_to_device(DevAddr dst, DevAddr src,
+                                                             size_t count) noexcept;
+
+// H2D-time eager-tag: register the H2D'd buffer at `addr` as a fhetch
+// input so subsequent compute / D2D ops see a tagged polynomial instead
+// of a never-touched shadow buffer.
+std::expected<void, HazeInternalError> tag_h2d_input(DevAddr addr) noexcept;
 
 } // namespace haze

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -1205,7 +1205,7 @@ TEST_CASE("hazeAdd with unknown source address returns error", "[unit]") {
     void *fake1 = reinterpret_cast<void *>(uintptr_t{0x4000000000ULL} + 0x8000000ULL);
     void *fake2 = reinterpret_cast<void *>(uintptr_t{0x4000000000ULL} + 0x9000000ULL);
     // NOLINTEND(performance-no-int-to-ptr)
-    REQUIRE(hazeAdd(d_dst, fake1, fake2, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeAdd(d_dst, fake1, fake2, 0, nullptr) == HAZE_ERROR_UNKNOWN_ADDRESS);
     hazeGetLastError();
 
     REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
@@ -1252,7 +1252,7 @@ TEST_CASE("hazeMul with unknown source address returns error", "[unit]") {
     void *fake1 = reinterpret_cast<void *>(uintptr_t{0x4000000000ULL} + 0x8000000ULL);
     void *fake2 = reinterpret_cast<void *>(uintptr_t{0x4000000000ULL} + 0x9000000ULL);
     // NOLINTEND(performance-no-int-to-ptr)
-    REQUIRE(hazeMul(d_dst, fake1, fake2, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeMul(d_dst, fake1, fake2, 0, nullptr) == HAZE_ERROR_UNKNOWN_ADDRESS);
     hazeGetLastError();
 
     REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);

--- a/test/test_d2d_copy.cpp
+++ b/test/test_d2d_copy.cpp
@@ -1,0 +1,173 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// hazeMemcpy(D2D) on a compute-produced source: src has a poly_map_
+// binding but no shadow_data_ entry until D2H. The shadow-only copy
+// path would silently produce zeros; the contract is to emit a
+// pass-through fhetch IR node so replay materializes dst correctly.
+
+#include "integration_helpers.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
+#include <vector>
+
+namespace {
+
+constexpr uint64_t kRingDim = 4096;
+constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
+
+} // namespace
+
+TEST_CASE("hazeMemcpy(D2D) copies a compute-produced polynomial via IR", "[integration]") {
+    const uint64_t q = haze::test::setup_integration_compute_config();
+
+    void *src_in = nullptr;
+    void *dst_compute = nullptr;
+    void *dst_copy = nullptr;
+    REQUIRE(hazeMalloc(&src_in, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&dst_compute, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&dst_copy, kBytes) == HAZE_SUCCESS);
+
+    const auto residue = haze::test::make_residue(q, /*seed=*/42, kRingDim);
+    REQUIRE(hazeMemcpy(src_in, residue.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    // Compute op: dst_compute = src_in + src_in. This binds dst_compute
+    // in poly_map_ but leaves shadow_data_[dst_compute] absent.
+    REQUIRE(hazeAdd(dst_compute, src_in, src_in, 0, nullptr) == HAZE_SUCCESS);
+
+    // The D2D under test.
+    REQUIRE(hazeMemcpy(dst_copy, dst_compute, kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE) ==
+            HAZE_SUCCESS);
+
+    std::vector<uint64_t> out(kRingDim);
+    REQUIRE(hazeMemcpy(out.data(), dst_copy, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+
+    // Expected: 2 * residue[i] mod q.
+    for (std::size_t i = 0; i < kRingDim; ++i) {
+        const uint64_t expected = (residue[i] + residue[i]) % q;
+        REQUIRE(out[i] == expected);
+    }
+
+    REQUIRE(hazeFree(dst_copy) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(dst_compute) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(src_in) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeMemcpy(D2D) copies a residue into an MRP-registered addr", "[integration]") {
+    // D2D is a value copy: src and dst end up holding their respective polys
+    // independently. Copying a single-residue poly into one member of a
+    // registered MRP output group leaves the source intact, gives dst the
+    // copied value, keeps the other group members at their original
+    // residues, and the group itself survives.
+    constexpr uint64_t kRingDimMrp = 4096;
+    constexpr std::size_t kBytesMrp = kRingDimMrp * sizeof(uint64_t);
+    constexpr uint64_t kQ0 = 576460752303415297ULL;
+    constexpr uint64_t kQ1 = 576460752303439873ULL;
+    constexpr uint64_t kQ2 = 576460752303702017ULL;
+
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDimMrp) == HAZE_SUCCESS);
+    uint64_t picked = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDimMrp, kQ0, &picked) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(0, picked) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+
+    const std::vector<uint64_t> base = {picked, kQ1, kQ2};
+    std::vector<std::vector<uint64_t>> src_residues = {
+        haze::test::make_residue(picked, /*seed=*/1, kRingDimMrp),
+        haze::test::make_residue(kQ1, /*seed=*/2, kRingDimMrp),
+        haze::test::make_residue(kQ2, /*seed=*/3, kRingDimMrp),
+    };
+
+    auto srcs = haze::test::allocate_and_h2d_residues(src_residues);
+    auto outs = haze::test::allocate_dst_residues(3, kBytesMrp);
+
+    // MRP op binds outs[0..2] in poly_map_ AND registers them as a group.
+    REQUIRE(hazeAddMrp(outs.data(), haze::test::to_const(srcs).data(),
+                       haze::test::to_const(srcs).data(), base.data(), base.size(),
+                       nullptr) == HAZE_SUCCESS);
+
+    // Distinguishable single-residue value: srcs[0] + 13 mod q0. Differs
+    // from outs[0]'s original (2 * srcs[0]) so the test can tell the new
+    // residue apart from the original group value.
+    void *single = nullptr;
+    REQUIRE(hazeMalloc(&single, kBytesMrp) == HAZE_SUCCESS);
+    REQUIRE(hazeAddScalar(single, srcs[0], /*scalar=*/13, 0, nullptr) == HAZE_SUCCESS);
+
+    REQUIRE(hazeMemcpy(outs[0], single, kBytesMrp, HAZE_MEMCPY_DEVICE_TO_DEVICE) == HAZE_SUCCESS);
+
+    std::vector<uint64_t> out_copy(kRingDimMrp);
+    std::vector<uint64_t> out_mrp1(kRingDimMrp);
+    std::vector<uint64_t> out_mrp2(kRingDimMrp);
+    std::vector<uint64_t> out_src(kRingDimMrp);
+    REQUIRE(hazeMemcpy(out_copy.data(), outs[0], kBytesMrp, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+            HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(out_mrp1.data(), outs[1], kBytesMrp, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+            HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(out_mrp2.data(), outs[2], kBytesMrp, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+            HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(out_src.data(), single, kBytesMrp, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+            HAZE_SUCCESS);
+
+    for (std::size_t i = 0; i < kRingDimMrp; ++i) {
+        const uint64_t expected_single = (src_residues[0][i] + 13U) % picked;
+        REQUIRE(out_copy[i] == expected_single);
+        REQUIRE(out_src[i] == expected_single);
+        REQUIRE(out_mrp1[i] == (src_residues[1][i] + src_residues[1][i]) % kQ1);
+        REQUIRE(out_mrp2[i] == (src_residues[2][i] + src_residues[2][i]) % kQ2);
+    }
+
+    REQUIRE(hazeFree(single) == HAZE_SUCCESS);
+    haze::test::free_all_residues(outs);
+    haze::test::free_all_residues(srcs);
+}
+
+TEST_CASE("hazeMemcpy(D2D) from a never-written source returns SOURCE_UNAVAILABLE",
+          "[integration]") {
+    haze::test::setup_integration_compute_config();
+
+    void *src = nullptr;
+    void *dst = nullptr;
+    REQUIRE(hazeMalloc(&src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&dst, kBytes) == HAZE_SUCCESS);
+
+    // src is allocated but never H2D'd or compute-touched. D2D must fail
+    // loudly rather than silently produce a zero-filled dst.
+    REQUIRE(hazeMemcpy(dst, src, kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE) ==
+            HAZE_ERROR_SOURCE_UNAVAILABLE);
+
+    REQUIRE(hazeFree(dst) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(src) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeMemcpy(D2D) promotes an H2D'd source through the IR copy", "[integration]") {
+    // H2D'd-but-never-compute-touched source: D2D triggers lookup_or_create
+    // which promotes the shadow bytes into a tagged fhetch input, then
+    // emits the copy IR. Round-trip bytes must match the original H2D.
+    const uint64_t q = haze::test::setup_integration_compute_config();
+    (void)q;
+
+    void *src = nullptr;
+    void *dst = nullptr;
+    REQUIRE(hazeMalloc(&src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&dst, kBytes) == HAZE_SUCCESS);
+
+    const auto residue = haze::test::make_residue(q, /*seed=*/7, kRingDim);
+    REQUIRE(hazeMemcpy(src, residue.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(dst, src, kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE) == HAZE_SUCCESS);
+
+    std::vector<uint64_t> out(kRingDim);
+    REQUIRE(hazeMemcpy(out.data(), dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    for (std::size_t i = 0; i < kRingDim; ++i) {
+        REQUIRE(out[i] == residue[i]);
+    }
+
+    REQUIRE(hazeFree(dst) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(src) == HAZE_SUCCESS);
+}

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -39,7 +39,7 @@ TEST_CASE("hazeMalloc with size != polynomial bytes is rejected", "[unit]") {
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     void *p = nullptr;
     // ring_dim=4096 → polynomial bytes = 32768; 8KB request fails.
-    REQUIRE(hazeMalloc(&p, 8192) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeMalloc(&p, 8192) == HAZE_ERROR_ALLOC_TOO_SMALL);
     hazeGetLastError();
 }
 
@@ -89,31 +89,6 @@ TEST_CASE("H2D then D2H round-trip preserves data", "[unit]") {
 
     REQUIRE(dst == src);
     REQUIRE(hazeFree(dev) == HAZE_SUCCESS);
-}
-
-TEST_CASE("D2D memcpy copies shadow buffer", "[unit]") {
-    constexpr size_t kBytes = 32768;
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    void *src_dev = nullptr;
-    void *dst_dev = nullptr;
-    REQUIRE(hazeMalloc(&src_dev, kBytes) == HAZE_SUCCESS);
-    REQUIRE(hazeMalloc(&dst_dev, kBytes) == HAZE_SUCCESS);
-
-    std::vector<uint8_t> pattern(kBytes);
-    for (size_t i = 0; i < kBytes; ++i)
-        pattern[i] = static_cast<uint8_t>(i & 0xFF);
-
-    REQUIRE(hazeMemcpy(src_dev, pattern.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
-            HAZE_SUCCESS);
-    REQUIRE(hazeMemcpy(dst_dev, src_dev, kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE) == HAZE_SUCCESS);
-
-    std::vector<uint8_t> result(kBytes, 0);
-    REQUIRE(hazeMemcpy(result.data(), dst_dev, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
-
-    REQUIRE(result == pattern);
-    REQUIRE(hazeFree(src_dev) == HAZE_SUCCESS);
-    REQUIRE(hazeFree(dst_dev) == HAZE_SUCCESS);
 }
 
 TEST_CASE("hazeMemset fills shadow buffer", "[unit]") {


### PR DESCRIPTION
D2D was previously broken due to not actually emitting the copy instruction. Now we do emit a copy instruction using `sr_addps` (the standard way to do this using the copy modulus). At the same time, the allocator was simplified to remove unnecessary pooled/etc components (there was no pool) and also made sure every h2d was tagged as an input.