### PR TITLE
Add Claude automated code review CI for PRs

### DIFF
--- a/.github/instructions/CODE_REVIEW_GUIDE.md
+++ b/.github/instructions/CODE_REVIEW_GUIDE.md
@@ -1,0 +1,145 @@
+# Code Review Guide — libhaze
+
+This guide defines how automated and manual PR reviews should be conducted for the `niobium-haze` repository. Reviews must be actionable, concise, and focused on correctness and safety.
+
+> **Scope reminder**: This is a *runtime shim* — not an FHE application or compiler. FHE circuit correctness is out of scope here. The critical areas are the record-and-replay contract, shadow storage invariants, lock ordering, and the C ABI boundary.
+
+> **Automated review scope**: Automated reviews perform static file analysis only (Read, Write, Edit tools). Build validation (`make test`, `make test-sim`), sanitizer runs, and transport tests require manual review or dedicated CI workflows.
+
+---
+
+## Project Context
+
+- **What it is**: A CUDA-shaped record-and-replay runtime for the Niobium FHE accelerator (`libhaze`). The public C ABI (`include/haze/haze.h`) mirrors CUDA function shapes one-for-one so CUDA-targeting code ports by mechanical prefix substitution.
+- **Stack**: C++23, Clang 19+, CMake ≥ 3.22. `-Wthread-safety` (TSA) is the canonical enforcement path for lock contracts.
+- **Key subsystems**:
+  - `src/api/` — thin `extern "C"` shims, argument validation, `hazeError_t` translation.
+  - `src/core/` — `EpochState`, `DeviceAllocator`, `CompilerBackend`, `Config`.
+  - `src/common/` — `HazeMutex`, `HazeLockGuard`, error/log utilities.
+  - `replay_bridge/` — OpenFHE integration, `cryptocontext.dat`, ciphertext template generation.
+  - `include/haze/` — public C ABI (no C++ in interface).
+- **Execution model**: Every compute call appends a node to the FHETCH trace. `hazeMemcpy(D2H)` is the **sole flush trigger** — it calls `replay_and_populate()`, dispatches the trace, and writes simulator results into shadow buffers. `hazeDeviceSynchronize` and `hazeStreamSynchronize` are no-ops.
+
+---
+
+## 1. Required Review Output
+
+Every review must produce these sections in order:
+
+1. **Summary** (2–4 lines): what changed and why, as inferred from the diff.
+2. **Blockers** (must-fix): correctness bugs, ABI breaks, lock order violations, flush-trigger violations, exceptions crossing the C boundary.
+3. **Risks / Watch-outs**: areas likely to regress silently — shadow storage contract, thread safety, hazeDeviceReset + bridge re-init pattern.
+4. **Non-blocking suggestions**: code duplication, unnecessary complexity, consistency with surrounding code.
+5. **Questions for the author**: missing context, unclear assumptions.
+
+Label every issue: **Blocker / High / Medium / Low**.
+
+---
+
+## 2. PR Risk Classification
+
+### Blocker — must not merge
+- **Lock order violation**: any path where `DeviceAllocator` calls back into `EpochState` while holding `EpochState::mutex_`. The permitted direction is epoch → allocator only; the reverse deadlocks.
+- **Flush-trigger bypass**: any materialization (reading simulator results, writing to shadow storage) that happens outside of `hazeMemcpy(D2H)` → `replay_and_populate()`. This breaks the lazy execution contract.
+- **Exception crossing the C ABI boundary**: any `extern "C"` function that can throw. Every public entry point must be `HAZE_NOEXCEPT`.
+- **ABI break in `include/haze/`**: removing or reordering public API symbols, changing `hazeError_t` enumerator values, changing struct layouts in `haze_types.h`.
+- **`DevAddr` arithmetic outside the C ABI edge**: `DevAddr` is an `enum class : uintptr_t`; it must only be cast to/from `void*` at `src/api/` entry points, never inside core or common.
+- **Undefined behavior, use-after-free, or memory corruption** in any path.
+- **Missing `HAZE_API` on new public symbols** or `HAZE_NOEXCEPT` on new public entry points.
+- **Raw owning pointers or manual `new`/`delete`** outside of C-API wrappers. libhaze targets C++23 — ownership must be expressed via `std::unique_ptr`, `std::shared_ptr`, or RAII value types. A raw owning pointer is never acceptable in new code.
+
+### High Risk — deep review required
+- Changes to `src/core/epoch.cpp` (recording state machine, `replay_and_populate`, `EpochSession` RAII guard).
+- Changes to `src/core/allocator.*` (shadow storage, `alloc_set_`, `shadow_data_`, `extract_polynomial_components`).
+- Changes to `include/haze/haze.h` or `include/haze/haze_types.h` (public ABI).
+- Changes to `replay_bridge/` (OpenFHE integration, key extraction, `post_recording_hook` registration).
+- Any new or modified use of `fhetch::sr_*`, `tag_input`, `tag_output`, `fhetch::result` (FHETCH recording surface).
+- Changes to `HazeMutex` / `HazeLockGuard` or any mutation to lock annotations (`HAZE_REQUIRES`, `HAZE_EXCLUDES`).
+- Changes to `src/core/config.hpp` (especially `kLocalTarget` or `kHbmBase`).
+- Multi-residue (MRP) paths: `hazeModUp`, `hazeModDown`, `hazeMemcpyMrp`, and any `.template` file generation.
+- Any fallible internal function that does not return `std::expected<T, HazeInternalError>` — mismatched error propagation hides failures at the API edge.
+
+### Medium Risk — targeted review
+- New compute API implementations in `src/api/compute.cpp`.
+- New or modified test cases under `test/`.
+- Changes to `hazeSetRingDimension`, `hazeMalloc`, `hazeFree` (single-size invariant enforcement).
+- Changes to the `EpochSession` RAII guard lifecycle (constructor, destructor, `ensure_initialized`).
+
+### Low Risk — light review
+- Docs, comments, README updates.
+- Small isolated refactors with no behavior change.
+- `test/e2e/` additions that follow the canonical `ops.hpp` pattern.
+
+---
+
+## 3. Core Correctness Checklist
+
+### 3.1 C++23 Ownership, RAII, and `std::expected`
+libhaze is authored with Rust-informed preferences: strong ownership, exhaustive RAII, and `std::expected` as the standard fallible return type. Flag any deviation.
+
+- **`std::expected<T, HazeInternalError>`**: every internal function that can fail must return this type. Output parameters, error codes returned via reference, or bool+side-channel patterns are not acceptable in new code. If an existing function uses a legacy pattern and the PR touches it, flag it as a Medium to migrate.
+- **RAII everywhere**: every resource with a non-trivial destructor (file handles, `niobium::compiler()` scopes, mutex guards, any OS resource) must be managed by a wrapping value type or `std::unique_ptr`. Manual cleanup in destructors or `goto`-style cleanup blocks are Blockers.
+- **No raw owning pointers**: `T*` is only acceptable as a non-owning borrow (e.g., passing a pointer into a C API). Any `T*` that owns its pointee and isn't immediately wrapped in a smart pointer is a Blocker.
+- **Value types over pointer soup**: prefer `std::optional<T>` over nullable pointers for optional values; prefer returning `std::expected` over passing a success-flag output parameter.
+- **`[[nodiscard]]` on `std::expected` returns**: callers that discard a fallible result silently swallow errors. Flag unchecked `std::expected` return values in any non-test code.
+- **Move semantics**: large types (e.g., shadow buffers, polynomial handles) should be moved, not copied, across ownership boundaries. Unnecessary copies in hot paths are a Medium issue.
+
+### 3.2 Lock Order and Thread Safety
+This is the most subtle correctness area in libhaze.
+
+- **Lock order**: `EpochState::mutex_` → `DeviceAllocator`. Never the reverse. Any new call from allocator-side code into `EpochState` is a Blocker.
+- **TSA annotations**: every new lock usage must carry `HAZE_REQUIRES` or `HAZE_EXCLUDES` on the calling function. Missing annotations defeat clang's `-Wthread-safety` enforcement.
+- **`HazeMutex` / `HazeLockGuard`**: use these, not `std::mutex` / `std::lock_guard`. The standard library types carry no TSA annotations.
+- **Shared data without synchronization**: flag any access to `EpochState` or `DeviceAllocator` fields from outside `mutex_`-protected regions.
+- **`CompilerBackend::init`**: called once under lock-free fast path. Any new initialization that is not idempotent or not thread-safe is a Blocker.
+
+### 3.3 Shadow Storage Contract
+- **`alloc_set_` vs `shadow_data_`**: `alloc_set_` tracks lifetime (`hazeMalloc`/`hazeFree`); `shadow_data_` tracks payload (exists only after H2D/memset/D2D/`update_shadow`). Code that reads `shadow_data_` without first checking `alloc_set_` membership is a correctness bug.
+- **Missing entry reads**: D2H from an address with no `shadow_data_` entry must return zeros (not crash). Compute / D2D extract from a missing entry must return `SourceUnavailable` — using an uninitialized device address is a contract violation, not a defensive case.
+- **`extract_polynomial_components`**: this evicts the shadow entry. Any code that reads the shadow after calling this is a use-after-evict bug.
+- **`hazeFree` eviction**: shadow entries at freed addresses must be cleared; leaking them past `hazeFree` causes ghost data in a subsequent `hazeMalloc` at the same address.
+
+### 3.4 Record-and-Replay State Machine
+- **D2H as the sole flush trigger**: `replay_and_populate()` must only be called from `hazeMemcpy(D2H)`. Any new call site is a design violation.
+- **`EpochSession` RAII guard**: every compute call must go through an `EpochSession`. Missing it skips `ensure_initialized` and the recording start/stop lifecycle.
+- **`tag_input` promotion**: `epoch().lookup_or_create_locked(addr)` creates a fresh `fhetch::Polynomial` from shadow bytes. Calling this on an address whose shadow was already evicted via `extract_polynomial_components` is a silent data hazard.
+- **`tag_output` registration**: outputs must be tagged before `stop_epoch()`. Missing `tag_output` means `result()` will not find the output polynomial and the D2H read returns stale zeros.
+- **No-op when not recording**: `replay_and_populate()` must be a no-op when no FHETCH epoch is in flight (e.g., plain H2D-then-D2H round-trips). Confirm the guard condition is preserved.
+
+### 3.5 C ABI Boundary
+- **`HAZE_NOEXCEPT`**: all `extern "C"` entry points must be `HAZE_NOEXCEPT`. Check every new or modified function in `src/api/`.
+- **`HAZE_API` visibility**: new public symbols need `HAZE_API`; implementation-internal symbols must not have it.
+- **`hazeError_t` translation**: `std::expected` errors from core must be translated to `hazeError_t` at the API edge, not propagated as exceptions or left untranslated.
+- **No C++ types in public headers**: `include/haze/haze.h` and `haze_types.h` must stay pure C. Any new `struct`, `enum`, or function signature must be valid in C99.
+- **`DevAddr` cast sites**: the only legitimate `(DevAddr)ptr` and `(void*)addr` casts are at `src/api/` entry points. Flag any cast in `src/core/` or `src/common/`.
+
+### 3.6 Single-Size Allocation Invariant
+- Every `hazeMalloc` allocation must equal `ring_dim * sizeof(uint64_t)`. Any path that accepts a different size or skips the size check is a Blocker.
+- `hazeSetRingDimension` must be called before the first `hazeMalloc`. New code that calls `hazeMalloc` without a prior ring-dimension set is a contract violation.
+- `hazeHostAlloc` is the correct path for non-polynomial scratch (pointer arrays, twiddle tables, kernel-arg packs) — these must never go through `hazeMalloc`.
+
+### 3.7 hazeDeviceReset and Bridge Re-init
+- Any test that calls `hazeDeviceReset` must re-call `hazeReplayBridgeInitCryptoContext` before any subsequent MRP compute call. The `post_recording_hook` is wiped by reset.
+- The canonical helper is `integration_helpers.hpp::setup_integration_compute_config`. New test cases that bypass it and reset manually must replicate this re-init.
+- Missing re-init after reset causes a null hook dereference on the next `stop_epoch` that triggers `post_recording_hook`.
+
+### 3.8 Code and Data Structure Reuse
+- Does new code solve a problem already handled by an existing helper in `src/common/` or `src/core/`? Search before flagging.
+- Are there two near-identical implementations of the same operation (e.g., shadow read/write in two places)? Flag and suggest consolidation.
+- Is a new type introduced that duplicates the shape of `DevAddr`, `HazeInternalError`, or an existing handle type?
+
+### 3.9 Build System
+- Are new source files added to `CMakeLists.txt`?
+- Are new symbols in `include/haze/` exported correctly (`HAZE_API`, visibility)?
+- Are new dependencies introduced? They must be available in the nix flake and documented.
+- Does the change affect `replay_bridge/` linkage? That target must stay isolated so OpenFHE includes do not leak into `libhaze` sources.
+
+---
+
+## 4. Comment Style
+
+- **Blocker**: `[Blocker] file:line — problem — fix`
+- **High**: `[High] file:line — problem — suggested fix`
+- **Medium / Low**: one line is enough unless a fix is non-obvious.
+- Prefer proposing a minimal patch over describing the problem abstractly.
+- Do not flag style issues unless they affect readability or create ambiguity.

--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -1,7 +1,6 @@
 name: PR - Claude Code Review
 
 on:
-  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, reopened]
   issue_comment:
@@ -18,7 +17,6 @@ jobs:
     name: PR - Full Code Review
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
@@ -49,11 +47,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 45
-            --allowedTools Edit,Read,Write
+            --allowedTools Read
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}
@@ -81,6 +79,7 @@ jobs:
             2. Blockers (must-fix)
             3. Risks / Watch-outs
             4. Non-blocking suggestions
+            5. Questions for the author
 
             Rules:
             - Each issue must be one line: [Severity] file:line — problem — fix
@@ -130,7 +129,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
-          fetch-depth: 1
+          fetch-depth: 2
 
       - name: Get files changed in latest push
         id: changed-files
@@ -144,11 +143,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 25
-            --allowedTools Edit,Read,Write
+            --allowedTools Read
           track_progress: true
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -1,0 +1,207 @@
+name: PR - Claude Code Review
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  full-review:
+    name: PR - Full Code Review
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude'))
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          separator: " "
+
+      - name: Claude Full Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 45
+            --allowedTools Edit,Read,Write
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            You are a code reviewer for PR #${{ github.event.pull_request.number }} in ${{ github.repository }}.
+
+            Start by reading the review guide at:
+            .github/instructions/CODE_REVIEW_GUIDE.md
+
+            Then review this PR following the guide.
+            The changed files are: ${{ steps.changed-files.outputs.all_changed_files }}
+
+            For each changed file:
+            1. Read the FULL file content using the Read tool
+            2. Apply the universal checklist from the guide (sections 3)
+
+            Turn limit safety: after reading each file, count the tool calls you have made
+            so far against the --max-turns 45 limit. If the number of files you have not
+            yet read exceeds your estimated remaining turns, stop reading new files and
+            post the review immediately with findings gathered so far, noting which files
+            were skipped due to the turn limit.
+
+            Post a single concise PR comment with only:
+            1. Summary (2–4 lines)
+            2. Blockers (must-fix)
+            3. Risks / Watch-outs
+            4. Non-blocking suggestions
+
+            Rules:
+            - Each issue must be one line: [Severity] file:line — problem — fix
+            - No prose, no elaboration, no closing summary
+            - If a section has no findings, omit it entirely
+            - Label each issue: Blocker / High / Medium / Low
+
+      - name: Usage Summary
+        if: always()
+        run: |
+          EXECUTION_FILE="${{ steps.claude-review.outputs.execution_file }}"
+
+          INPUT=0; OUTPUT=0; TURNS=0
+          if [ -f "$EXECUTION_FILE" ]; then
+            INPUT=$(jq '[.. | objects | select(has("usage")) | .usage.input_tokens // 0] | add // 0' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+            OUTPUT=$(jq '[.. | objects | select(has("usage")) | .usage.output_tokens // 0] | add // 0' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+            TURNS=$(jq '[.. | objects | select(has("type") and (.type == "assistant"))] | length' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+          fi
+          TOTAL=$((INPUT + OUTPUT))
+          COST=$(echo "scale=4; ($INPUT * 3 + $OUTPUT * 15) / 1000000" | bc)
+
+          echo "## PR - Full Code Review — Usage" >> $GITHUB_STEP_SUMMARY
+          echo "| | |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Model | claude-sonnet-4-6 |" >> $GITHUB_STEP_SUMMARY
+          echo "| Input tokens | $INPUT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Output tokens | $OUTPUT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total tokens | $TOTAL |" >> $GITHUB_STEP_SUMMARY
+          echo "| Estimated cost | \$$COST USD |" >> $GITHUB_STEP_SUMMARY
+          echo "| Turns used | $TURNS |" >> $GITHUB_STEP_SUMMARY
+
+  partial-review:
+    name: PR - Partial Code Review
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' && github.event.action == 'synchronize'
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 1
+
+      - name: Get files changed in latest push
+        id: changed-files
+        uses: tj-actions/changed-files@v47
+        with:
+          separator: " "
+          since_last_remote_commit: true
+
+      - name: Claude Partial Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 25
+            --allowedTools Edit,Read,Write
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are performing a PARTIAL review of the latest commit to PR #${{ github.event.pull_request.number }}.
+
+            Files changed in this push: ${{ steps.changed-files.outputs.all_changed_files }}
+
+            Start by reading the review guide at:
+            .github/instructions/CODE_REVIEW_GUIDE.md
+
+            For each changed file:
+            1. Read the relevant sections using the Read tool
+            2. Apply the full checklist from the guide (sections 3), but report ONLY findings
+               rated Blocker or High — skip Medium and Low entirely
+
+            Turn limit safety: after reading each file, count the tool calls you have made
+            so far against the --max-turns 25 limit. If the number of files you have not
+            yet read exceeds your estimated remaining turns, stop reading new files and
+            post the review immediately with findings gathered so far, noting which files
+            were skipped due to the turn limit.
+
+            Post a single concise PR comment with only:
+            1. What changed in this commit (1 line)
+            2. Blockers — if any
+            3. High risks — if any
+
+            Rules:
+            - Each issue must be one line: [Severity] file:line — problem — fix
+            - No prose, no elaboration, no closing summary
+            - If no blockers or high risks found, post only: "✅ No blockers or high risks in this commit."
+
+      - name: Usage Summary
+        if: always()
+        run: |
+          EXECUTION_FILE="${{ steps.claude-review.outputs.execution_file }}"
+
+          INPUT=0; OUTPUT=0; TURNS=0
+          if [ -f "$EXECUTION_FILE" ]; then
+            INPUT=$(jq '[.. | objects | select(has("usage")) | .usage.input_tokens // 0] | add // 0' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+            OUTPUT=$(jq '[.. | objects | select(has("usage")) | .usage.output_tokens // 0] | add // 0' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+            TURNS=$(jq '[.. | objects | select(has("type") and (.type == "assistant"))] | length' "$EXECUTION_FILE" 2>/dev/null || echo 0)
+          fi
+          TOTAL=$((INPUT + OUTPUT))
+          COST=$(echo "scale=4; ($INPUT * 3 + $OUTPUT * 15) / 1000000" | bc)
+
+          echo "## PR - Partial Code Review — Usage" >> $GITHUB_STEP_SUMMARY
+          echo "| | |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Model | claude-sonnet-4-6 |" >> $GITHUB_STEP_SUMMARY
+          echo "| Input tokens | $INPUT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Output tokens | $OUTPUT |" >> $GITHUB_STEP_SUMMARY
+          echo "| Total tokens | $TOTAL |" >> $GITHUB_STEP_SUMMARY
+          echo "| Estimated cost | \$$COST USD |" >> $GITHUB_STEP_SUMMARY
+          echo "| Turns used | $TURNS |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
  ## Summary

  - Adds `pr-claude-code-review.yml` with two jobs: **full-review**
    (PR open/reopen and `@claude` comments) and **partial-review**
    (each subsequent push), mirroring the pattern in niobium-compiler.
  - Adds `.github/instructions/CODE_REVIEW_GUIDE.md` with a libhaze-specific
    review guide covering the invariants Claude must check on every PR.

  ## Review guide coverage

  The guide encodes the correctness areas specific to this codebase:

  - **Lock order** — `EpochState::mutex_` → `DeviceAllocator` only; reverse direction is a Blocker.
  - **D2H as sole flush trigger** — materialization outside `hazeMemcpy(D2H)` / `replay_and_populate()` is a Blocker.
  - **Shadow storage contract** — `alloc_set_` vs `shadow_data_` lifecycle, use-after-evict via `extract_polynomial_components`.
  - **C ABI boundary** — `HAZE_NOEXCEPT`, `HAZE_API`, `DevAddr` cast sites, no C++ in public headers.
  - **Single-size invariant** — every `hazeMalloc` must equal `ring_dim * sizeof(uint64_t)`.
  - **`hazeDeviceReset` + bridge re-init** — tests that reset must re-call `hazeReplayBridgeInitCryptoContext`.
  - **C++23 ownership** — `std::expected` on every fallible internal path, exhaustive RAII, no raw owning pointers.

 ## Test plan

  - [ ] Merge this PR and open a follow-up PR with a real change; confirm `full-review` posts a comment.
  - [ ] Push an additional commit to that PR; confirm `partial-review` fires and reports only Blockers/High.