### PR TITLE
feat(api): add hazeMemcpyMrp per-residue C-ABI transfer

### DIFF
--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -86,6 +86,15 @@ HAZE_API hazeError_t hazeMemsetAsync(void *dev_ptr, int value, size_t count,
 HAZE_API hazeError_t hazeMemcpyPeerAsync(void *dst, int dst_device, const void *src, int src_device,
                                          size_t count, hazeStream_t stream) HAZE_NOEXCEPT;
 
+// Per-residue (MRP) variant of hazeMemcpy: `dst`/`src` are arrays of
+// `base_len` poly pointers and `count` is bytes-per-residue, applied to every
+// residue under `kind`. `base` (the per-residue primes, see the MRP block
+// below) is consulted only by D2D, which records a per-residue pass-through
+// copy under base[i] and registers the dst as an MRP output group.
+HAZE_API hazeError_t hazeMemcpyMrp(void *const *dst, const void *const *src, size_t count,
+                                   hazeMemcpyKind kind, const uint64_t *base,
+                                   size_t base_len) HAZE_NOEXCEPT;
+
 // Device configuration: ring dimension, ciphertext moduli, twiddle factors,
 // program metadata, target selection, lifecycle reset.
 

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -14,7 +14,9 @@
 #include "common/handle.hpp"
 #include "core/allocator.hpp"
 #include "core/epoch.hpp"
+#include "core/mrp_polymap.hpp"
 
+#include <cstdint>
 #include <cstdlib>
 #include <expected>
 #include <haze/haze.h>
@@ -108,6 +110,22 @@ extern "C" hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
 extern "C" hazeError_t hazeMemcpyAsync(void *dst, const void *src, size_t count,
                                        hazeMemcpyKind kind, hazeStream_t /*stream*/) noexcept {
     return hazeMemcpy(dst, src, count, kind);
+}
+
+extern "C" hazeError_t hazeMemcpyMrp(void *const *dst, const void *const *src, size_t count,
+                                     hazeMemcpyKind kind, const uint64_t *base,
+                                     size_t base_len) noexcept {
+    if (dst == nullptr || src == nullptr || base == nullptr || base_len == 0)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+
+    if (kind == HAZE_MEMCPY_HOST_TO_DEVICE)
+        return set_internal_result(haze::copy_h2d_mrp(dst, src, count, base_len));
+    if (kind == HAZE_MEMCPY_DEVICE_TO_HOST)
+        return set_internal_result(haze::copy_to_host_mrp(dst, src, count, base_len));
+    if (kind == HAZE_MEMCPY_DEVICE_TO_DEVICE)
+        return set_internal_result(haze::copy_device_to_device_mrp(dst, src, base, base_len));
+
+    return set_error(HAZE_ERROR_INVALID_VALUE);
 }
 
 extern "C" hazeError_t hazeMemset(void *dev_ptr, int value, size_t count) noexcept {

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -37,6 +37,11 @@ namespace haze {
 
 namespace fhetch = niobium::fhetch;
 
+// fhetch's modulus-independent copy sentinel (TraceWriter COPY_MODULUS_VALUE):
+// the simulator reads it as "no reduction", so sr_addps(x, 0, kCopyModulus)
+// is a pure copy of x.
+constexpr uint64_t kCopyModulus = 0xFFFFFFFFFFFFFFFFULL;
+
 EpochState &EpochState::instance() noexcept {
     static EpochState inst;
     return inst;
@@ -119,6 +124,16 @@ void EpochState::store_compute_result_locked(DevAddr addr,
     if (!pending_outputs_.contains(addr)) {
         pending_outputs_.emplace(addr, "haze_out_" + std::to_string(output_counter_++));
     }
+}
+
+std::expected<void, HazeInternalError> EpochState::copy_result_locked(DevAddr dst,
+                                                                      DevAddr src) noexcept {
+    auto src_poly = lookup_or_create_locked(src);
+    if (!src_poly)
+        return std::unexpected(src_poly.error());
+    store_compute_result_locked(
+        dst, fhetch::sr_addps(*src_poly, fhetch::Scalar::from_int(0), kCopyModulus));
+    return {};
 }
 
 std::expected<void, HazeInternalError> EpochState::tag_h2d_input_locked(DevAddr addr) noexcept {
@@ -333,23 +348,10 @@ std::expected<void, HazeInternalError> copy_to_host(void *dst, DevAddr src, size
 
 std::expected<void, HazeInternalError> copy_device_to_device(DevAddr dst, DevAddr src,
                                                              size_t /*count*/) noexcept {
-    // D2D is a recorded polynomial copy under the first configured ciphertext
-    // modulus. sr_addps with imm=0 and a real modulus is a normalize-and-copy
-    // — identity for any well-formed CKKS residue and the right contract for
-    // record-and-replay; an "unbounded" copy isn't meaningful in CKKS. The
-    // real modulus also triggers remember_modulus, which is what makes a
-    // freshly-tagged input visible to sync_fhetch_state_to_compiler at
-    // replay time.
-    const uint64_t q = config().modulus(0);
-    if (q == 0)
-        return std::unexpected(HazeInternalError::NotConfigured);
+    // D2D is a recorded pass-through copy; the source is already tagged (H2D
+    // eager-tag or a prior compute), so the copy carries no real modulus.
     EpochSession session;
-    auto src_poly = epoch().lookup_or_create_locked(src);
-    if (!src_poly)
-        return std::unexpected(src_poly.error());
-    fhetch::Polynomial result = fhetch::sr_addps(*src_poly, fhetch::Scalar::from_int(0), q);
-    epoch().store_compute_result_locked(dst, std::move(result));
-    return {};
+    return epoch().copy_result_locked(dst, src);
 }
 
 std::expected<void, HazeInternalError> tag_h2d_input(DevAddr addr) noexcept {

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -67,6 +67,12 @@ class EpochState {
     void store_compute_result_locked(DevAddr addr, niobium::fhetch::Polynomial poly) noexcept
         HAZE_REQUIRES(mutex_);
 
+    // Record a pass-through copy dst <- src under the COPY_MODULUS sentinel.
+    // A copy is modulus-agnostic and H2D eager-tags inputs, so the op needn't
+    // carry a real prime; shared by the SRP and MRP D2D paths.
+    std::expected<void, HazeInternalError> copy_result_locked(DevAddr dst, DevAddr src) noexcept
+        HAZE_REQUIRES(mutex_);
+
     // Eagerly tag the H2D'd shadow bytes at `addr` as a fhetch input.
     // Builds the Polynomial via a non-evicting read (shadow stays intact
     // for subsequent compute-free D2H), calls `tag_input`, and binds it

--- a/src/core/mrp_polymap.cpp
+++ b/src/core/mrp_polymap.cpp
@@ -126,18 +126,16 @@ std::expected<void, HazeInternalError> copy_device_to_device_mrp(void *const *ds
                                                                  const void *const *src,
                                                                  const uint64_t *base,
                                                                  std::size_t len) noexcept {
-    // Per-residue pass-through copy under base[i]: sr_addps(+0) emits real IR
-    // and triggers remember_modulus so a compute-produced source is captured.
+    // Per-residue pass-through copy, then register the dst as an MRP output
+    // group under the real base[i] so it reads back as an MRP, matching the
+    // arithmetic MRP ops.
     EpochSession session;
     std::vector<DevAddr> addrs;
     addrs.reserve(len);
     for (std::size_t i = 0; i < len; ++i) {
-        auto src_poly = epoch().lookup_or_create_locked(to_dev_addr(src[i]));
-        if (!src_poly)
-            return std::unexpected(src_poly.error());
         DevAddr d = to_dev_addr(dst[i]);
-        epoch().store_compute_result_locked(
-            d, fhetch::sr_addps(*src_poly, fhetch::Scalar::from_int(0), base[i]));
+        if (auto copied = epoch().copy_result_locked(d, to_dev_addr(src[i])); !copied)
+            return copied;
         addrs.push_back(d);
     }
     if (len > 1) {

--- a/src/core/mrp_polymap.cpp
+++ b/src/core/mrp_polymap.cpp
@@ -15,6 +15,7 @@
 
 #include "common/errors.hpp"
 #include "common/handle.hpp"
+#include "core/allocator.hpp"
 #include "core/epoch.hpp"
 
 #include <cstddef>
@@ -87,6 +88,57 @@ std::expected<void, HazeInternalError> store_mrp_locked(void *const *dst_polys,
         DevAddr a = to_dev_addr(dst_polys[i]);
         epoch().store_compute_result_locked(a, mrp[base[i]]);
         addrs.push_back(a);
+    }
+    if (len > 1) {
+        auto group_name = mrp_signature_name("haze_mrp_out", addrs.front());
+        return epoch().register_mrp_output_group_locked(addrs, std::span(base, len),
+                                                        std::move(group_name));
+    }
+    return {};
+}
+
+std::expected<void, HazeInternalError> copy_h2d_mrp(void *const *dst, const void *const *src,
+                                                    std::size_t count, std::size_t len) noexcept {
+    // Write every residue's shadow first, then tag them under one session:
+    // tag promotes the just-written bytes to a fhetch input per residue.
+    for (std::size_t i = 0; i < len; ++i)
+        if (auto h2d = allocator().copy_h2d(to_dev_addr(dst[i]), src[i], count); !h2d)
+            return h2d;
+    EpochSession session;
+    for (std::size_t i = 0; i < len; ++i)
+        if (auto tag = epoch().tag_h2d_input_locked(to_dev_addr(dst[i])); !tag)
+            return tag;
+    return {};
+}
+
+std::expected<void, HazeInternalError> copy_to_host_mrp(void *const *dst, const void *const *src,
+                                                        std::size_t count,
+                                                        std::size_t len) noexcept {
+    // The first copy_to_host flushes the recording; the rest read shadow bytes
+    // (replay_and_populate is a no-op once the recording is flushed).
+    for (std::size_t i = 0; i < len; ++i)
+        if (auto d2h = copy_to_host(dst[i], to_dev_addr(src[i]), count); !d2h)
+            return d2h;
+    return {};
+}
+
+std::expected<void, HazeInternalError> copy_device_to_device_mrp(void *const *dst,
+                                                                 const void *const *src,
+                                                                 const uint64_t *base,
+                                                                 std::size_t len) noexcept {
+    // Per-residue pass-through copy under base[i]: sr_addps(+0) emits real IR
+    // and triggers remember_modulus so a compute-produced source is captured.
+    EpochSession session;
+    std::vector<DevAddr> addrs;
+    addrs.reserve(len);
+    for (std::size_t i = 0; i < len; ++i) {
+        auto src_poly = epoch().lookup_or_create_locked(to_dev_addr(src[i]));
+        if (!src_poly)
+            return std::unexpected(src_poly.error());
+        DevAddr d = to_dev_addr(dst[i]);
+        epoch().store_compute_result_locked(
+            d, fhetch::sr_addps(*src_poly, fhetch::Scalar::from_int(0), base[i]));
+        addrs.push_back(d);
     }
     if (len > 1) {
         auto group_name = mrp_signature_name("haze_mrp_out", addrs.front());

--- a/src/core/mrp_polymap.hpp
+++ b/src/core/mrp_polymap.hpp
@@ -38,6 +38,21 @@ std::expected<void, HazeInternalError> store_mrp_locked(void *const *dst_polys,
                                                         const uint64_t *base, std::size_t len)
     HAZE_REQUIRES(epoch().mutex());
 
+// Per-residue fan-out backing hazeMemcpyMrp. Each manages its own
+// EpochSession (call without the lock held), so they mirror the single-ptr
+// copy_* free functions in epoch.hpp rather than the *_locked glue above.
+std::expected<void, HazeInternalError> copy_h2d_mrp(void *const *dst, const void *const *src,
+                                                    std::size_t count, std::size_t len) noexcept;
+
+std::expected<void, HazeInternalError> copy_to_host_mrp(void *const *dst, const void *const *src,
+                                                        std::size_t count,
+                                                        std::size_t len) noexcept;
+
+std::expected<void, HazeInternalError> copy_device_to_device_mrp(void *const *dst,
+                                                                 const void *const *src,
+                                                                 const uint64_t *base,
+                                                                 std::size_t len) noexcept;
+
 // Build an MRS from per-modulus uint64_t scalars + their primes. Pure-data
 // helper: does not touch the polymap, so no lock contract.
 inline niobium::fhetch::MRS build_mrs(const uint64_t *scalars, const uint64_t *base,

--- a/test/test_d2d_copy.cpp
+++ b/test/test_d2d_copy.cpp
@@ -20,6 +20,24 @@ namespace {
 constexpr uint64_t kRingDim = 4096;
 constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
 
+// Three-prime MRP config for the hazeMemcpyMrp cases; returns the base
+// [picked, q1, q2] with picked the bridge-aligned prime for residue 0.
+std::vector<uint64_t> setup_mrp3_config() {
+    constexpr uint64_t kQ0 = 576460752303415297ULL;
+    constexpr uint64_t kQ1 = 576460752303439873ULL;
+    constexpr uint64_t kQ2 = 576460752303702017ULL;
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    uint64_t picked = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
+    REQUIRE(picked != 0);
+    REQUIRE(hazeSetCiphertextModulus(0, picked) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    return {picked, kQ1, kQ2};
+}
+
 } // namespace
 
 TEST_CASE("hazeMemcpy(D2D) copies a compute-produced polynomial via IR", "[integration]") {
@@ -170,4 +188,146 @@ TEST_CASE("hazeMemcpy(D2D) promotes an H2D'd source through the IR copy", "[inte
 
     REQUIRE(hazeFree(dst) == HAZE_SUCCESS);
     REQUIRE(hazeFree(src) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeMemcpyMrp(D2D) copies a compute-produced MRP via per-residue IR", "[integration]") {
+    const auto base = setup_mrp3_config();
+    const std::vector<std::vector<uint64_t>> res = {
+        haze::test::make_residue(base[0], /*seed=*/1, kRingDim),
+        haze::test::make_residue(base[1], /*seed=*/2, kRingDim),
+        haze::test::make_residue(base[2], /*seed=*/3, kRingDim),
+    };
+    auto srcs = haze::test::allocate_and_h2d_residues(res);
+    auto computed = haze::test::allocate_dst_residues(3, kBytes);
+    auto copied = haze::test::allocate_dst_residues(3, kBytes);
+
+    // computed = srcs + srcs: bound in poly_map_ but no shadow until D2H, so a
+    // shadow-only copy would zero-fill. The per-residue IR copy must capture it.
+    REQUIRE(hazeAddMrp(computed.data(), haze::test::to_const(srcs).data(),
+                       haze::test::to_const(srcs).data(), base.data(), base.size(),
+                       nullptr) == HAZE_SUCCESS);
+
+    REQUIRE(hazeMemcpyMrp(copied.data(), haze::test::to_const(computed).data(), kBytes,
+                          HAZE_MEMCPY_DEVICE_TO_DEVICE, base.data(), base.size()) == HAZE_SUCCESS);
+
+    for (std::size_t r = 0; r < 3; ++r) {
+        std::vector<uint64_t> out(kRingDim);
+        REQUIRE(hazeMemcpy(out.data(), copied[r], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+                HAZE_SUCCESS);
+        for (std::size_t i = 0; i < kRingDim; ++i)
+            REQUIRE(out[i] == (res[r][i] + res[r][i]) % base[r]);
+    }
+
+    haze::test::free_all_residues(copied);
+    haze::test::free_all_residues(computed);
+    haze::test::free_all_residues(srcs);
+}
+
+TEST_CASE("hazeMemcpyMrp(D2D) promotes H2D'd sources and registers the output group",
+          "[integration]") {
+    const auto base = setup_mrp3_config();
+    const std::vector<std::vector<uint64_t>> res = {
+        haze::test::make_residue(base[0], /*seed=*/4, kRingDim),
+        haze::test::make_residue(base[1], /*seed=*/5, kRingDim),
+        haze::test::make_residue(base[2], /*seed=*/6, kRingDim),
+    };
+    auto srcs = haze::test::allocate_and_h2d_residues(res);
+    auto dst = haze::test::allocate_dst_residues(3, kBytes);
+
+    REQUIRE(hazeMemcpyMrp(dst.data(), haze::test::to_const(srcs).data(), kBytes,
+                          HAZE_MEMCPY_DEVICE_TO_DEVICE, base.data(), base.size()) == HAZE_SUCCESS);
+
+    for (std::size_t r = 0; r < 3; ++r) {
+        std::vector<uint64_t> out(kRingDim);
+        REQUIRE(hazeMemcpy(out.data(), dst[r], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        REQUIRE(out == res[r]);
+    }
+
+    // No compute op ran, so the D2D fan-out is the only haze_mrp_out_* group;
+    // confirm register_mrp_output_group_locked made it readable as an MRP.
+    haze::test::check_mrp_against_per_residue(base, res);
+
+    haze::test::free_all_residues(dst);
+    haze::test::free_all_residues(srcs);
+}
+
+TEST_CASE("hazeMemcpyMrp round-trips H2D then D2H per residue", "[integration]") {
+    const auto base = setup_mrp3_config();
+    const std::vector<std::vector<uint64_t>> res = {
+        haze::test::make_residue(base[0], /*seed=*/7, kRingDim),
+        haze::test::make_residue(base[1], /*seed=*/8, kRingDim),
+        haze::test::make_residue(base[2], /*seed=*/9, kRingDim),
+    };
+    auto dev = haze::test::allocate_dst_residues(3, kBytes);
+
+    const std::vector<const void *> host_src = {res[0].data(), res[1].data(), res[2].data()};
+    REQUIRE(hazeMemcpyMrp(dev.data(), host_src.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE,
+                          base.data(), base.size()) == HAZE_SUCCESS);
+
+    std::vector<std::vector<uint64_t>> out(3, std::vector<uint64_t>(kRingDim));
+    const std::vector<void *> host_dst = {out[0].data(), out[1].data(), out[2].data()};
+    REQUIRE(hazeMemcpyMrp(host_dst.data(), haze::test::to_const(dev).data(), kBytes,
+                          HAZE_MEMCPY_DEVICE_TO_HOST, base.data(), base.size()) == HAZE_SUCCESS);
+
+    for (std::size_t r = 0; r < 3; ++r)
+        REQUIRE(out[r] == res[r]);
+
+    haze::test::free_all_residues(dev);
+}
+
+TEST_CASE("hazeMemcpyMrp(D2D) from a never-written source returns SOURCE_UNAVAILABLE",
+          "[integration]") {
+    const auto base = setup_mrp3_config();
+    auto src = haze::test::allocate_dst_residues(3, kBytes); // never written
+    auto dst = haze::test::allocate_dst_residues(3, kBytes);
+
+    REQUIRE(hazeMemcpyMrp(dst.data(), haze::test::to_const(src).data(), kBytes,
+                          HAZE_MEMCPY_DEVICE_TO_DEVICE, base.data(),
+                          base.size()) == HAZE_ERROR_SOURCE_UNAVAILABLE);
+
+    haze::test::free_all_residues(dst);
+    haze::test::free_all_residues(src);
+}
+
+TEST_CASE("hazeMemcpyMrp(D2D) with base_len 1 copies without registering a group",
+          "[integration]") {
+    const uint64_t q = haze::test::setup_integration_compute_config();
+    const auto residue = haze::test::make_residue(q, /*seed=*/11, kRingDim);
+
+    void *src = nullptr;
+    void *dst = nullptr;
+    REQUIRE(hazeMalloc(&src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&dst, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(src, residue.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    const std::vector<const void *> src_arr = {src};
+    const std::vector<void *> dst_arr = {dst};
+    REQUIRE(hazeMemcpyMrp(dst_arr.data(), src_arr.data(), kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE, &q,
+                          1) == HAZE_SUCCESS);
+
+    std::vector<uint64_t> out(kRingDim);
+    REQUIRE(hazeMemcpy(out.data(), dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    REQUIRE(out == residue);
+
+    REQUIRE(hazeFree(dst) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(src) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeMemcpyMrp rejects malformed arguments", "[integration]") {
+    const auto base = setup_mrp3_config();
+    auto dst = haze::test::allocate_dst_residues(3, kBytes);
+    auto src = haze::test::allocate_dst_residues(3, kBytes);
+    const auto csrc = haze::test::to_const(src);
+
+    REQUIRE(hazeMemcpyMrp(nullptr, csrc.data(), kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE, base.data(),
+                          base.size()) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeMemcpyMrp(dst.data(), nullptr, kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE, base.data(),
+                          base.size()) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeMemcpyMrp(dst.data(), csrc.data(), kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE, nullptr,
+                          base.size()) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeMemcpyMrp(dst.data(), csrc.data(), kBytes, HAZE_MEMCPY_DEVICE_TO_DEVICE,
+                          base.data(), 0) == HAZE_ERROR_INVALID_VALUE);
+
+    haze::test::free_all_residues(dst);
+    haze::test::free_all_residues(src);
 }


### PR DESCRIPTION
New `hazeMemcpyMrp(dst[], src[], count, kind, base[], base_len)` — the multi-residue (MRP) variant of hazeMemcpy. Fans out per residue over the existing MRP polymap helpers:
- H2D: per-residue copy_h2d + eager fhetch input tag under one EpochSession.
- D2H: per-residue shadow read after a single (idempotent) replay flush.
- D2D: per-residue sr_addps(+0) under base[i] so a compute-produced source is captured at replay (PR-1 contract), then registers the dst as an MRP output group when base_len > 1.

The extern "C" shim validates the top-level arrays once and dispatches on the type of transfer being performed (H2D, etc); per-residue faults surface from the core helpers.