### PR TITLE
core: collapse internal errors, drop vestigial code, audit cleanup

### DIFF
--- a/include/haze/haze_types.h
+++ b/include/haze/haze_types.h
@@ -72,44 +72,23 @@ typedef struct haze_exec_s *hazeGraphExec_t;
 // are silenced for the entire ABI block.
 // NOLINTBEGIN(cppcoreguidelines-use-enum-class,performance-enum-size)
 
+// Only user-actionable conditions get their own code. Anything that
+// signals "haze itself is broken" maps to HAZE_ERROR_INTERNAL — callers
+// can log it but can't recover; the rich classification lives in
+// haze's internal `HazeInternalError` enum and surfaces via the
+// HAZE_DEBUG=1 stderr log.
 typedef enum {
     HAZE_SUCCESS = 0,
-    HAZE_ERROR_INVALID_HANDLE,          // opaque handle (stream / event / graph) is null or stale
-    HAZE_ERROR_INVALID_VALUE,           // argument violated the documented contract
-    HAZE_ERROR_OUT_OF_MEMORY,           // allocator could not satisfy the request
-    HAZE_ERROR_NOT_SUPPORTED,           // operation is not implemented for this build / target
-    HAZE_ERROR_NOT_READY,               // CUDA-shape parity: device or async result not ready
-    HAZE_ERROR_LAUNCH_FAILURE,          // compilation or execution failure on the backend
-    HAZE_ERROR_DMEMERR,                 // hardware data-memory error (FPGA / silicon target)
-    HAZE_ERROR_IMEMERR,                 // hardware instruction-memory error
-    HAZE_ERROR_INSTRERR,                // hardware instruction error
-    HAZE_ERROR_CONFIGERR,               // ring_dim / modulus / target not configured
-    HAZE_ERROR_ISEQERR,                 // hardware instruction-sequence error
-    HAZE_ERROR_UNKNOWN_ADDRESS,         // DevAddr not in the allocator's table
-    HAZE_ERROR_NO_DATA,                 // address allocated but never written
-    HAZE_ERROR_ALLOC_TOO_SMALL,         // allocation size < polynomial size
-    HAZE_ERROR_SOURCE_UNAVAILABLE,      // compute / D2D source has no shadow + no poly_map_
-    HAZE_ERROR_BACKEND_INIT_FAILED,     // niobium::compiler().init() threw
-    HAZE_ERROR_BACKEND_REPLAY_FAILED,   // stop_epoch / replay returned false / threw
-    HAZE_ERROR_BACKEND_SHAPE_MISMATCH,  // backend result / MRP-group shape mismatch
-    HAZE_ERROR_MISSING_POLYMAP_BINDING, // pending output / MRP group addr missing
-    HAZE_ERROR_SHADOW_SIZE_MISMATCH,    // shadow buffer length disagrees with ring_dim
-    HAZE_ERROR_BACKEND_OUTPUT_MISSING,  // fhetch::result(name, ...) returned false
-    HAZE_ERROR_BACKEND_OUTPUT_DECODE_FAILED, // extract_polynomial_values returned false
-    HAZE_ERROR_BRIDGE_HOOK_FAILED,           // post-recording hook reported failures
-    HAZE_ERROR_POOL_MAP_DESYNC,              // pool_free_ entry has no alloc_set_ peer
+    HAZE_ERROR_INVALID_VALUE,      // argument violated the documented contract
+    HAZE_ERROR_OUT_OF_MEMORY,      // allocator could not satisfy the request
+    HAZE_ERROR_NOT_SUPPORTED,      // operation is not implemented for this build / target
+    HAZE_ERROR_CONFIGERR,          // ring_dim / modulus / target not configured
+    HAZE_ERROR_UNKNOWN_ADDRESS,    // DevAddr not in the allocator's table
+    HAZE_ERROR_NO_DATA,            // address allocated but never written
+    HAZE_ERROR_ALLOC_TOO_SMALL,    // allocation size < polynomial size
+    HAZE_ERROR_SOURCE_UNAVAILABLE, // compute / D2D source has no shadow + no poly_map_
+    HAZE_ERROR_INTERNAL,           // haze invariant broke or backend failed; see HAZE_DEBUG log
 } hazeError_t;
-
-// ---------------------------------------------------------------------------
-// Memory-compute overlap capability flags
-// ---------------------------------------------------------------------------
-
-typedef enum {
-    HAZE_OVERLAP_NONE = 0,
-    HAZE_OVERLAP_LOAD = 1U << 0,
-    HAZE_OVERLAP_STORE = 1U << 1,
-    HAZE_OVERLAP_FULL = (1U << 0) | (1U << 1),
-} hazeOverlapFlags;
 
 // ---------------------------------------------------------------------------
 // DMA direction
@@ -119,11 +98,9 @@ typedef enum {
 // ---------------------------------------------------------------------------
 
 typedef enum {
-    HAZE_MEMCPY_HOST_TO_HOST = 0,
     HAZE_MEMCPY_HOST_TO_DEVICE = 1,
     HAZE_MEMCPY_DEVICE_TO_HOST = 2,
     HAZE_MEMCPY_DEVICE_TO_DEVICE = 3,
-    HAZE_MEMCPY_DEFAULT = 4,
 } hazeMemcpyKind;
 
 // ---------------------------------------------------------------------------
@@ -138,8 +115,6 @@ typedef struct {
     int supportedRingDimExponents[32]; /* HAZE-specific */
     int maxCiphertextModuli;           /* HAZE-specific */
     int numHBMBanks;                   /* HAZE-specific */
-    hazeOverlapFlags overlapCaps;      /* HAZE-specific */
-    int instructionFIFODepth;          /* HAZE-specific */
 } hazeDeviceProp;
 
 // ---------------------------------------------------------------------------
@@ -152,7 +127,6 @@ typedef enum {
     HAZE_MEMORY_TYPE_UNREGISTERED = 0,
     HAZE_MEMORY_TYPE_HOST = 1,
     HAZE_MEMORY_TYPE_DEVICE = 2,
-    HAZE_MEMORY_TYPE_MANAGED = 4
 } hazeMemoryType;
 // NOLINTEND(cppcoreguidelines-use-enum-class,performance-enum-size)
 

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -143,9 +143,9 @@ hazeError_t to_haze_error(BridgeError e) {
     case BridgeError::InvalidModulus:
         return HAZE_ERROR_INVALID_VALUE;
     case BridgeError::OpenFheUnavailable:
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     }
-    return HAZE_ERROR_LAUNCH_FAILURE;
+    return HAZE_ERROR_INTERNAL;
 }
 
 // Drop trailing towers from `dcrt` to exactly `target`; throws if the CC
@@ -484,9 +484,9 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         return HAZE_SUCCESS;
     } catch (const std::exception &e) {
         haze::log_error("replay_bridge", std::string{"init threw: "} + e.what());
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     } catch (...) {
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     }
 }
 
@@ -555,9 +555,9 @@ hazeReplayBridgeRegisterCryptoContext(const lbcrypto::CryptoContext<DCRTPoly> &c
         return HAZE_SUCCESS;
     } catch (const std::exception &e) {
         log_error("replay_bridge", std::string{"register_crypto_context threw: "} + e.what());
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     } catch (...) {
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     }
 }
 
@@ -661,9 +661,9 @@ extract_keyswitch_key_into(const lbcrypto::CryptoContext<DCRTPoly> &cc,
         return HAZE_SUCCESS;
     } catch (const std::exception &e) {
         log_error("replay_bridge", std::string{diag_prefix} + " threw: " + e.what());
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     } catch (...) {
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     }
 }
 
@@ -689,7 +689,7 @@ HAZE_API hazeError_t hazeReplayBridgeExtractEvalMultKey(
         log_error("replay_bridge", std::string{"ExtractEvalMultKey threw: "} + e.what());
         return HAZE_ERROR_INVALID_VALUE;
     } catch (...) {
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     }
 }
 
@@ -717,9 +717,9 @@ HAZE_API hazeError_t hazeReplayBridgeExtractAutomorphismKey(
         return extract_keyswitch_key_into(cc, it->second, "ExtractAutomorphismKey", out);
     } catch (const std::exception &e) {
         log_error("replay_bridge", std::string{"ExtractAutomorphismKey threw: "} + e.what());
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     } catch (...) {
-        return HAZE_ERROR_LAUNCH_FAILURE;
+        return HAZE_ERROR_INTERNAL;
     }
 }
 

--- a/src/api/compute.cpp
+++ b/src/api/compute.cpp
@@ -12,7 +12,7 @@
 // from the Product.
 //
 // HAZE compute API: extern "C" shims dispatching to the templates in
-// haze_compute.hpp. Each shim validates pointer arguments, casts to
+// core/compute.hpp. Each shim validates pointer arguments, casts to
 // DevAddr, and selects the matching FHETCH operation.
 
 #include "core/compute.hpp"
@@ -32,72 +32,72 @@ extern "C" hazeError_t hazeAdd(void *dst, const void *src1, const void *src2, in
                                hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op<fhetch::sr_addp>(haze::to_dev_addr(dst), haze::to_dev_addr(src1),
-                                               haze::to_dev_addr(src2), mod_idx);
+    return set_internal_result(haze::binary_pp_op<fhetch::sr_addp>(
+        haze::to_dev_addr(dst), haze::to_dev_addr(src1), haze::to_dev_addr(src2), mod_idx));
 }
 
 extern "C" hazeError_t hazeSub(void *dst, const void *src1, const void *src2, int mod_idx,
                                hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op<fhetch::sr_subp>(haze::to_dev_addr(dst), haze::to_dev_addr(src1),
-                                               haze::to_dev_addr(src2), mod_idx);
+    return set_internal_result(haze::binary_pp_op<fhetch::sr_subp>(
+        haze::to_dev_addr(dst), haze::to_dev_addr(src1), haze::to_dev_addr(src2), mod_idx));
 }
 
 extern "C" hazeError_t hazeMul(void *dst, const void *src1, const void *src2, int mod_idx,
                                hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op<fhetch::sr_mulp>(haze::to_dev_addr(dst), haze::to_dev_addr(src1),
-                                               haze::to_dev_addr(src2), mod_idx);
+    return set_internal_result(haze::binary_pp_op<fhetch::sr_mulp>(
+        haze::to_dev_addr(dst), haze::to_dev_addr(src1), haze::to_dev_addr(src2), mod_idx));
 }
 
 extern "C" hazeError_t hazeAddScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
                                      hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op<fhetch::sr_addps>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
-                                                scalar, mod_idx);
+    return set_internal_result(haze::binary_ps_op<fhetch::sr_addps>(
+        haze::to_dev_addr(dst), haze::to_dev_addr(src), scalar, mod_idx));
 }
 
 extern "C" hazeError_t hazeSubScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
                                      hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op<fhetch::sr_subps>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
-                                                scalar, mod_idx);
+    return set_internal_result(haze::binary_ps_op<fhetch::sr_subps>(
+        haze::to_dev_addr(dst), haze::to_dev_addr(src), scalar, mod_idx));
 }
 
 extern "C" hazeError_t hazeMulScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
                                      hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op<fhetch::sr_mulps>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
-                                                scalar, mod_idx);
+    return set_internal_result(haze::binary_ps_op<fhetch::sr_mulps>(
+        haze::to_dev_addr(dst), haze::to_dev_addr(src), scalar, mod_idx));
 }
 
 extern "C" hazeError_t hazeNTT(void *dst, const void *src, int mod_idx,
                                hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_pq_op<fhetch::sr_ntt>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
-                                             mod_idx);
+    return set_internal_result(
+        haze::unary_pq_op<fhetch::sr_ntt>(haze::to_dev_addr(dst), haze::to_dev_addr(src), mod_idx));
 }
 
 extern "C" hazeError_t hazeINTT(void *dst, const void *src, int mod_idx,
                                 hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_pq_op<fhetch::sr_intt>(haze::to_dev_addr(dst), haze::to_dev_addr(src),
-                                              mod_idx);
+    return set_internal_result(haze::unary_pq_op<fhetch::sr_intt>(haze::to_dev_addr(dst),
+                                                                  haze::to_dev_addr(src), mod_idx));
 }
 
 extern "C" hazeError_t hazeAutomorph(void *dst, const void *src, uint64_t index,
                                      hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_pi_op<fhetch::sr_automorph_eval>(haze::to_dev_addr(dst),
-                                                        haze::to_dev_addr(src), index);
+    return set_internal_result(haze::unary_pi_op<fhetch::sr_automorph_eval>(
+        haze::to_dev_addr(dst), haze::to_dev_addr(src), index));
 }
 
 // ---------------------------------------------------------------------------
@@ -114,7 +114,8 @@ extern "C" hazeError_t hazeAddMrp(void *const *dst, const void *const *src1,
                                   hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op_mrp<fhetch::mr_addp>(dst, src1, src2, base, base_len);
+    return set_internal_result(
+        haze::binary_pp_op_mrp<fhetch::mr_addp>(dst, src1, src2, base, base_len));
 }
 
 extern "C" hazeError_t hazeSubMrp(void *const *dst, const void *const *src1,
@@ -122,7 +123,8 @@ extern "C" hazeError_t hazeSubMrp(void *const *dst, const void *const *src1,
                                   hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op_mrp<fhetch::mr_subp>(dst, src1, src2, base, base_len);
+    return set_internal_result(
+        haze::binary_pp_op_mrp<fhetch::mr_subp>(dst, src1, src2, base, base_len));
 }
 
 extern "C" hazeError_t hazeMulMrp(void *const *dst, const void *const *src1,
@@ -130,7 +132,8 @@ extern "C" hazeError_t hazeMulMrp(void *const *dst, const void *const *src1,
                                   hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src1 == nullptr || src2 == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_pp_op_mrp<fhetch::mr_mulp>(dst, src1, src2, base, base_len);
+    return set_internal_result(
+        haze::binary_pp_op_mrp<fhetch::mr_mulp>(dst, src1, src2, base, base_len));
 }
 
 extern "C" hazeError_t hazeAddScalarMrp(void *const *dst, const void *const *src,
@@ -138,7 +141,8 @@ extern "C" hazeError_t hazeAddScalarMrp(void *const *dst, const void *const *src
                                         size_t base_len, hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || scalars == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op_mrp<fhetch::mr_addps>(dst, src, scalars, base, base_len);
+    return set_internal_result(
+        haze::binary_ps_op_mrp<fhetch::mr_addps>(dst, src, scalars, base, base_len));
 }
 
 extern "C" hazeError_t hazeSubScalarMrp(void *const *dst, const void *const *src,
@@ -146,7 +150,8 @@ extern "C" hazeError_t hazeSubScalarMrp(void *const *dst, const void *const *src
                                         size_t base_len, hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || scalars == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op_mrp<fhetch::mr_subps>(dst, src, scalars, base, base_len);
+    return set_internal_result(
+        haze::binary_ps_op_mrp<fhetch::mr_subps>(dst, src, scalars, base, base_len));
 }
 
 extern "C" hazeError_t hazeMulScalarMrp(void *const *dst, const void *const *src,
@@ -154,21 +159,22 @@ extern "C" hazeError_t hazeMulScalarMrp(void *const *dst, const void *const *src
                                         size_t base_len, hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || scalars == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::binary_ps_op_mrp<fhetch::mr_mulps>(dst, src, scalars, base, base_len);
+    return set_internal_result(
+        haze::binary_ps_op_mrp<fhetch::mr_mulps>(dst, src, scalars, base, base_len));
 }
 
 extern "C" hazeError_t hazeNTTMrp(void *const *dst, const void *const *src, const uint64_t *base,
                                   size_t base_len, hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_p_op_mrp<fhetch::mr_ntt>(dst, src, base, base_len);
+    return set_internal_result(haze::unary_p_op_mrp<fhetch::mr_ntt>(dst, src, base, base_len));
 }
 
 extern "C" hazeError_t hazeINTTMrp(void *const *dst, const void *const *src, const uint64_t *base,
                                    size_t base_len, hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_p_op_mrp<fhetch::mr_intt>(dst, src, base, base_len);
+    return set_internal_result(haze::unary_p_op_mrp<fhetch::mr_intt>(dst, src, base, base_len));
 }
 
 extern "C" hazeError_t hazeAutomorphMrp(void *const *dst, const void *const *src, uint64_t index,
@@ -176,7 +182,8 @@ extern "C" hazeError_t hazeAutomorphMrp(void *const *dst, const void *const *src
                                         hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_pi_op_mrp<fhetch::mr_automorph_eval>(dst, src, index, base, base_len);
+    return set_internal_result(
+        haze::unary_pi_op_mrp<fhetch::mr_automorph_eval>(dst, src, index, base, base_len));
 }
 
 extern "C" hazeError_t hazeRotAutomorphCoeffMrp(void *const *dst, const void *const *src,
@@ -184,7 +191,8 @@ extern "C" hazeError_t hazeRotAutomorphCoeffMrp(void *const *dst, const void *co
                                                 size_t base_len, hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return haze::unary_pi_op_mrp<fhetch::mr_rot_automorph_coeff>(dst, src, offset, base, base_len);
+    return set_internal_result(
+        haze::unary_pi_op_mrp<fhetch::mr_rot_automorph_coeff>(dst, src, offset, base, base_len));
 }
 
 // CRT basis conversion (hazeBasisConvert / hazeModDown / hazeModUp) is

--- a/src/api/config.cpp
+++ b/src/api/config.cpp
@@ -19,26 +19,26 @@
 #include <haze/haze_types.h>
 
 extern "C" hazeError_t hazeSetRingDimension(uint64_t n) noexcept {
-    return set_error(haze::config().set_ring_dimension(n));
+    return set_internal_result(haze::config().set_ring_dimension(n));
 }
 
 extern "C" hazeError_t hazeSetCiphertextModulus(int index, uint64_t modulus) noexcept {
-    return set_error(haze::config().set_modulus(index, modulus));
+    return set_internal_result(haze::config().set_modulus(index, modulus));
 }
 
 extern "C" hazeError_t hazeSetTwiddleFactors(int index, uint64_t generator) noexcept {
-    return set_error(haze::config().set_twiddle_generator(index, generator));
+    return set_internal_result(haze::config().set_twiddle_generator(index, generator));
 }
 
 extern "C" hazeError_t hazeConfigureDevice() noexcept {
-    return set_error(haze::config().configure_device());
+    return set_internal_result(haze::config().configure_device());
 }
 
 extern "C" hazeError_t hazeSetProgramInfo(const char *name, const char *version,
                                           const char *description) noexcept {
-    return set_error(haze::config().set_program_info(name, version, description));
+    return set_internal_result(haze::config().set_program_info(name, version, description));
 }
 
 extern "C" hazeError_t hazeSetTarget(const char *target) noexcept {
-    return set_error(haze::config().set_target(target));
+    return set_internal_result(haze::config().set_target(target));
 }

--- a/src/api/device.cpp
+++ b/src/api/device.cpp
@@ -25,7 +25,7 @@ extern "C" hazeError_t hazeGetDeviceCount(int *count) noexcept {
 }
 
 extern "C" hazeError_t hazeSetDevice(int device) noexcept {
-    return set_error(haze::device_set_active(device));
+    return set_internal_result(haze::device_set_active(device));
 }
 
 extern "C" hazeError_t hazeGetDevice(int *device) noexcept {
@@ -36,7 +36,7 @@ extern "C" hazeError_t hazeGetDevice(int *device) noexcept {
 }
 
 extern "C" hazeError_t hazeGetDeviceProperties(hazeDeviceProp *prop, int device) noexcept {
-    return set_error(haze::device_fill_properties(prop, device));
+    return set_internal_result(haze::device_fill_properties(prop, device));
 }
 
 extern "C" hazeError_t hazeDeviceSynchronize() noexcept {

--- a/src/api/error.cpp
+++ b/src/api/error.cpp
@@ -27,28 +27,14 @@ extern "C" const char *hazeGetErrorString(hazeError_t error) noexcept {
     switch (error) {
     case HAZE_SUCCESS:
         return "no error";
-    case HAZE_ERROR_INVALID_HANDLE:
-        return "invalid handle";
     case HAZE_ERROR_INVALID_VALUE:
         return "invalid value";
     case HAZE_ERROR_OUT_OF_MEMORY:
         return "out of memory";
     case HAZE_ERROR_NOT_SUPPORTED:
         return "not supported";
-    case HAZE_ERROR_NOT_READY:
-        return "device not ready";
-    case HAZE_ERROR_LAUNCH_FAILURE:
-        return "compilation or execution failure";
-    case HAZE_ERROR_DMEMERR:
-        return "data memory error";
-    case HAZE_ERROR_IMEMERR:
-        return "instruction memory error";
-    case HAZE_ERROR_INSTRERR:
-        return "instruction error";
     case HAZE_ERROR_CONFIGERR:
         return "configuration error";
-    case HAZE_ERROR_ISEQERR:
-        return "instruction sequence error";
     case HAZE_ERROR_UNKNOWN_ADDRESS:
         return "unknown device address";
     case HAZE_ERROR_NO_DATA:
@@ -57,24 +43,8 @@ extern "C" const char *hazeGetErrorString(hazeError_t error) noexcept {
         return "allocation size below polynomial size";
     case HAZE_ERROR_SOURCE_UNAVAILABLE:
         return "compute / D2D source has no shadow data and no poly_map_ binding";
-    case HAZE_ERROR_BACKEND_INIT_FAILED:
-        return "backend init failed";
-    case HAZE_ERROR_BACKEND_REPLAY_FAILED:
-        return "backend replay failed";
-    case HAZE_ERROR_BACKEND_SHAPE_MISMATCH:
-        return "backend result shape mismatch";
-    case HAZE_ERROR_MISSING_POLYMAP_BINDING:
-        return "address missing from poly_map_";
-    case HAZE_ERROR_SHADOW_SIZE_MISMATCH:
-        return "shadow buffer length disagrees with ring_dim";
-    case HAZE_ERROR_BACKEND_OUTPUT_MISSING:
-        return "backend output missing";
-    case HAZE_ERROR_BACKEND_OUTPUT_DECODE_FAILED:
-        return "backend output decode failed";
-    case HAZE_ERROR_BRIDGE_HOOK_FAILED:
-        return "replay bridge post-recording hook failed";
-    case HAZE_ERROR_POOL_MAP_DESYNC:
-        return "allocator pool / alloc_set_ desync";
+    case HAZE_ERROR_INTERNAL:
+        return "internal haze error (set HAZE_DEBUG=1 for details)";
     default:
         return "unknown error";
     }

--- a/src/api/graph.cpp
+++ b/src/api/graph.cpp
@@ -12,9 +12,9 @@
 // from the Product.
 //
 // Graph capture / execution shims (CUDA-shape names). All entries
-// currently return HAZE_ERROR_NOT_SUPPORTED; graph capture is a future
-// task. Output handles are zeroed on entry so callers that ignore the
-// error code do not see uninitialised pointers.
+// return HAZE_ERROR_NOT_SUPPORTED — graph capture has no analogue in
+// the record-and-replay model. Output handles are zeroed on entry so
+// callers that ignore the error code do not see uninitialised pointers.
 
 #include "common/errors.hpp"
 

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -34,7 +34,7 @@ extern "C" hazeError_t hazeMalloc(void **ptr, size_t size) noexcept {
 extern "C" hazeError_t hazeFree(void *ptr) noexcept {
     if (ptr != nullptr)
         haze::epoch().invalidate(haze::to_dev_addr(ptr));
-    return set_error(haze::allocator().free(haze::to_dev_addr(ptr)));
+    return set_internal_result(haze::allocator().free(haze::to_dev_addr(ptr)));
 }
 
 extern "C" hazeError_t hazeMallocAsync(void **ptr, size_t size, hazeStream_t /*stream*/) noexcept {
@@ -73,7 +73,7 @@ extern "C" hazeError_t hazeFreeHost(void *ptr) noexcept {
 
 extern "C" hazeError_t hazePointerGetAttributes(hazePointerAttributes *attrs,
                                                 const void *ptr) noexcept {
-    return set_error(haze::allocator().pointer_attributes(attrs, ptr));
+    return set_internal_result(haze::allocator().pointer_attributes(attrs, ptr));
 }
 
 extern "C" hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
@@ -85,27 +85,21 @@ extern "C" hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
 
     if (kind == HAZE_MEMCPY_HOST_TO_DEVICE) {
         const haze::DevAddr dev = haze::to_dev_addr(dst);
-        const hazeError_t err = alloc.copy_h2d(dev, src, count);
-        if (err != HAZE_SUCCESS)
-            return set_error(err);
-        if (auto tag = haze::tag_h2d_input(dev); !tag)
-            return set_error(haze::to_public_error(tag.error()));
-        return set_error(HAZE_SUCCESS);
+        if (auto h2d = alloc.copy_h2d(dev, src, count); !h2d)
+            return set_internal_result(h2d);
+        return set_internal_result(haze::tag_h2d_input(dev));
     }
 
     if (kind == HAZE_MEMCPY_DEVICE_TO_HOST) {
         // D2H finalises any in-flight recording (replay + shadow
         // populate) before reading the shadow buffer. See
         // haze::copy_to_host for the contract.
-        return set_error(haze::copy_to_host(dst, haze::to_dev_addr(src), count));
+        return set_internal_result(haze::copy_to_host(dst, haze::to_dev_addr(src), count));
     }
 
     if (kind == HAZE_MEMCPY_DEVICE_TO_DEVICE) {
-        auto result =
-            haze::copy_device_to_device(haze::to_dev_addr(dst), haze::to_dev_addr(src), count);
-        if (!result)
-            return set_error(haze::to_public_error(result.error()));
-        return set_error(HAZE_SUCCESS);
+        return set_internal_result(
+            haze::copy_device_to_device(haze::to_dev_addr(dst), haze::to_dev_addr(src), count));
     }
 
     return set_error(HAZE_ERROR_INVALID_VALUE);
@@ -120,10 +114,10 @@ extern "C" hazeError_t hazeMemset(void *dev_ptr, int value, size_t count) noexce
     if (dev_ptr == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
     const haze::DevAddr dev = haze::to_dev_addr(dev_ptr);
-    const hazeError_t err = haze::allocator().memset(dev, value, count);
-    if (err == HAZE_SUCCESS)
-        haze::epoch().invalidate(dev);
-    return set_error(err);
+    if (auto result = haze::allocator().memset(dev, value, count); !result)
+        return set_internal_result(result);
+    haze::epoch().invalidate(dev);
+    return HAZE_SUCCESS;
 }
 
 extern "C" hazeError_t hazeMemsetAsync(void *dev_ptr, int value, size_t count,

--- a/src/common/errors.cpp
+++ b/src/common/errors.cpp
@@ -21,6 +21,7 @@ namespace haze {
 
 hazeError_t to_public_error(HazeInternalError err) noexcept {
     switch (err) {
+    // User-actionable: the caller can fix their code.
     case HazeInternalError::InvalidArgument:
         return HAZE_ERROR_INVALID_VALUE;
     case HazeInternalError::NotConfigured:
@@ -33,27 +34,24 @@ hazeError_t to_public_error(HazeInternalError err) noexcept {
         return HAZE_ERROR_ALLOC_TOO_SMALL;
     case HazeInternalError::SourceUnavailable:
         return HAZE_ERROR_SOURCE_UNAVAILABLE;
+    // Internal: haze invariants / backend failed. Caller can't recover;
+    // the specific variant survives in the HAZE_DEBUG=1 stderr log.
     case HazeInternalError::BackendInitFailed:
-        return HAZE_ERROR_BACKEND_INIT_FAILED;
     case HazeInternalError::BackendReplayFailed:
-        return HAZE_ERROR_BACKEND_REPLAY_FAILED;
     case HazeInternalError::BackendShapeMismatch:
     case HazeInternalError::MrpGroupAddrModuliMismatch:
-        return HAZE_ERROR_BACKEND_SHAPE_MISMATCH;
     case HazeInternalError::MissingPolyMapBinding:
-        return HAZE_ERROR_MISSING_POLYMAP_BINDING;
     case HazeInternalError::ShadowSizeMismatch:
-        return HAZE_ERROR_SHADOW_SIZE_MISMATCH;
     case HazeInternalError::BackendOutputMissing:
-        return HAZE_ERROR_BACKEND_OUTPUT_MISSING;
     case HazeInternalError::BackendOutputDecodeFailed:
-        return HAZE_ERROR_BACKEND_OUTPUT_DECODE_FAILED;
     case HazeInternalError::BridgeHookFailed:
-        return HAZE_ERROR_BRIDGE_HOOK_FAILED;
     case HazeInternalError::PoolMapDesync:
-        return HAZE_ERROR_POOL_MAP_DESYNC;
+        return HAZE_ERROR_INTERNAL;
     }
-    return HAZE_ERROR_INVALID_VALUE;
+    // Unreachable: the switch above is exhaustive. If a new variant is
+    // added without extending this table, "haze is broken" is the
+    // correct user-visible classification.
+    return HAZE_ERROR_INTERNAL;
 }
 
 namespace {
@@ -107,12 +105,13 @@ bool debug_logging_enabled() noexcept {
 } // namespace
 
 void record_internal_error(HazeInternalError err, const char *context) noexcept {
-    if (!debug_logging_enabled())
-        return;
-    if (context != nullptr) {
-        std::println(stderr, "[haze] internal error: {} ({})", internal_error_name(err), context);
-    } else {
-        std::println(stderr, "[haze] internal error: {}", internal_error_name(err));
+    if (debug_logging_enabled()) {
+        if (context != nullptr) {
+            std::println(stderr, "[haze] internal error: {} ({})", internal_error_name(err),
+                         context);
+        } else {
+            std::println(stderr, "[haze] internal error: {}", internal_error_name(err));
+        }
     }
 }
 

--- a/src/common/errors.hpp
+++ b/src/common/errors.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <cstdint>
+#include <expected>
 #include <haze/haze_types.h>
 
 // Thread-local last-error state. set_error is the inline writer used at
@@ -57,3 +58,11 @@ hazeError_t to_public_error(HazeInternalError err) noexcept;
 void record_internal_error(HazeInternalError err, const char *context = nullptr) noexcept;
 
 } // namespace haze
+
+// Translate an internal-error result at the C ABI boundary. Lives at
+// namespace scope so api/ shims can write
+// `return set_internal_result(core_call(...));` directly.
+[[nodiscard]] inline hazeError_t
+set_internal_result(std::expected<void, haze::HazeInternalError> result) noexcept {
+    return set_error(result ? HAZE_SUCCESS : haze::to_public_error(result.error()));
+}

--- a/src/common/handle.hpp
+++ b/src/common/handle.hpp
@@ -17,11 +17,10 @@
 
 namespace haze {
 
-// Virtual HBM address base for HAZE's DeviceAllocator.
-// Must lie above FHETCH's synthetic address range (today < 0x1000000000)
-// so HAZE-allocated DevAddr values cannot alias FHETCH-emitted synthetic
-// addresses inside the recorded IR. The specific offset (256 GiB) is
-// arbitrary within the constraint; chosen to leave generous headroom.
+// Virtual HBM address base for HAZE's DeviceAllocator. The offset
+// (256 GiB) sits well above any plausible upstream synthetic-address
+// range so HAZE-allocated DevAddr values cannot collide with synthetic
+// addresses fhetch may emit inside the recorded IR.
 inline constexpr uintptr_t kHbmBase = 0x4000000000ULL;
 
 // Strong-typed device address. Wraps the uintptr_t we cast from the

--- a/src/common/log.hpp
+++ b/src/common/log.hpp
@@ -16,13 +16,12 @@
 
 namespace haze {
 
-// Single sink for [haze]-prefixed runtime diagnostics. Replaces ad-hoc
-// `std::cerr << "[haze] ...";` blocks across haze + replay_bridge so the
-// prefix is consistent and call sites stay short.
+// Tagged sink for [haze]-prefixed runtime diagnostics emitted from
+// replay_bridge (libhaze internal failures route through
+// record_internal_error in errors.hpp instead).
 //
-// Output format: "[haze] <tag>: <body>\n". `tag` identifies the subsystem
-// (e.g. "epoch", "replay_bridge"). Both arguments are printed verbatim;
-// callers compose their own error text.
+// Output format: "[haze] <tag>: <body>\n". Both arguments are printed
+// verbatim; callers compose their own error text.
 void log_error(std::string_view tag, std::string_view body) noexcept;
 
 } // namespace haze

--- a/src/common/thread_safety.hpp
+++ b/src/common/thread_safety.hpp
@@ -30,11 +30,9 @@
 //   - Mark accessor methods that hand out a reference to the underlying
 //     capability with HAZE_RETURN_CAPABILITY(field).
 //
-// Limitation: HAZE_ACQUIRED_BEFORE/AFTER work on capabilities that are
-// declared in the same translation unit. For HAZE's epoch -> allocator
-// lock order, the architectural separation (DeviceAllocator never calls
-// into EpochState) is the primary enforcement, with TSAN as the runtime
-// backstop.
+// For HAZE's epoch -> allocator lock order, the architectural separation
+// (DeviceAllocator never calls into EpochState) is the primary
+// enforcement, with TSAN as the runtime backstop.
 
 // Clang's thread-safety attributes are exposed as GNU-style
 // __attribute__((...)), not C++11 [[clang::...]]. The macro names
@@ -48,8 +46,6 @@
 #define HAZE_ACQUIRE(...) __attribute__((acquire_capability(__VA_ARGS__)))
 #define HAZE_RELEASE(...) __attribute__((release_capability(__VA_ARGS__)))
 #define HAZE_RETURN_CAPABILITY(x) __attribute__((lock_returned(x)))
-#define HAZE_TRY_ACQUIRE(...) __attribute__((try_acquire_capability(__VA_ARGS__)))
-#define HAZE_NO_THREAD_SAFETY_ANALYSIS __attribute__((no_thread_safety_analysis))
 #else
 #define HAZE_CAPABILITY(s)
 #define HAZE_SCOPED_CAPABILITY
@@ -59,8 +55,6 @@
 #define HAZE_ACQUIRE(...)
 #define HAZE_RELEASE(...)
 #define HAZE_RETURN_CAPABILITY(x)
-#define HAZE_TRY_ACQUIRE(...)
-#define HAZE_NO_THREAD_SAFETY_ANALYSIS
 #endif
 
 #include <mutex>
@@ -70,9 +64,8 @@ namespace haze {
 // Thin wrapper around std::mutex annotated as a clang TSA capability.
 // libstdc++'s std::mutex carries no annotations, so without this
 // wrapper the TSA attributes cannot identify the underlying mutex as
-// the capability they protect. Forwards lock/unlock/try_lock so
-// std::lock_guard and std::unique_lock continue to work. Used by
-// EpochState::mutex_ and DeviceAllocator::mutex_.
+// the capability they protect. Used by EpochState::mutex_ and
+// DeviceAllocator::mutex_.
 class HAZE_CAPABILITY("mutex") HazeMutex {
   public:
     HazeMutex() = default;
@@ -81,12 +74,6 @@ class HAZE_CAPABILITY("mutex") HazeMutex {
 
     void lock() HAZE_ACQUIRE() { impl_.lock(); }
     void unlock() HAZE_RELEASE() { impl_.unlock(); }
-    bool try_lock() HAZE_TRY_ACQUIRE(true) { return impl_.try_lock(); }
-
-    // Escape hatch for code that needs the underlying std::mutex
-    // (e.g., std::unique_lock<std::mutex> when constructed with the
-    // raw mutex). Carries no analysis — use sparingly.
-    std::mutex &raw() noexcept HAZE_NO_THREAD_SAFETY_ANALYSIS { return impl_; }
 
   private:
     std::mutex impl_;

--- a/src/core/allocator.cpp
+++ b/src/core/allocator.cpp
@@ -40,10 +40,10 @@ void DeviceAllocator::clear_pool_locked() noexcept {
 
 void DeviceAllocator::set_polynomial_size(size_t bytes) noexcept {
     HazeLockGuard lock(mutex_);
-    if (poly_bytes_ == bytes)
-        return;
-    clear_pool_locked();
-    poly_bytes_ = bytes;
+    if (poly_bytes_ != bytes) {
+        clear_pool_locked();
+        poly_bytes_ = bytes;
+    }
 }
 
 size_t DeviceAllocator::polynomial_size() const noexcept {
@@ -99,21 +99,22 @@ std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate(size_t bytes
     return addr;
 }
 
-hazeError_t DeviceAllocator::free(DevAddr addr) noexcept {
-    if (to_uintptr(addr) == 0)
-        return HAZE_SUCCESS; // hazeFree(nullptr) matches CUDA semantics
-
+std::expected<void, HazeInternalError> DeviceAllocator::free(DevAddr addr) noexcept {
+    if (to_uintptr(addr) == 0) {
+        // hazeFree(nullptr) matches CUDA semantics: silent success.
+        return {};
+    }
     HazeLockGuard lock(mutex_);
     if (!alloc_set_.contains(addr)) {
         record_internal_error(HazeInternalError::UnknownAddress, "DeviceAllocator::free");
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::UnknownAddress);
     }
     // Evict the shadow — those bytes are no longer the user's to read.
     // The DevAddr stays in alloc_set_ and goes onto the free list for
     // the next allocate() to recycle.
     shadow_data_.erase(addr);
     pool_free_.push_back(addr);
-    return HAZE_SUCCESS;
+    return {};
 }
 
 std::expected<std::vector<uint64_t>, HazeInternalError>
@@ -137,8 +138,9 @@ DeviceAllocator::extract_polynomial_components(DevAddr addr, uint64_t ring_dim) 
     }
     auto node = shadow_data_.extract(addr);
     if (!node) {
-        // Address allocated but never written; caller may fall back to
-        // a zero polynomial via fhetch.
+        // Address allocated but never written. epoch::lookup_or_create_locked
+        // translates this to SourceUnavailable — compute / D2D on an
+        // uninitialized buffer is a contract violation.
         record_internal_error(HazeInternalError::NoData,
                               "DeviceAllocator::extract_polynomial_components");
         return std::unexpected(HazeInternalError::NoData);
@@ -191,14 +193,15 @@ DeviceAllocator::read_polynomial_components(DevAddr addr, uint64_t ring_dim) con
     return data_it->second;
 }
 
-hazeError_t DeviceAllocator::copy_h2d(DevAddr dst, const void *src, size_t count) noexcept {
+std::expected<void, HazeInternalError> DeviceAllocator::copy_h2d(DevAddr dst, const void *src,
+                                                                 size_t count) noexcept {
     if (src == nullptr)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     HazeLockGuard lock(mutex_);
     if (!alloc_set_.contains(dst))
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::UnknownAddress);
     if (count > poly_bytes_)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::AllocTooSmall);
     // Lazy-create or overwrite the shadow entry. Sized to the full
     // allocation so partial writes leave the tail at zero (matches
     // prior eager-zero semantics for the unwritten tail).
@@ -208,65 +211,44 @@ hazeError_t DeviceAllocator::copy_h2d(DevAddr dst, const void *src, size_t count
         shadow.assign(want_elems, uint64_t{0});
     }
     std::memcpy(reinterpret_cast<uint8_t *>(shadow.data()), src, count);
-    return HAZE_SUCCESS;
+    return {};
 }
 
-hazeError_t DeviceAllocator::copy_d2d(DevAddr dst, DevAddr src, size_t count) noexcept {
-    HazeLockGuard lock(mutex_);
-    if (!alloc_set_.contains(src) || !alloc_set_.contains(dst))
-        return HAZE_ERROR_INVALID_VALUE;
-    if (count > poly_bytes_)
-        return HAZE_ERROR_INVALID_VALUE;
-    auto src_data = shadow_data_.find(src);
-    if (src_data == shadow_data_.end()) {
-        // D2D from an address with no live shadow → dst inherits the
-        // "no shadow" state. Evict whatever dst had (if anything).
-        shadow_data_.erase(dst);
-        return HAZE_SUCCESS;
-    }
-    auto &dst_shadow = shadow_data_[dst];
-    const size_t want_elems = poly_bytes_ / sizeof(uint64_t);
-    if (dst_shadow.size() != want_elems) {
-        dst_shadow.assign(want_elems, uint64_t{0});
-    }
-    std::memcpy(reinterpret_cast<uint8_t *>(dst_shadow.data()),
-                reinterpret_cast<const uint8_t *>(src_data->second.data()), count);
-    return HAZE_SUCCESS;
-}
-
-hazeError_t DeviceAllocator::memset(DevAddr addr, int value, size_t count) noexcept {
+std::expected<void, HazeInternalError> DeviceAllocator::memset(DevAddr addr, int value,
+                                                               size_t count) noexcept {
     HazeLockGuard lock(mutex_);
     if (!alloc_set_.contains(addr))
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::UnknownAddress);
     if (count > poly_bytes_)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::AllocTooSmall);
     auto &shadow = shadow_data_[addr];
     const size_t want_elems = poly_bytes_ / sizeof(uint64_t);
     if (shadow.size() != want_elems) {
         shadow.assign(want_elems, uint64_t{0});
     }
     std::memset(reinterpret_cast<uint8_t *>(shadow.data()), value, count);
-    return HAZE_SUCCESS;
+    return {};
 }
 
-hazeError_t DeviceAllocator::copy_to_host(void *dst, DevAddr src, size_t count) const noexcept {
+std::expected<void, HazeInternalError> DeviceAllocator::copy_to_host(void *dst, DevAddr src,
+                                                                     size_t count) const noexcept {
     if (dst == nullptr)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     HazeLockGuard lock(mutex_);
     if (!alloc_set_.contains(src))
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::UnknownAddress);
     if (count > poly_bytes_)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::AllocTooSmall);
     auto data_it = shadow_data_.find(src);
     if (data_it == shadow_data_.end()) {
         // Address allocated but no bytes ever written or already
         // consumed by compute. Match the prior eager-zero semantic:
         // return zeros, success. Do not erase any state.
         std::memset(dst, 0, count);
-        return HAZE_SUCCESS;
+        return {};
     }
     std::memcpy(dst, reinterpret_cast<const uint8_t *>(data_it->second.data()), count);
-    return HAZE_SUCCESS;
+    return {};
 }
 
 std::expected<void, HazeInternalError>
@@ -284,17 +266,10 @@ DeviceAllocator::update_shadow(DevAddr addr, std::vector<uint64_t> &&values) noe
     return {};
 }
 
-bool DeviceAllocator::is_device_pointer(const void *ptr) const noexcept {
-    if (ptr == nullptr)
-        return false;
-    HazeLockGuard lock(mutex_);
-    return alloc_set_.contains(to_dev_addr(ptr));
-}
-
-hazeError_t DeviceAllocator::pointer_attributes(hazePointerAttributes *attrs,
-                                                const void *ptr) const noexcept {
+std::expected<void, HazeInternalError>
+DeviceAllocator::pointer_attributes(hazePointerAttributes *attrs, const void *ptr) const noexcept {
     if (attrs == nullptr)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     *attrs = {};
     // Resolve classification under one locked snapshot, then fill the
     // attribute fields outside the lock. Snapshotting closes the window
@@ -329,21 +304,21 @@ hazeError_t DeviceAllocator::pointer_attributes(hazePointerAttributes *attrs,
         attrs->type = HAZE_MEMORY_TYPE_UNREGISTERED;
         break;
     }
-    return HAZE_SUCCESS;
+    return {};
 }
 
 void DeviceAllocator::register_host_pointer(const void *ptr) noexcept {
-    if (ptr == nullptr)
-        return;
-    HazeLockGuard lock(mutex_);
-    host_set_.insert(ptr);
+    if (ptr != nullptr) {
+        HazeLockGuard lock(mutex_);
+        host_set_.insert(ptr);
+    }
 }
 
 void DeviceAllocator::unregister_host_pointer(const void *ptr) noexcept {
-    if (ptr == nullptr)
-        return;
-    HazeLockGuard lock(mutex_);
-    host_set_.erase(ptr);
+    if (ptr != nullptr) {
+        HazeLockGuard lock(mutex_);
+        host_set_.erase(ptr);
+    }
 }
 
 void DeviceAllocator::reset() noexcept {

--- a/src/core/allocator.hpp
+++ b/src/core/allocator.hpp
@@ -90,22 +90,22 @@ class DeviceAllocator {
     size_t polynomial_size() const noexcept HAZE_EXCLUDES(mutex_);
 
     std::expected<DevAddr, HazeInternalError> allocate(size_t bytes) noexcept HAZE_EXCLUDES(mutex_);
-    hazeError_t free(DevAddr addr) noexcept HAZE_EXCLUDES(mutex_);
+    std::expected<void, HazeInternalError> free(DevAddr addr) noexcept HAZE_EXCLUDES(mutex_);
 
     // Bulk operations on a single allocation. Each path validates count
-    // against the allocation size and sets has_data on success.
-    hazeError_t copy_h2d(DevAddr dst, const void *src, size_t count) noexcept HAZE_EXCLUDES(mutex_);
-    hazeError_t copy_d2d(DevAddr dst, DevAddr src, size_t count) noexcept HAZE_EXCLUDES(mutex_);
-    hazeError_t memset(DevAddr addr, int value, size_t count) noexcept HAZE_EXCLUDES(mutex_);
+    // against the allocation size.
+    std::expected<void, HazeInternalError> copy_h2d(DevAddr dst, const void *src,
+                                                    size_t count) noexcept HAZE_EXCLUDES(mutex_);
+    std::expected<void, HazeInternalError> memset(DevAddr addr, int value, size_t count) noexcept
+        HAZE_EXCLUDES(mutex_);
 
     // Snapshot the shadow buffer as a vector of `ring_dim` 64-bit limbs.
     // Used by EpochState::lookup_or_create_locked when promoting fresh
     // shadow data to a FHETCH input polynomial. Returns NoData if the
-    // address has no shadow entry — the caller can fall back to
-    // fhetch::Polynomial::zeros for unwritten reads. **Evicts the
-    // shadow entry on success** — the caller now owns the bytes via
-    // fhetch's Polynomial storage; the HAZE-side shadow is freed
-    // mid-program. Non-const for that reason.
+    // address has no shadow entry; the caller surfaces this as
+    // SourceUnavailable. **Evicts the shadow entry on success** — the
+    // caller now owns the bytes via fhetch's Polynomial storage; the
+    // HAZE-side shadow is freed mid-program. Non-const for that reason.
     HAZE_API std::expected<std::vector<uint64_t>, HazeInternalError>
     extract_polynomial_components(DevAddr addr, uint64_t ring_dim) noexcept HAZE_EXCLUDES(mutex_);
 
@@ -118,7 +118,8 @@ class DeviceAllocator {
 
     // Read shadow bytes into a host buffer. Caller is responsible for
     // any compute materialization; this only touches the staging buffer.
-    hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) const noexcept
+    std::expected<void, HazeInternalError> copy_to_host(void *dst, DevAddr src,
+                                                        size_t count) const noexcept
         HAZE_EXCLUDES(mutex_);
 
     // Full-replace write of the shadow buffer; `values` is truncated
@@ -131,10 +132,9 @@ class DeviceAllocator {
     // pointers, HOST for hazeHostAlloc-allocated pointers, UNREGISTERED
     // for any other pointer (matches cudaPointerGetAttributes from
     // CUDA 11 onward).
-    hazeError_t pointer_attributes(hazePointerAttributes *attrs, const void *ptr) const noexcept
+    std::expected<void, HazeInternalError> pointer_attributes(hazePointerAttributes *attrs,
+                                                              const void *ptr) const noexcept
         HAZE_EXCLUDES(mutex_);
-
-    bool is_device_pointer(const void *ptr) const noexcept HAZE_EXCLUDES(mutex_);
 
     // Track an allocation made by hazeHostAlloc so pointer_attributes
     // can report it as HOST. The set is keyed by raw void* — pointers

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -81,10 +81,6 @@ void CompilerBackend::start_recording() noexcept {
     niobium::compiler().start();
 }
 
-void CompilerBackend::start_epoch() noexcept {
-    niobium::compiler().start_epoch();
-}
-
 bool CompilerBackend::stop_epoch() noexcept {
     // Use stop() (not stop_epoch()): stop() writes both the .fhetch trace
     // and fhetch_replay.json that nbcc_fhetch_replay needs for HTTP dispatch.

--- a/src/core/backend.hpp
+++ b/src/core/backend.hpp
@@ -24,9 +24,9 @@ namespace haze {
 // only the *control* operations: init, recording lifecycle, replay.
 //
 // Single concrete class, no virtual dispatch. Backend swap (e.g. to the
-// niobium-fhetch dummy compiler when stable) happens at link time: the
-// implementation file (haze_backend.cpp) calls into whichever library
-// supplies the niobium::compiler() symbol.
+// niobium-fhetch dummy compiler when stable) happens at link time:
+// backend.cpp calls into whichever library supplies the
+// niobium::compiler() symbol.
 class CompilerBackend {
   public:
     static CompilerBackend &instance() noexcept;
@@ -45,10 +45,6 @@ class CompilerBackend {
 
     // Begin a new recording (after init or after stop_epoch).
     static void start_recording() noexcept;
-
-    // Mark the start of a functional epoch — anchors poly-ID base on
-    // first call, resets to that base on subsequent calls.
-    static void start_epoch() noexcept;
 
     // Finalize the current epoch's recording, write the per-epoch .fhetch
     // trace, and reset state for the next epoch. Returns true on success.

--- a/src/core/basis_convert.cpp
+++ b/src/core/basis_convert.cpp
@@ -52,7 +52,7 @@ std::expected<void, HazeInternalError> validate(const hazeModDownParams &p) noex
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
     // rescale_base must be a *proper* subset of src_base — equal-length
-    // would leave dst empty (FhetchApi.cpp:1660 asserts the same).
+    // would leave dst empty (upstream fhetch asserts the same).
     if (p.rescale_base_len >= p.src_base_len) {
         record_internal_error(HazeInternalError::InvalidArgument,
                               "hazeModDown: rescale_base_len >= src_base_len");
@@ -129,9 +129,9 @@ std::expected<void, HazeInternalError> mod_down(void *const *dst, const void *co
 
     const fhetch::ModuliBase rescale_base(p.rescale_base, p.rescale_base + p.rescale_base_len);
     fhetch::MRP result = fhetch::rescale_fbc(*src_mrp, rescale_base);
-    // result.base() == src_base \ rescale_base in src_base's original order
-    // (FhetchApi.cpp:1606-1617). Use it directly so HAZE-side and
-    // backend-side never disagree on the dst layout.
+    // result.base() == src_base \ rescale_base in src_base's original
+    // order. Use it directly so HAZE-side and backend-side never disagree
+    // on the dst layout.
     const auto &dst_base = result.base();
     return store_mrp_locked(dst, result, dst_base.data(), dst_base.size());
 }
@@ -166,9 +166,8 @@ std::expected<void, HazeInternalError> mod_up(void *const *dst, const void *cons
         return std::unexpected(HazeInternalError::BackendShapeMismatch);
     }
 
-    // Each result[d].base() == src_base + p_base (FhetchApi.cpp:1704-1705)
-    // — same size and order across all digits. Use it directly to flatten
-    // dst writes.
+    // Each result[d].base() == src_base + p_base — same size and order
+    // across all digits. Use it directly to flatten dst writes.
     for (size_t d = 0; d < p.digit_count; ++d) {
         const auto &d_base = result[d].base();
         auto stored =

--- a/src/core/basis_convert.hpp
+++ b/src/core/basis_convert.hpp
@@ -21,7 +21,7 @@
 namespace haze {
 
 // Internal C++ entry points for the CRT basis-conversion composites.
-// extern "C" shims in haze_basis_convert_api.cpp validate pointer
+// extern "C" shims in src/api/basis_convert.cpp validate pointer
 // arguments, dispatch here, and map HazeInternalError to hazeError_t.
 // Each function does its own pre-flight validation on the params struct
 // and opens an EpochSession internally.

--- a/src/core/compute.hpp
+++ b/src/core/compute.hpp
@@ -21,7 +21,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <expected>
-#include <haze/haze_types.h>
 #include <niobium/fhetch_api.h>
 
 namespace haze {
@@ -33,57 +32,62 @@ namespace haze {
 
 // Polynomial-polynomial-modulus. Used by hazeAdd, hazeSub, hazeMul.
 template <auto OpFn>
-hazeError_t binary_pp_op(DevAddr dst, DevAddr src1, DevAddr src2, int mod_idx) noexcept {
+std::expected<void, HazeInternalError> binary_pp_op(DevAddr dst, DevAddr src1, DevAddr src2,
+                                                    int mod_idx) noexcept {
     EpochSession session;
     const uint64_t q = config().modulus(mod_idx);
     if (q == 0)
-        return set_error(HAZE_ERROR_INVALID_VALUE);
+        return std::unexpected(HazeInternalError::InvalidArgument);
     auto p1 = epoch().lookup_or_create_locked(src1);
     if (!p1)
-        return set_error(to_public_error(p1.error()));
+        return std::unexpected(p1.error());
     auto p2 = epoch().lookup_or_create_locked(src2);
     if (!p2)
-        return set_error(to_public_error(p2.error()));
+        return std::unexpected(p2.error());
     epoch().store_compute_result_locked(dst, OpFn(*p1, *p2, q));
-    return HAZE_SUCCESS;
+    return {};
 }
 
 // Polynomial-scalar-modulus. Used by hazeAddScalar, hazeSubScalar, hazeMulScalar.
 template <auto OpFn>
-hazeError_t binary_ps_op(DevAddr dst, DevAddr src, uint64_t scalar, int mod_idx) noexcept {
+std::expected<void, HazeInternalError> binary_ps_op(DevAddr dst, DevAddr src, uint64_t scalar,
+                                                    int mod_idx) noexcept {
     EpochSession session;
     const uint64_t q = config().modulus(mod_idx);
     if (q == 0)
-        return set_error(HAZE_ERROR_INVALID_VALUE);
+        return std::unexpected(HazeInternalError::InvalidArgument);
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
-        return set_error(to_public_error(p.error()));
+        return std::unexpected(p.error());
     epoch().store_compute_result_locked(dst,
                                         OpFn(*p, niobium::fhetch::Scalar::from_int(scalar), q));
-    return HAZE_SUCCESS;
+    return {};
 }
 
 // Polynomial-modulus. Used by hazeNTT, hazeINTT.
-template <auto OpFn> hazeError_t unary_pq_op(DevAddr dst, DevAddr src, int mod_idx) noexcept {
+template <auto OpFn>
+std::expected<void, HazeInternalError> unary_pq_op(DevAddr dst, DevAddr src, int mod_idx) noexcept {
     EpochSession session;
     const uint64_t q = config().modulus(mod_idx);
     if (q == 0)
-        return set_error(HAZE_ERROR_INVALID_VALUE);
+        return std::unexpected(HazeInternalError::InvalidArgument);
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
-        return set_error(to_public_error(p.error()));
+        return std::unexpected(p.error());
     epoch().store_compute_result_locked(dst, OpFn(*p, q));
-    return HAZE_SUCCESS;
+    return {};
 }
 
 // Polynomial-index. Used by hazeAutomorph.
-template <auto OpFn> hazeError_t unary_pi_op(DevAddr dst, DevAddr src, uint64_t index) noexcept {
+template <auto OpFn>
+std::expected<void, HazeInternalError> unary_pi_op(DevAddr dst, DevAddr src,
+                                                   uint64_t index) noexcept {
     EpochSession session;
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
-        return set_error(to_public_error(p.error()));
+        return std::unexpected(p.error());
     epoch().store_compute_result_locked(dst, OpFn(*p, index));
-    return HAZE_SUCCESS;
+    return {};
 }
 
 // MRP compute templates: same shape as the SRP templates, fanned out per
@@ -92,68 +96,72 @@ template <auto OpFn> hazeError_t unary_pi_op(DevAddr dst, DevAddr src, uint64_t 
 
 // MRP polynomial-polynomial. Used by hazeAddMrp, hazeSubMrp, hazeMulMrp.
 template <auto OpFn>
-hazeError_t binary_pp_op_mrp(void *const *dst, const void *const *src1, const void *const *src2,
-                             const uint64_t *base, std::size_t base_len) noexcept {
+std::expected<void, HazeInternalError>
+binary_pp_op_mrp(void *const *dst, const void *const *src1, const void *const *src2,
+                 const uint64_t *base, std::size_t base_len) noexcept {
     EpochSession session;
     auto m1 = build_mrp_locked(src1, base, base_len);
     if (!m1)
-        return set_error(to_public_error(m1.error()));
+        return std::unexpected(m1.error());
     auto m2 = build_mrp_locked(src2, base, base_len);
     if (!m2)
-        return set_error(to_public_error(m2.error()));
+        return std::unexpected(m2.error());
     niobium::fhetch::MRP result = OpFn(*m1, *m2);
     auto stored = store_mrp_locked(dst, result, base, base_len);
     if (!stored)
-        return set_error(to_public_error(stored.error()));
-    return HAZE_SUCCESS;
+        return std::unexpected(stored.error());
+    return {};
 }
 
 // MRP polynomial-scalar (scalars[i] pairs with base[i]); used by
 // hazeAddScalarMrp, hazeSubScalarMrp, hazeMulScalarMrp.
 template <auto OpFn>
-hazeError_t binary_ps_op_mrp(void *const *dst, const void *const *src, const uint64_t *scalars,
-                             const uint64_t *base, std::size_t base_len) noexcept {
+std::expected<void, HazeInternalError>
+binary_ps_op_mrp(void *const *dst, const void *const *src, const uint64_t *scalars,
+                 const uint64_t *base, std::size_t base_len) noexcept {
     EpochSession session;
     auto m = build_mrp_locked(src, base, base_len);
     if (!m)
-        return set_error(to_public_error(m.error()));
+        return std::unexpected(m.error());
     niobium::fhetch::MRP result = OpFn(*m, build_mrs(scalars, base, base_len));
     auto stored = store_mrp_locked(dst, result, base, base_len);
     if (!stored)
-        return set_error(to_public_error(stored.error()));
-    return HAZE_SUCCESS;
+        return std::unexpected(stored.error());
+    return {};
 }
 
 // MRP polynomial-only: mr_ntt/mr_intt carry their moduli base inside the
 // MRP, so this can't reuse unary_pq_op. Used by hazeNTTMrp, hazeINTTMrp.
 template <auto OpFn>
-hazeError_t unary_p_op_mrp(void *const *dst, const void *const *src, const uint64_t *base,
-                           std::size_t base_len) noexcept {
+std::expected<void, HazeInternalError> unary_p_op_mrp(void *const *dst, const void *const *src,
+                                                      const uint64_t *base,
+                                                      std::size_t base_len) noexcept {
     EpochSession session;
     auto m = build_mrp_locked(src, base, base_len);
     if (!m)
-        return set_error(to_public_error(m.error()));
+        return std::unexpected(m.error());
     niobium::fhetch::MRP result = OpFn(*m);
     auto stored = store_mrp_locked(dst, result, base, base_len);
     if (!stored)
-        return set_error(to_public_error(stored.error()));
-    return HAZE_SUCCESS;
+        return std::unexpected(stored.error());
+    return {};
 }
 
 // MRP polynomial-with-index. Used by hazeAutomorphMrp (mr_automorph_eval
 // takes an odd integer k in [1, 2N-1] and is otherwise modulus-independent).
 template <auto OpFn>
-hazeError_t unary_pi_op_mrp(void *const *dst, const void *const *src, uint64_t index,
-                            const uint64_t *base, std::size_t base_len) noexcept {
+std::expected<void, HazeInternalError> unary_pi_op_mrp(void *const *dst, const void *const *src,
+                                                       uint64_t index, const uint64_t *base,
+                                                       std::size_t base_len) noexcept {
     EpochSession session;
     auto m = build_mrp_locked(src, base, base_len);
     if (!m)
-        return set_error(to_public_error(m.error()));
+        return std::unexpected(m.error());
     niobium::fhetch::MRP result = OpFn(*m, index);
     auto stored = store_mrp_locked(dst, result, base, base_len);
     if (!stored)
-        return set_error(to_public_error(stored.error()));
-    return HAZE_SUCCESS;
+        return std::unexpected(stored.error());
+    return {};
 }
 
 } // namespace haze

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -12,12 +12,13 @@
 // from the Product.
 #include "core/config.hpp"
 
+#include "common/errors.hpp"
 #include "common/thread_safety.hpp"
 #include "core/allocator.hpp"
 
 #include <cstdint>
 #include <cstdlib>
-#include <haze/haze_types.h>
+#include <expected>
 #include <string>
 #include <utility>
 #include <vector>
@@ -27,7 +28,6 @@ namespace haze {
 namespace {
 
 bool is_supported_ring_dim(uint64_t n) noexcept {
-    // TODO: add an explicit upper bound once hardware constraints are known.
     return (n != 0) && ((n & (n - 1)) == 0);
 }
 
@@ -38,32 +38,32 @@ Config &Config::instance() noexcept {
     return inst;
 }
 
-hazeError_t Config::set_ring_dimension(uint64_t n) noexcept {
+std::expected<void, HazeInternalError> Config::set_ring_dimension(uint64_t n) noexcept {
     if (!is_supported_ring_dim(n))
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     // Hold the Config lock across the allocator update so no observer
     // ever sees (new ring_dim, old pool poly_bytes) or vice versa. Lock
     // order is Config -> Allocator; the allocator never calls back into
     // Config, so this direction cannot deadlock.
     HazeLockGuard lock(mutex_);
     if (configured_ && ring_dim_ != n)
-        return HAZE_ERROR_CONFIGERR;
+        return std::unexpected(HazeInternalError::NotConfigured);
     ring_dim_ = n;
     DeviceAllocator::instance().set_polynomial_size(n * sizeof(uint64_t));
-    return HAZE_SUCCESS;
+    return {};
 }
 
-hazeError_t Config::set_modulus(int idx, uint64_t modulus) noexcept {
+std::expected<void, HazeInternalError> Config::set_modulus(int idx, uint64_t modulus) noexcept {
     if (idx < 0)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     if (modulus == 0)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     HazeLockGuard lock(mutex_);
     if (configured_) {
         const auto i = static_cast<size_t>(idx);
         if (i >= moduli_.size() || moduli_[i] != modulus)
-            return HAZE_ERROR_CONFIGERR;
-        return HAZE_SUCCESS;
+            return std::unexpected(HazeInternalError::NotConfigured);
+        return {};
     }
     // Reject sparse writes — every index from 0 to idx-1 must already
     // have been set with a non-zero modulus. Without this constraint,
@@ -71,38 +71,39 @@ hazeError_t Config::set_modulus(int idx, uint64_t modulus) noexcept {
     // returns indistinguishably from "out of range," and the compute
     // templates would conflate the two failure modes.
     if (std::cmp_less(moduli_.size(), idx))
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     if (std::cmp_equal(moduli_.size(), idx)) {
         moduli_.push_back(modulus);
     } else {
         moduli_[static_cast<size_t>(idx)] = modulus;
     }
-    return HAZE_SUCCESS;
+    return {};
 }
 
-hazeError_t Config::set_twiddle_generator(int idx, uint64_t generator) noexcept {
+std::expected<void, HazeInternalError> Config::set_twiddle_generator(int idx,
+                                                                     uint64_t generator) noexcept {
     if (idx < 0)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     HazeLockGuard lock(mutex_);
     if (configured_) {
         const auto i = static_cast<size_t>(idx);
         if (i >= twiddle_generators_.size() || twiddle_generators_[i] != generator)
-            return HAZE_ERROR_CONFIGERR;
-        return HAZE_SUCCESS;
+            return std::unexpected(HazeInternalError::NotConfigured);
+        return {};
     }
     if (std::cmp_less_equal(twiddle_generators_.size(), idx)) {
         twiddle_generators_.resize(static_cast<size_t>(idx) + 1, 0);
     }
     twiddle_generators_[static_cast<size_t>(idx)] = generator;
-    return HAZE_SUCCESS;
+    return {};
 }
 
-hazeError_t Config::configure_device() noexcept {
+std::expected<void, HazeInternalError> Config::configure_device() noexcept {
     HazeLockGuard lock(mutex_);
     if (ring_dim_ == 0)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::NotConfigured);
     configured_ = true;
-    return HAZE_SUCCESS;
+    return {};
 }
 
 uint64_t Config::ring_dim() const noexcept {
@@ -117,35 +118,25 @@ uint64_t Config::modulus(int idx) const noexcept {
     return moduli_[static_cast<size_t>(idx)];
 }
 
-bool Config::is_configured() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return configured_;
-}
-
-std::vector<uint64_t> Config::moduli_copy() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return moduli_;
-}
-
-hazeError_t Config::set_program_info(const char *name, const char *version,
-                                     const char *description) noexcept {
+std::expected<void, HazeInternalError>
+Config::set_program_info(const char *name, const char *version, const char *description) noexcept {
     if (name == nullptr || version == nullptr || description == nullptr)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     HazeLockGuard lock(mutex_);
     program_name_ = name;
     program_version_ = version;
     program_description_ = description;
     program_info_set_ = true;
-    return HAZE_SUCCESS;
+    return {};
 }
 
-hazeError_t Config::set_target(const char *target) noexcept {
+std::expected<void, HazeInternalError> Config::set_target(const char *target) noexcept {
     if (target == nullptr)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     HazeLockGuard lock(mutex_);
     target_ = target;
     target_set_ = true;
-    return HAZE_SUCCESS;
+    return {};
 }
 
 std::string Config::program_name() const noexcept {

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -12,9 +12,11 @@
 // from the Product.
 #pragma once
 
+#include "common/errors.hpp"
 #include "common/thread_safety.hpp"
 
 #include <cstdint>
+#include <expected>
 #include <haze/haze_types.h>
 #include <string>
 #include <string_view>
@@ -47,23 +49,22 @@ class Config {
     static Config &instance() noexcept;
 
     // FHE parameters (existing public API).
-    hazeError_t set_ring_dimension(uint64_t n) noexcept;
-    hazeError_t set_modulus(int idx, uint64_t modulus) noexcept;
-    hazeError_t set_twiddle_generator(int idx, uint64_t generator) noexcept;
-    hazeError_t configure_device() noexcept;
+    std::expected<void, HazeInternalError> set_ring_dimension(uint64_t n) noexcept;
+    std::expected<void, HazeInternalError> set_modulus(int idx, uint64_t modulus) noexcept;
+    std::expected<void, HazeInternalError> set_twiddle_generator(int idx,
+                                                                 uint64_t generator) noexcept;
+    std::expected<void, HazeInternalError> configure_device() noexcept;
 
     uint64_t ring_dim() const noexcept;
     uint64_t modulus(int idx) const noexcept;
-    bool is_configured() const noexcept;
-    std::vector<uint64_t> moduli_copy() const noexcept;
 
     // Program / target metadata fed to the compiler during init.
     // Defaults: name="haze", version="0.1", description="HAZE runtime",
     // target=kLocalTarget (overridable by HAZE_TARGET env var unless
     // an explicit hazeSetTarget call has been made).
-    hazeError_t set_program_info(const char *name, const char *version,
-                                 const char *description) noexcept;
-    hazeError_t set_target(const char *target) noexcept;
+    std::expected<void, HazeInternalError> set_program_info(const char *name, const char *version,
+                                                            const char *description) noexcept;
+    std::expected<void, HazeInternalError> set_target(const char *target) noexcept;
     std::string program_name() const noexcept;
     std::string program_version() const noexcept;
     std::string program_description() const noexcept;

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -12,8 +12,11 @@
 // from the Product.
 #include "core/device.hpp"
 
+#include "common/errors.hpp"
+
 #include <cstddef>
 #include <cstring>
+#include <expected>
 #include <haze/haze_types.h>
 
 namespace haze {
@@ -41,18 +44,20 @@ int device_active() noexcept {
     return g_active_device;
 }
 
-hazeError_t device_set_active(int device) noexcept {
+std::expected<void, HazeInternalError> device_set_active(int device) noexcept {
     if (device != 0)
-        return HAZE_ERROR_INVALID_VALUE;
-    g_active_device = device;
-    return HAZE_SUCCESS;
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    // g_active_device is initialised to 0, only reset to 0, and the
+    // guard above rejects every non-zero value — no assignment needed.
+    return {};
 }
 
-hazeError_t device_fill_properties(hazeDeviceProp *prop, int device) noexcept {
+std::expected<void, HazeInternalError> device_fill_properties(hazeDeviceProp *prop,
+                                                              int device) noexcept {
     if (prop == nullptr)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
     if (device != 0)
-        return HAZE_ERROR_INVALID_VALUE;
+        return std::unexpected(HazeInternalError::InvalidArgument);
 
     *prop = {};
     std::strncpy(prop->name, "Niobium FPGA", sizeof(prop->name) - 1);
@@ -65,9 +70,7 @@ hazeError_t device_fill_properties(hazeDeviceProp *prop, int device) noexcept {
     }
     prop->maxCiphertextModuli = kMaxCiphertextModuli;
     prop->numHBMBanks = kNumHbmBanks;
-    prop->overlapCaps = HAZE_OVERLAP_FULL;
-    prop->instructionFIFODepth = 256;
-    return HAZE_SUCCESS;
+    return {};
 }
 
 void device_reset() noexcept {

--- a/src/core/device.hpp
+++ b/src/core/device.hpp
@@ -12,20 +12,22 @@
 // from the Product.
 #pragma once
 
+#include "common/errors.hpp"
+
+#include <expected>
 #include <haze/haze_types.h>
 
 namespace haze {
 
-// Single-device runtime state. The active-device selector is the only
-// mutable field; everything else (count, properties) is constexpr in
-// the impl. Free functions instead of a class — there is one int of
-// state and one invariant ("active must be 0"); a class adds nothing
-// over an `int` plus a setter.
+// Single-device runtime state. Only one device exists; the only valid
+// device index is 0. Free functions instead of a class — a class adds
+// nothing over a one-int counter and a couple of getters.
 
 int device_count() noexcept;
 int device_active() noexcept;
-hazeError_t device_set_active(int device) noexcept;
-hazeError_t device_fill_properties(hazeDeviceProp *prop, int device) noexcept;
+std::expected<void, HazeInternalError> device_set_active(int device) noexcept;
+std::expected<void, HazeInternalError> device_fill_properties(hazeDeviceProp *prop,
+                                                              int device) noexcept;
 void device_reset() noexcept;
 
 } // namespace haze

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -23,7 +23,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <expected>
-#include <haze/haze_types.h>
 #include <haze/replay_bridge.h>
 #include <ios>
 #include <niobium/compiler.h>
@@ -44,22 +43,16 @@ EpochState &EpochState::instance() noexcept {
 }
 
 void EpochState::ensure_recording_locked() {
-    // EpochSession initializes the backend before locking; this defensive
-    // check guards future code paths that might bypass EpochSession.
-    if (!backend().is_initialized())
-        return;
-    if (!recording_) {
-        // start_epoch() before start() memorizes the polynomial-ID base so
-        // post-materialize resets snap back to it; without it, IDs drift.
-        CompilerBackend::start_epoch();
+    // EpochSession initializes the backend before locking; the
+    // is_initialized() check guards future code paths that might bypass
+    // EpochSession. start_epoch() before start() memorizes the
+    // polynomial-ID base so post-materialize resets snap back to it;
+    // without it, IDs drift.
+    if (backend().is_initialized() && !recording_) {
+        niobium::compiler().start_epoch();
         CompilerBackend::start_recording();
         recording_ = true;
     }
-}
-
-bool EpochState::is_recording() noexcept {
-    HazeLockGuard lock(mutex_);
-    return recording_;
 }
 
 void EpochState::invalidate(DevAddr addr) noexcept {
@@ -157,10 +150,9 @@ std::expected<void, HazeInternalError> EpochState::tag_h2d_input_locked(DevAddr 
 
 void EpochState::tag_mrp_input_if_new_locked(const std::string &name, const fhetch::MRP &mrp) {
     // Dedup so each name reaches fhetch exactly once.
-    auto [it, inserted] = mrp_input_tagged_names_.insert(name);
-    if (!inserted)
-        return;
-    fhetch::tag_input(*it, mrp);
+    if (auto [it, inserted] = mrp_input_tagged_names_.insert(name); inserted) {
+        fhetch::tag_input(*it, mrp);
+    }
 }
 
 std::expected<void, HazeInternalError>
@@ -300,7 +292,7 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked() {
         }
     }
 
-    clear_state_locked(); // also clears captured inputs/outputs (E7).
+    clear_state_locked();
     return {};
 }
 
@@ -330,13 +322,12 @@ HazeMutex &EpochSession::init_then_get_mutex() noexcept {
     return epoch().mutex_;
 }
 
-hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept {
+std::expected<void, HazeInternalError> copy_to_host(void *dst, DevAddr src, size_t count) noexcept {
     // D2H is the sole flush trigger: finalize, replay, and populate shadows
     // before reading. No-op when not recording, so H2D-then-D2H round-trips
     // and follow-up D2H reads in the same epoch are free.
-    auto replay_result = epoch().replay_and_populate();
-    if (!replay_result)
-        return to_public_error(replay_result.error());
+    if (auto replay_result = epoch().replay_and_populate(); !replay_result)
+        return std::unexpected(replay_result.error());
     return allocator().copy_to_host(dst, src, count);
 }
 

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -42,8 +42,6 @@ class EpochState {
 
     // ---- Public methods (take mutex_ internally) ----
 
-    bool is_recording() noexcept HAZE_EXCLUDES(mutex_);
-
     // Drop any polymap binding for `addr`. Called by allocator paths
     // (H2D, D2D, memset, free) so the next compute rebuilds from shadow.
     void invalidate(DevAddr addr) noexcept HAZE_EXCLUDES(mutex_);
@@ -71,10 +69,9 @@ class EpochState {
 
     // Eagerly tag the H2D'd shadow bytes at `addr` as a fhetch input.
     // Builds the Polynomial via a non-evicting read (shadow stays intact
-    // for subsequent compute-free D2H), tag_inputs it, and binds it in
-    // poly_map_. Modulus tracking is left to the first real op that
-    // consumes the address. Returns an internal error if the H2D
-    // post-conditions (ring_dim set, shadow populated) are violated.
+    // for subsequent compute-free D2H), calls `tag_input`, and binds it
+    // in poly_map_. Returns an internal error if the H2D post-conditions
+    // (ring_dim set, shadow populated) are violated.
     std::expected<void, HazeInternalError> tag_h2d_input_locked(DevAddr addr) noexcept
         HAZE_REQUIRES(mutex_);
 
@@ -159,9 +156,9 @@ class HAZE_SCOPED_CAPABILITY EpochSession {
 };
 
 // D2H trigger: finalize any active recording (no-op otherwise), then
-// copy from the device shadow buffer to host. Returns a public
-// hazeError_t already translated for the C ABI.
-hazeError_t copy_to_host(void *dst, DevAddr src, size_t count) noexcept;
+// copy from the device shadow buffer to host. The api/ shim translates
+// the internal error at the C ABI edge.
+std::expected<void, HazeInternalError> copy_to_host(void *dst, DevAddr src, size_t count) noexcept;
 
 // D2D as a recorded copy: promotes `src` if needed (via
 // `lookup_or_create_locked`), emits a pass-through fhetch IR node, and

--- a/src/core/polynomial_io.hpp
+++ b/src/core/polynomial_io.hpp
@@ -28,14 +28,13 @@ namespace haze {
 // the round-trip + parse behind a single call so the materialization
 // engine doesn't need to carry that detail.
 //
-// TODO(niobium-fhetch): replace with Polynomial::int_data() when
-// upstream adds it; the round-trip would then become a one-line read of
-// the in-memory components vector. Tracked separately because the
-// upstream API change is multi-repo.
+// TODO(niobium-fhetch): rewire to Polynomial::int_data() (added
+// upstream in fhetch_api.h) and drop the JSON round-trip. Deferred —
+// the rewire is a separate task.
 //
-// `tag` is used in the temp filename for diagnostic clarity if multiple
-// extractions race. Returns true on success and populates `out` with
-// the values; false on any I/O or parse failure.
+// `tag` distinguishes the temp filename when multiple extractions
+// happen in the same epoch. Returns true on success and populates `out`
+// with the values; false on any I/O or parse failure.
 bool extract_polynomial_values(const niobium::fhetch::Polynomial &p, std::string_view tag,
                                std::vector<uint64_t> &out);
 

--- a/src/core/stream.cpp
+++ b/src/core/stream.cpp
@@ -25,46 +25,30 @@ std::atomic<uint64_t> g_next_event_id{1};
 } // namespace
 
 hazeStream_t stream_create() noexcept {
-    return new (std::nothrow) haze_stream_s{
-        .id = g_next_stream_id.fetch_add(1, std::memory_order_relaxed), .is_default = false};
+    return new (std::nothrow)
+        haze_stream_s{.id = g_next_stream_id.fetch_add(1, std::memory_order_relaxed)};
 }
 
 void stream_destroy(hazeStream_t s) noexcept {
-    if (s == nullptr)
-        return;
-    if (s->is_default)
-        return; // never destroy the default stream
-    delete s;
-}
-
-hazeStream_t stream_default() noexcept {
-    // id=0 mirrors CUDA's default-stream convention. The instance has
-    // static storage duration — initialised once on first call (C++11
-    // magic statics handle the thread-safe init), destroyed at normal
-    // process exit. No heap allocation, no leak, no mutex needed for
-    // the lazy init.
-    static haze_stream_s instance{.id = 0, .is_default = true};
-    return &instance;
+    delete s; // delete nullptr is well-defined and a no-op
 }
 
 void streams_reset() noexcept {
-    // Default stream lives for the process; nothing to drop here. Only
-    // the user-stream id counter resets.
     g_next_stream_id.store(1, std::memory_order_relaxed);
 }
 
 hazeEvent_t event_create() noexcept {
-    return new (std::nothrow) haze_event_s{
-        .id = g_next_event_id.fetch_add(1, std::memory_order_relaxed), .recorded = false};
+    return new (std::nothrow)
+        haze_event_s{.id = g_next_event_id.fetch_add(1, std::memory_order_relaxed)};
 }
 
 void event_destroy(hazeEvent_t e) noexcept {
     delete e;
 }
 
-void event_record(hazeEvent_t e) noexcept {
-    if (e != nullptr)
-        e->recorded = true;
+void event_record(hazeEvent_t /*e*/) noexcept {
+    // Events do not model ordering in this runtime (CUDA-shape parity
+    // only); recording is a no-op.
 }
 
 void events_reset() noexcept {

--- a/src/core/stream.hpp
+++ b/src/core/stream.hpp
@@ -20,23 +20,19 @@
 // boundary per the documented opaque-handle pattern.
 struct haze_stream_s {
     uint64_t id;
-    bool is_default;
 };
 
 struct haze_event_s {
     uint64_t id;
-    bool recorded;
 };
 
 namespace haze {
 
 // Free functions instead of registry classes — state is just two
-// counters and a default-stream singleton, not enough invariants to
-// justify the wrapper. Default stream id=0 mirrors CUDA stream-0.
+// counters, not enough invariants to justify a wrapper.
 
-hazeStream_t stream_create() noexcept;        // new haze_stream_s, caller owns
-void stream_destroy(hazeStream_t s) noexcept; // delete unless is_default
-hazeStream_t stream_default() noexcept;       // lazy-init singleton
+hazeStream_t stream_create() noexcept; // new haze_stream_s, caller owns
+void stream_destroy(hazeStream_t s) noexcept;
 void streams_reset() noexcept;
 
 hazeEvent_t event_create() noexcept;

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -1434,7 +1434,7 @@ TEST_CASE("hazeFree mid-recording on MRP output addrs does not break replay", "[
 
     // Pre-fix: leaks a stale pending_mrp_groups_ entry. At the D2H below,
     // replay_and_populate's group walk hits MissingPolyMapBinding ->
-    // HAZE_ERROR_LAUNCH_FAILURE because poly_map_[intt_dst...] are gone.
+    // HAZE_ERROR_INTERNAL because poly_map_[intt_dst...] are gone.
     haze::test::free_all_residues(intt_dst);
 
     d.add(dst, haze::test::to_const(d_a), haze::test::to_const(d_b));

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -64,8 +64,8 @@ TEST_CASE("hazeSetTwiddleFactors rejects negative index", "[unit]") {
 
 TEST_CASE("hazeConfigureDevice fails without ring dimension", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeConfigureDevice() == HAZE_ERROR_CONFIGERR);
+    REQUIRE(hazeGetLastError() == HAZE_ERROR_CONFIGERR);
 }
 
 TEST_CASE("hazeConfigureDevice succeeds when ring dimension is set", "[unit]") {
@@ -95,8 +95,8 @@ TEST_CASE("hazeDeviceReset returns success and re-permits configuration", "[unit
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // After reset, configure_device should fail again until ring_dim re-set.
-    REQUIRE(hazeConfigureDevice() == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeConfigureDevice() == HAZE_ERROR_CONFIGERR);
+    REQUIRE(hazeGetLastError() == HAZE_ERROR_CONFIGERR);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 }


### PR DESCRIPTION
Error layer:
- src/core/ and src/common/ callables now return std::expected<T, HazeInternalError>; src/api/ shims translate at the C ABI boundary via the new set_internal_result() helper in common/errors.hpp. No bare `return;` survives in internal fallible paths — every failure routes through record_internal_error + std::unexpected.
- Public hazeError_t collapses to user-actionable codes only: SUCCESS, INVALID_VALUE, OUT_OF_MEMORY, NOT_SUPPORTED, CONFIGERR, UNKNOWN_ADDRESS, NO_DATA, ALLOC_TOO_SMALL, SOURCE_UNAVAILABLE, INTERNAL. Everything that means "haze is broken, not your fault" maps to INTERNAL; the rich classification survives in the HAZE_DEBUG=1 stderr log via HazeInternalError.
- Removed: INVALID_HANDLE, NOT_READY, DMEMERR/IMEMERR/INSTRERR/ISEQERR, LAUNCH_FAILURE, hazeOverlapFlags + overlapCaps + instructionFIFODepth, HAZE_MEMCPY_HOST_TO_HOST, HAZE_MEMCPY_DEFAULT, HAZE_MEMORY_TYPE_MANAGED.

Compute-on-uninitialized is now an error:
- EpochState::lookup_or_create_locked returns HazeInternalError::SourceUnavailable when an address has no shadow data and no poly_map_ binding. The old zero-polynomial fallback is gone — D2D / compute on an unwritten buffer is a contract violation.

Dead code removed:
- is_recording, is_default, recorded (stream), try_lock, raw, HAZE_TRY_ACQUIRE, HAZE_NO_THREAD_SAFETY_ANALYSIS, copy_d2d, is_device_pointer, stream_default, the no-op g_active_device write, Config::is_configured, Config::moduli_copy.
- CompilerBackend::start_epoch wrapper inlined into epoch.cpp; niobium::compiler().start_epoch() is called directly.

Comment hygiene:
- Stale file paths corrected (haze_backend.cpp -> backend.cpp, haze_compute.hpp -> core/compute.hpp, haze_basis_convert_api.cpp -> src/api/basis_convert.cpp).
- Brittle FhetchApi.cpp:1660/1606/1704 line citations replaced with conceptual claims that survive vendor bumps.
- Orphan `(E7)` annotation removed.
- Stale "fall back to zero polynomial" comments rewritten to match the new SourceUnavailable behavior.

Tests adjusted for the reclassified error codes (hazeConfigureDevice without a ring dim is HAZE_ERROR_CONFIGERR, not INVALID_VALUE).