### PR TITLE
fix(replay_bridge): keep macOS RTTI uniform so hazeFlush serialization works

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -1,8 +1,13 @@
 name: build-matrix
 
-# Build-only portability matrix for the static, symbol-isolated libhaze: arm
-# macOS + linux x86_64/aarch64. Tests and lint stay on the nix build-test.yml /
-# flake-check.yml gates, so this builds with -DHAZE_BUILD_TESTS=OFF (no Catch2).
+# Portability matrix for the static, symbol-isolated libhaze: arm macOS + linux
+# x86_64/aarch64. Linux + lint coverage stays on the nix build-test.yml /
+# flake-check.yml gates, so the Linux legs build only (-DHAZE_BUILD_TESTS=OFF, no
+# Catch2). The macOS leg additionally builds the suite and runs the unit + sim
+# tests: build-test.yml runs those gates only on Linux, and some failures are
+# macOS-toolchain-specific (e.g. RTTI/visibility interactions in the cereal-based
+# replay_bridge serialization that ELF/libstdc++ never surfaces). Running them
+# here keeps macOS from silently drifting.
 
 on:
   pull_request:
@@ -35,6 +40,8 @@ jobs:
             runner: ubuntu-24.04-arm
           - name: macos-arm64
             runner: macos-14
+            # macOS-only: build the Catch2 suite and run unit + sim tests here.
+            run_tests: true
     steps:
       - name: Generate token
         id: app-token
@@ -65,8 +72,9 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           # Pin a versioned LLVM (matches the linux clang-19 floor) so a Homebrew
-          # `llvm` bump can't cause macOS-only drift.
-          brew install llvm@19 cmake ninja
+          # `llvm` bump can't cause macOS-only drift. catch2 (v3) is needed for
+          # the test suite this leg builds (HAZE_BUILD_TESTS=ON below).
+          brew install llvm@19 cmake ninja catch2
           llvm="$(brew --prefix llvm@19)"
           echo "CC=$llvm/bin/clang"   >> "$GITHUB_ENV"
           echo "CXX=$llvm/bin/clang++" >> "$GITHUB_ENV"
@@ -105,18 +113,36 @@ jobs:
         run: |
           # EXTRA_LDFLAGS carries the macOS libc++ path (empty elsewhere),
           # applied to both links so the absorbed objects bind the right libc++.
+          # Tests build only where this leg runs them (macOS); Linux stays
+          # build-only and Catch2-free (covered by build-test.yml's nix gate).
           rm -rf build
           cmake -S . -B build \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DOPENFHE_INSTALL_DIR="$PWD/openfhe-install" \
-            -DHAZE_BUILD_TESTS=OFF \
+            -DHAZE_BUILD_TESTS=${{ matrix.run_tests && 'ON' || 'OFF' }} \
             -DCMAKE_SHARED_LINKER_FLAGS="${EXTRA_LDFLAGS:-}" \
             -DCMAKE_EXE_LINKER_FLAGS="${EXTRA_LDFLAGS:-}"
           cmake --build build --target haze
+          if [ "${{ matrix.run_tests }}" = "true" ]; then
+            cmake --build build --target haze_tests
+          fi
 
-      # Tests are OFF here, so the symbol-leak ctest does not run; invoke the
-      # checker directly to validate isolation on each native target.
       - name: Check symbol isolation
         shell: bash
         run: scripts/check_symbol_leak.sh build
+
+      # macOS-only: exercise the in-process FHETCH simulator (HAZE_TARGET=local),
+      # which drives hazeFlush -> replay_bridge serialization. This is the path
+      # that surfaces macOS-specific RTTI/visibility regressions; Linux runs the
+      # same suite via the nix devshell in build-test.yml. cd into runs/ so the
+      # recorder's program_dir resolves under the build tree (mirrors the Makefile
+      # and the haze_{unit,sim}_tests ctest contract).
+      - name: Run unit + sim tests (macOS)
+        if: matrix.run_tests
+        shell: bash
+        run: |
+          mkdir -p build/runs
+          cd build/runs
+          HAZE_TARGET=local ../haze_tests "~[integration]"
+          HAZE_TARGET=local ../haze_tests "[integration]"

--- a/replay_bridge/CMakeLists.txt
+++ b/replay_bridge/CMakeLists.txt
@@ -33,8 +33,22 @@ target_include_directories(haze_replay_bridge
 target_link_libraries(haze_replay_bridge PUBLIC Niobium::fhetch)
 
 # OBJECT library: no linkable artifact, so OUTPUT_NAME would be a no-op.
+#
+# Deliberately NOT CXX_VISIBILITY_PRESET=hidden. On arm64 macOS clang encodes
+# RTTI uniqueness in bit 63 of type_info::__type_name: a default-visibility class
+# gets "non-unique" typeinfo (libc++ compares by strcmp), while -fvisibility=hidden
+# gives "unique" typeinfo (pointer comparison, treated as a distinct type across
+# image boundaries). This is the only TU in the libhaze/haze_tests image that
+# instantiates cereal save<> over OpenFHE types; if it were hidden, ld64 would let
+# its unique-flavored weak typeinfo win the coalesce, and cereal's shared_ptr fast
+# path (typeid(*ptr) == typeid(T)) would compare a folded bit-clear name against
+# the in-memory bit-set name and miss -- throwing "unregistered polymorphic type"
+# for CryptoContextImpl / NativeVector during every hazeFlush (macOS-only; Linux
+# libstdc++ has no uniqueness bit). The OpenFHE stack and libnbfhetch are all
+# default-visibility, so this keeps the flavor uniform. Symbol isolation does not
+# rely on this preset -- libhaze.so's haze*-only export surface is enforced by the
+# -exported_symbols_list / version-script at link time (see CMakeLists.txt).
 set_target_properties(haze_replay_bridge PROPERTIES
-  CXX_VISIBILITY_PRESET     hidden
   VISIBILITY_INLINES_HIDDEN ON
   POSITION_INDEPENDENT_CODE  ON
 )


### PR DESCRIPTION
## Problem

`make test-sim` failed **110/120** on arm64 macOS (and `test-e2e` too): `hazeFlush()` errored because the `replay_bridge`/libnbfhetch serialization path threw cereal `Trying to save an unregistered polymorphic type` for `intnat::NativeVectorT<...>` (input bins) and `lbcrypto::CryptoContextImpl<...>` (output templates). It passed in CI only because **CI runs the sim/e2e suite exclusively on Linux** (`build-test.yml` is `ubuntu-latest`); macOS was build-only. So this was latent, not a regression.

## Root cause

On arm64 macOS, clang encodes RTTI uniqueness in bit 63 of `type_info::__type_name`:
- `-fvisibility=hidden` class -> "unique" typeinfo, libc++ compares by **pointer** (distinct across image boundaries)
- default-visibility class -> "non-unique" typeinfo, libc++ compares by **strcmp**

`replay_bridge/openfhe_template.cpp` was the **only** TU in the libhaze/haze_tests image that both includes OpenFHE headers and was compiled `-fvisibility=hidden` (`CXX_VISIBILITY_PRESET hidden`). ld64 coalesced the weak cereal `save<>` instantiations and the bridge's unique-flavored typeinfo won, so cereal's `shared_ptr` fast path (`typeid(*ptr) == typeid(T)`) compared a constant-folded bit-clear name against the in-memory bit-set name, missed, and threw. Linux libstdc++ has no uniqueness bit, so it was never affected. (Matches fhetch's own build, which sets no visibility flags -> uniform non-unique RTTI.)

## Fix

Drop `CXX_VISIBILITY_PRESET hidden` from the `haze_replay_bridge` target (keep `VISIBILITY_INLINES_HIDDEN` + PIC) so the bridge matches the rest of the OpenFHE/libnbfhetch stack. Symbol isolation is **unaffected** -- libhaze's `haze*`-only export surface is enforced by the `-exported_symbols_list`/version-script at link time, not by that per-TU preset.

## Catching it earlier

`ci(build-matrix)`: the macOS leg now builds the Catch2 suite and runs the unit + sim tests (the sim path is what drives `hazeFlush` -> `replay_bridge` serialization). Linux legs stay build-only.

## Verification (local, arm64 macOS, clean rebuild)

- `make test-sim`: **120/120** (1,622,809 assertions) -- was 110/120 failing
- `make test-unit`: **56/56**
- `make test-e2e`: **5/5** (216,540 assertions, decrypt-verified)
- `scripts/check_symbol_leak.sh`: OK, libhaze.dylib exports only `_haze*` (75 symbols)