### PR TITLE
Bump niobium-fhetch to f63a705 (drop shadowing probes.h)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,7 +22,7 @@
       "locked": {
         "lastModified": 1779247542,
         "ref": "refs/heads/main",
-        "rev": "ae99cdd65c3d8e49a6b2c250a9e757f16cbc60b4",
+        "rev": "f63a705106a770749ddd635357d05d9e81989f5e",
         "revCount": 108,
         "submodules": true,
         "type": "git",


### PR DESCRIPTION
## Summary

Bumps `vendor/niobium-fhetch` from `ae99cdd` to `f63a705`.

`ae99cdd` shipped `include/niobium/openfhe/probes.h` in fhetch (declaring only `openfhe_suppress_probes`), which collides with OpenFHE's canonical `niobium/openfhe/probes.h` (the full CPROBE API). `f63a705` (niobium-fhetch#67) removes that duplicate so OpenFHE remains the single owner of the header.

## Impact on haze

None functionally. haze's only consumer is `src/core/backend.cpp`:
- `#include <niobium/openfhe/probes.h>`
- `openfhe_suppress_probes(1)`

Before the bump, that include resolved to fhetch's partial header (fhetch's own `include/` is propagated ahead of `openfhe/core`). After the bump, fhetch no longer ships it, so it falls through to OpenFHE's canonical header, which already declares `openfhe_suppress_probes`. OpenFHE's `include/openfhe/core` is on haze's include path in both build modes (add_subdirectory: propagated PUBLIC by the `niobium_fhetch` target; prebuilt: re-attached to `Niobium::fhetch`).

Verified by compiling a `backend.cpp`-equivalent TU against the post-bump fhetch include tree + OpenFHE's canonical header under haze's flags (`-std=c++23 -Wall -Wextra -Werror -Wpedantic -Wshadow -Wconversion`); clean compile.

## Context

Companion to niobium-fhetch#67 and the niobium-compiler submodule-bump PR #1475 that surfaced the shadowing.