### PR TITLE
fix(ci): repair openfhe-bump PR body block scalar

### DIFF
--- a/.github/workflows/openfhe-bump.yml
+++ b/.github/workflows/openfhe-bump.yml
@@ -137,7 +137,7 @@ jobs:
               --title "chore: bump stock OpenFHE to ${TAG}" \
               --body "Automated daily bump of the **stock** OpenFHE (vendor/openfhe + the openfhe-stock-src flake input) to **${TAG}**.
 
-The stock OpenFHE is the \`haze_e2e_tests\` reference oracle only — built shared with \`WITH_REDUCED_NOISE=ON\`, never absorbed into libhaze.so. The flag was verified present in the new release. The build-test, flake-check, and build-matrix gates validate the bump." \
+          The stock OpenFHE is the \`haze_e2e_tests\` reference oracle only -- built shared with \`WITH_REDUCED_NOISE=ON\`, never absorbed into libhaze.so. The flag was verified present in the new release. The build-test, flake-check, and build-matrix gates validate the bump." \
               --base main --head "$BRANCH"
           else
             echo "PR #${EXISTING} already open for ${BRANCH}; refreshed by push."


### PR DESCRIPTION
The `openfhe-bump` workflow has been failing at startup (0s, "workflow file issue") on every push to main.

## Cause

In the `gh pr create --body "..."` step, the body's second paragraph was written at column 0 -- less indented than the `run: |` block scalar's content (10 spaces). That terminates the literal block early, so YAML parses the prose as a new mapping key, finds no `:`, and rejects the whole file. GitHub then surfaces this as a failed "workflow file issue" run on each push.

```
.github/workflows/openfhe-bump.yml:140:10: could not parse as YAML: could not find expected ':'
```

## Fix

Indent the continuation line to the block scalar's base indent. YAML strips that indent back off, so the shell -- and the resulting PR markdown body -- still sees the line flush at column 0. Also swapped the non-ASCII em-dash for `--` per repo convention.

`actionlint` now passes clean. The workflow itself only triggers on `schedule` / `workflow_dispatch`, so this PR can't exercise a full run, but the parse error that blocked every invocation is resolved; verified by re-running actionlint and confirming the parsed body renders flush-left.