### PR TITLE
Trace modulus is the single source of truth (drop install_trace_*_moduli)

### DIFF
--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -372,10 +372,8 @@ struct HookCtx {
 
 // Pick the CC for a shape; uses `local_cache` (alive only during one hook
 // call) to dedupe per-shape builds. Heterogeneous arrays log + return nullptr.
-// TODO(niobium-fhetch:mod-map-tracking): the modulus-0 / COPY_MODULUS fallback
-// covers outputs whose address_modulus_map entry is the copy sentinel (an
-// address only ever touched by modulus-less copy ops) rather than a real
-// modulus registered before sync.
+// The modulus-0 / COPY_MODULUS fallback now covers only the residual case: an
+// address never bound to a real modulus (raw H2D, never compute-touched).
 const Context *context_for_shape(const HookCtx &hctx,
                                  std::map<std::vector<uint64_t>, Context> &local_cache,
                                  const niobium::CapturedShape &shape) {

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -195,14 +195,10 @@ void fill_native_poly(lbcrypto::NativePoly &np, const std::vector<uint64_t> &val
     np.SetValues(nv, np.GetFormat());
 }
 
-// Switch tower `t` of `elem` to the trace modulus `q`, recomputing the root of
-// unity (corder = 2 * ring_dim). No-op for the COPY sentinel / 0 (no real
-// modulus) or a tower already at `q`. Applied to a ZERO tower before fill: the
-// .fhetch trace modulus table is authoritative, but OpenFHE's GenCryptoContext
-// can only emit bit-width-approximate primes, so each tower is re-based to the
-// exact trace prime here. Doing it pre-fill (on zeros) means values land under
-// the right modulus directly — no reduction against a smaller scaffold prime,
-// and no post-hoc snapshot/refill.
+// Re-base tower `t` to the exact trace modulus `q` (GenCryptoContext only emits
+// bit-width-approximate primes); no-op for the COPY sentinel/0 or a tower
+// already at `q`. Done on a zero tower before fill, so values land under the
+// right modulus with no wrap against a smaller scaffold prime.
 void switch_tower_modulus(lbcrypto::DCRTPoly &elem, size_t t, uint64_t q, uint32_t corder) {
     if (q == 0 || q == kCopyModulus)
         return;
@@ -214,8 +210,7 @@ void switch_tower_modulus(lbcrypto::DCRTPoly &elem, size_t t, uint64_t q, uint32
 }
 
 // SRP: 1-element / 1-tower CT; empty `values` produces a template. `modulus`
-// is the trace modulus (kCopyModulus when none is known); the tower is rebased
-// to it before fill.
+// (kCopyModulus = unknown) is the trace prime the tower is re-based to.
 lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_ciphertext(const Context &ctx, uint64_t modulus,
                                                           const std::vector<uint64_t> &values) {
     auto ct = empty_ct_shell(ctx, /*k_count=*/1);
@@ -444,11 +439,9 @@ void on_post_recording(const HookCtx &hctx) {
                 log_hook_error("input '" + rec.name + "': no CC available for shape");
                 return;
             }
-            // synthesize_for_shape rebases each tower to its trace modulus
-            // before filling, so the .bin carries the exact trace primes.
             // [[clang::suppress]]: the analyzer reports divide-by-zero /
-            // shift-overflow on paths inside OpenFHE's ubintnat.h reached
-            // via RootOfUnity; q == 0 / sentinel is guarded before any call.
+            // shift-overflow on ubintnat.h paths reached via RootOfUnity (in
+            // switch_tower_modulus); q == 0 / sentinel is guarded before any call.
             [[clang::suppress]] auto ct =
                 synthesize_for_shape(*ctx, rec.shape, rec.per_residue_values);
             if (!niobium::detail::write_ciphertext_input_bin(rec.name, ct, rec.addr_ids)) {
@@ -467,10 +460,9 @@ void on_post_recording(const HookCtx &hctx) {
                     log_hook_error("output '" + name + "': no CC available for shape");
                     return;
                 }
-                // Template towers are rebased to the trace moduli in
-                // synthesize_for_shape (on zeros), so the driver's SetValues
-                // matches without a post-hoc install. [[clang::suppress]]:
-                // same ubintnat.h RootOfUnity analyzer false positives.
+                // Template towers carry the trace moduli from synthesize, so
+                // the driver's SetValues matches with no post-hoc install.
+                // [[clang::suppress]]: same RootOfUnity analyzer noise as inputs.
                 [[clang::suppress]] auto ct =
                     synthesize_for_shape(*ctx, shape, /*per_residue_values=*/{});
                 if (!niobium::detail::write_ciphertext_template(name, ct)) {

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -195,15 +195,36 @@ void fill_native_poly(lbcrypto::NativePoly &np, const std::vector<uint64_t> &val
     np.SetValues(nv, np.GetFormat());
 }
 
-// SRP: 1-element / 1-tower CT; empty `values` produces a template.
-lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_ciphertext(const Context &ctx,
+// Switch tower `t` of `elem` to the trace modulus `q`, recomputing the root of
+// unity (corder = 2 * ring_dim). No-op for the COPY sentinel / 0 (no real
+// modulus) or a tower already at `q`. Applied to a ZERO tower before fill: the
+// .fhetch trace modulus table is authoritative, but OpenFHE's GenCryptoContext
+// can only emit bit-width-approximate primes, so each tower is re-based to the
+// exact trace prime here. Doing it pre-fill (on zeros) means values land under
+// the right modulus directly — no reduction against a smaller scaffold prime,
+// and no post-hoc snapshot/refill.
+void switch_tower_modulus(lbcrypto::DCRTPoly &elem, size_t t, uint64_t q, uint32_t corder) {
+    if (q == 0 || q == kCopyModulus)
+        return;
+    if (elem.GetAllElements()[t].GetModulus().ConvertToInt() == q)
+        return;
+    const auto root =
+        lbcrypto::RootOfUnity<lbcrypto::NativeInteger>(corder, lbcrypto::NativeInteger(q));
+    elem.SwitchModulusAtIndex(t, DCRTPoly::Integer(q), DCRTPoly::Integer(root.ConvertToInt()));
+}
+
+// SRP: 1-element / 1-tower CT; empty `values` produces a template. `modulus`
+// is the trace modulus (kCopyModulus when none is known); the tower is rebased
+// to it before fill.
+lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_ciphertext(const Context &ctx, uint64_t modulus,
                                                           const std::vector<uint64_t> &values) {
     auto ct = empty_ct_shell(ctx, /*k_count=*/1);
-    trim_towers_to(ct->GetElements()[0], 1);
+    auto &dcrt = ct->GetElements()[0];
+    trim_towers_to(dcrt, 1);
+    switch_tower_modulus(dcrt, 0, modulus, static_cast<uint32_t>(2 * ctx.ring_dim));
     if (values.empty())
         return ct; // template
-    fill_native_poly(ct->GetElements()[0].GetAllElements()[0], values,
-                     "synthesize_haze_ciphertext");
+    fill_native_poly(dcrt.GetAllElements()[0], values, "synthesize_haze_ciphertext");
     return ct;
 }
 
@@ -215,8 +236,11 @@ synthesize_haze_mrp_ciphertext(const Context &ctx, const std::vector<uint64_t> &
     auto ct = empty_ct_shell(ctx, /*k_count=*/1);
     auto &dcrt = ct->GetElements()[0];
     trim_towers_to(dcrt, moduli.size());
+    const auto corder = static_cast<uint32_t>(2 * ctx.ring_dim);
+    for (size_t i = 0; i < moduli.size(); ++i)
+        switch_tower_modulus(dcrt, i, moduli[i], corder);
     if (per_residue_values.empty())
-        return ct; // template — reconstruct_probes installs trace moduli.
+        return ct; // template — towers already at the trace moduli.
     if (per_residue_values.size() != moduli.size()) {
         std::ostringstream body;
         body << "synthesize_haze_mrp_ciphertext: per_residue_values.size()="
@@ -252,10 +276,14 @@ lbcrypto::Ciphertext<DCRTPoly> synthesize_haze_array_ciphertext(
     const size_t k_count = per_element_moduli.size();
 
     auto ct = empty_ct_shell(ctx, k_count);
-    for (auto &dcrt : ct->GetElements())
+    const auto corder = static_cast<uint32_t>(2 * ctx.ring_dim);
+    for (auto &dcrt : ct->GetElements()) {
         trim_towers_to(dcrt, shared_moduli.size());
+        for (size_t i = 0; i < shared_moduli.size(); ++i)
+            switch_tower_modulus(dcrt, i, shared_moduli[i], corder);
+    }
     if (per_element_values.empty())
-        return ct; // template path: K-element shell, zeros in each tower
+        return ct; // template path: K-element shell at trace moduli, zeros in each tower
     if (per_element_values.size() != k_count) {
         std::ostringstream body;
         body << "synthesize_haze_array_ciphertext: per_element_values.size()="
@@ -315,9 +343,17 @@ lbcrypto::Ciphertext<DCRTPoly>
 synthesize_for_shape(const Context &ctx, const niobium::CapturedShape &shape,
                      const std::vector<std::vector<uint64_t>> &per_residue_values) {
     switch (shape.kind) {
-    case niobium::CapturedKind::SRP:
-        return synthesize_haze_ciphertext(
-            ctx, per_residue_values.empty() ? std::vector<uint64_t>{} : per_residue_values.front());
+    case niobium::CapturedKind::SRP: {
+        // SRP shape carries one element with one modulus; kCopyModulus when
+        // the address was never modulus-bound (raw opaque buffer).
+        const uint64_t modulus =
+            (shape.per_element_moduli.empty() || shape.per_element_moduli.front().empty())
+                ? kCopyModulus
+                : shape.per_element_moduli.front().front();
+        return synthesize_haze_ciphertext(ctx, modulus,
+                                          per_residue_values.empty() ? std::vector<uint64_t>{}
+                                                                     : per_residue_values.front());
+    }
     case niobium::CapturedKind::MRP:
         return synthesize_haze_mrp_ciphertext(ctx, shape.per_element_moduli.front(),
                                               per_residue_values);
@@ -392,80 +428,6 @@ const Context *context_for_shape(const HookCtx &hctx,
     return &ins->second;
 }
 
-// After fhetch 55fd616, reconstruct fills output templates via SetValues
-// without rebuilding params, so each template tower's modulus must already
-// equal the trace modulus. The synthetic per-shape context (Init path) is
-// built from bit-widths, so GenCryptoContext's primes won't match — install
-// the exact trace moduli. Towers already at the right modulus are left
-// untouched so their precomputed params stay byte-identical; COPY_MODULUS / 0
-// towers carry no real modulus and keep the template's.
-void install_trace_output_moduli(lbcrypto::Ciphertext<DCRTPoly> &ct,
-                                 const niobium::CapturedShape &shape, uint64_t ring_dim) {
-    const auto corder = static_cast<uint32_t>(2 * ring_dim);
-    auto &elements = ct->GetElements();
-    // synthesize_for_shape builds one CT element per per_element_moduli entry
-    // and trims each to its moduli-list length, so the two stay in lockstep.
-    if (elements.size() != shape.per_element_moduli.size())
-        throw std::runtime_error("install_trace_output_moduli: element/shape count mismatch");
-    for (size_t e = 0; e < elements.size(); ++e) {
-        const auto &moduli = shape.per_element_moduli[e];
-        auto &towers = elements[e].GetAllElements();
-        if (towers.size() != moduli.size())
-            throw std::runtime_error("install_trace_output_moduli: tower/moduli count mismatch");
-        for (size_t t = 0; t < moduli.size(); ++t) {
-            const uint64_t q = moduli[t];
-            if (q == 0 || q == kCopyModulus)
-                continue;
-            if (towers[t].GetModulus().ConvertToInt() == q)
-                continue;
-            const auto root =
-                lbcrypto::RootOfUnity<lbcrypto::NativeInteger>(corder, lbcrypto::NativeInteger(q));
-            elements[e].SwitchModulusAtIndex(t, DCRTPoly::Integer(q),
-                                             DCRTPoly::Integer(root.ConvertToInt()));
-        }
-    }
-}
-
-// Input counterpart of install_trace_output_moduli, but value-preserving:
-// inputs carry real residues. SwitchModulusAtIndex recenters values (right
-// for zeroed templates, wrong for data), so snapshot the raw residues, switch
-// the tower params, then restore them. Otherwise the .bin towers keep the
-// synthetic CC's prime and a --niobium_hw replay Montgomery-encodes with the
-// wrong modulus.
-void install_trace_input_moduli(lbcrypto::Ciphertext<DCRTPoly> &ct,
-                                const niobium::CapturedShape &shape, uint64_t ring_dim) {
-    const auto corder = static_cast<uint32_t>(2 * ring_dim);
-    auto &elements = ct->GetElements();
-    if (elements.size() != shape.per_element_moduli.size())
-        throw std::runtime_error("install_trace_input_moduli: element/shape count mismatch");
-    for (size_t e = 0; e < elements.size(); ++e) {
-        const auto &moduli = shape.per_element_moduli[e];
-        auto &towers = elements[e].GetAllElements();
-        if (towers.size() != moduli.size())
-            throw std::runtime_error("install_trace_input_moduli: tower/moduli count mismatch");
-        for (size_t t = 0; t < moduli.size(); ++t) {
-            const uint64_t q = moduli[t];
-            if (q == 0 || q == kCopyModulus)
-                continue;
-            if (towers[t].GetModulus().ConvertToInt() == q)
-                continue;
-            const size_t n = towers[t].GetLength();
-            std::vector<uint64_t> raw(n);
-            const auto &vals = towers[t].GetValues();
-            for (size_t i = 0; i < n; ++i)
-                raw[i] = vals[i].ConvertToInt();
-            const auto root =
-                lbcrypto::RootOfUnity<lbcrypto::NativeInteger>(corder, lbcrypto::NativeInteger(q));
-            elements[e].SwitchModulusAtIndex(t, DCRTPoly::Integer(q),
-                                             DCRTPoly::Integer(root.ConvertToInt()));
-            // Captured residues are already reduced mod q, so a verbatim
-            // refill restores them under the freshly-installed modulus.
-            fill_native_poly(elements[e].GetAllElements()[t], raw,
-                             "install_trace_input_moduli[tower " + std::to_string(t) + "]");
-        }
-    }
-}
-
 // LOAD-BEARING. Runs between stop_recording and reconstruct to produce the
 // OpenFHE artifacts the replay path needs. local_cache is per-call.
 void on_post_recording(const HookCtx &hctx) {
@@ -482,11 +444,13 @@ void on_post_recording(const HookCtx &hctx) {
                 log_hook_error("input '" + rec.name + "': no CC available for shape");
                 return;
             }
-            auto ct = synthesize_for_shape(*ctx, rec.shape, rec.per_residue_values);
+            // synthesize_for_shape rebases each tower to its trace modulus
+            // before filling, so the .bin carries the exact trace primes.
             // [[clang::suppress]]: the analyzer reports divide-by-zero /
             // shift-overflow on paths inside OpenFHE's ubintnat.h reached
-            // via RootOfUnity; q == 0 is guarded before any such call.
-            [[clang::suppress]] install_trace_input_moduli(ct, rec.shape, hctx.ring_dim);
+            // via RootOfUnity; q == 0 / sentinel is guarded before any call.
+            [[clang::suppress]] auto ct =
+                synthesize_for_shape(*ctx, rec.shape, rec.per_residue_values);
             if (!niobium::detail::write_ciphertext_input_bin(rec.name, ct, rec.addr_ids)) {
                 log_hook_error("write_ciphertext_input_bin failed for '" + rec.name + "'");
             }
@@ -503,10 +467,12 @@ void on_post_recording(const HookCtx &hctx) {
                     log_hook_error("output '" + name + "': no CC available for shape");
                     return;
                 }
-                auto ct = synthesize_for_shape(*ctx, shape, /*per_residue_values=*/{});
-                // [[clang::suppress]]: same ubintnat.h analyzer false
-                // positives as the input-moduli install above.
-                [[clang::suppress]] install_trace_output_moduli(ct, shape, hctx.ring_dim);
+                // Template towers are rebased to the trace moduli in
+                // synthesize_for_shape (on zeros), so the driver's SetValues
+                // matches without a post-hoc install. [[clang::suppress]]:
+                // same ubintnat.h RootOfUnity analyzer false positives.
+                [[clang::suppress]] auto ct =
+                    synthesize_for_shape(*ctx, shape, /*per_residue_values=*/{});
                 if (!niobium::detail::write_ciphertext_template(name, ct)) {
                     log_hook_error("write_ciphertext_template failed for '" + name + "'");
                 }

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -204,7 +204,9 @@ void switch_tower_modulus(lbcrypto::DCRTPoly &elem, size_t t, uint64_t q, uint32
         return;
     if (elem.GetAllElements()[t].GetModulus().ConvertToInt() == q)
         return;
-    const auto root =
+    // [[clang::suppress]]: ubintnat.h divide-by-zero / shift-overflow false
+    // positives reached via RootOfUnity; q is guarded non-zero/non-sentinel above.
+    [[clang::suppress]] const auto root =
         lbcrypto::RootOfUnity<lbcrypto::NativeInteger>(corder, lbcrypto::NativeInteger(q));
     elem.SwitchModulusAtIndex(t, DCRTPoly::Integer(q), DCRTPoly::Integer(root.ConvertToInt()));
 }
@@ -437,11 +439,9 @@ void on_post_recording(const HookCtx &hctx) {
                 log_hook_error("input '" + rec.name + "': no CC available for shape");
                 return;
             }
-            // [[clang::suppress]]: the analyzer reports divide-by-zero /
-            // shift-overflow on ubintnat.h paths reached via RootOfUnity (in
-            // switch_tower_modulus); q == 0 / sentinel is guarded before any call.
-            [[clang::suppress]] auto ct =
-                synthesize_for_shape(*ctx, rec.shape, rec.per_residue_values);
+            // synthesize_for_shape rebases towers to the trace primes, so the
+            // .bin carries the exact moduli (see switch_tower_modulus).
+            auto ct = synthesize_for_shape(*ctx, rec.shape, rec.per_residue_values);
             if (!niobium::detail::write_ciphertext_input_bin(rec.name, ct, rec.addr_ids)) {
                 log_hook_error("write_ciphertext_input_bin failed for '" + rec.name + "'");
             }
@@ -460,9 +460,7 @@ void on_post_recording(const HookCtx &hctx) {
                 }
                 // Template towers carry the trace moduli from synthesize, so
                 // the driver's SetValues matches with no post-hoc install.
-                // [[clang::suppress]]: same RootOfUnity analyzer noise as inputs.
-                [[clang::suppress]] auto ct =
-                    synthesize_for_shape(*ctx, shape, /*per_residue_values=*/{});
+                auto ct = synthesize_for_shape(*ctx, shape, /*per_residue_values=*/{});
                 if (!niobium::detail::write_ciphertext_template(name, ct)) {
                     log_hook_error("write_ciphertext_template failed for '" + name + "'");
                 }

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -72,6 +72,8 @@ bool CompilerBackend::ensure_initialized() noexcept {
         std::string target_arg_storage = "--target=" + target;
         std::string montgomery_arg_storage = "--montgomery";
         std::string bitrev_arg_storage = "--bit_reversal";
+        // 5 = prog + --target + the two optional format flags + NULL terminator
+        // (grow this if another optional flag is added).
         char *argv[5] = {prog_storage.data(), target_arg_storage.data(), nullptr, nullptr, nullptr};
         int argc = 2;
         if (montgomery)

--- a/src/core/compute.hpp
+++ b/src/core/compute.hpp
@@ -44,7 +44,7 @@ std::expected<void, HazeInternalError> binary_pp_op(DevAddr dst, DevAddr src1, D
     auto p2 = epoch().lookup_or_create_locked(src2);
     if (!p2)
         return std::unexpected(p2.error());
-    epoch().store_compute_result_locked(dst, OpFn(*p1, *p2, q));
+    epoch().store_compute_result_locked(dst, OpFn(*p1, *p2, q), q);
     return {};
 }
 
@@ -59,8 +59,8 @@ std::expected<void, HazeInternalError> binary_ps_op(DevAddr dst, DevAddr src, ui
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
         return std::unexpected(p.error());
-    epoch().store_compute_result_locked(dst,
-                                        OpFn(*p, niobium::fhetch::Scalar::from_int(scalar), q));
+    epoch().store_compute_result_locked(dst, OpFn(*p, niobium::fhetch::Scalar::from_int(scalar), q),
+                                        q);
     return {};
 }
 
@@ -74,11 +74,15 @@ std::expected<void, HazeInternalError> unary_pq_op(DevAddr dst, DevAddr src, int
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
         return std::unexpected(p.error());
-    epoch().store_compute_result_locked(dst, OpFn(*p, q));
+    epoch().store_compute_result_locked(dst, OpFn(*p, q), q);
     return {};
 }
 
-// Polynomial-index. Used by hazeAutomorph.
+// Polynomial-index. Used by hazeAutomorph. The eval-form automorph is a pure
+// slot permutation (value-independent of the modulus), so the op carries the
+// COPY sentinel; recover the source's recorded modulus and bind it as
+// metadata on source + result so a tagged SRP automorph is probe-serializable
+// on transport (matching the MRP automorph, which binds base[i]).
 template <auto OpFn>
 std::expected<void, HazeInternalError> unary_pi_op(DevAddr dst, DevAddr src,
                                                    uint64_t index) noexcept {
@@ -86,7 +90,13 @@ std::expected<void, HazeInternalError> unary_pi_op(DevAddr dst, DevAddr src,
     auto p = epoch().lookup_or_create_locked(src);
     if (!p)
         return std::unexpected(p.error());
-    epoch().store_compute_result_locked(dst, OpFn(*p, index));
+    const uint64_t q = epoch().recorded_modulus_locked(src);
+    auto result = OpFn(*p, index);
+    if (q != kCopyModulus) {
+        niobium::fhetch::bind_modulus(*p, q);
+        niobium::fhetch::bind_modulus(result, q);
+    }
+    epoch().store_compute_result_locked(dst, std::move(result), q);
     return {};
 }
 

--- a/src/core/compute.hpp
+++ b/src/core/compute.hpp
@@ -78,11 +78,10 @@ std::expected<void, HazeInternalError> unary_pq_op(DevAddr dst, DevAddr src, int
     return {};
 }
 
-// Polynomial-index. Used by hazeAutomorph. The eval-form automorph is a pure
-// slot permutation (value-independent of the modulus), so the op carries the
-// COPY sentinel; recover the source's recorded modulus and bind it as
-// metadata on source + result so a tagged SRP automorph is probe-serializable
-// on transport (matching the MRP automorph, which binds base[i]).
+// Polynomial-index (hazeAutomorph). The eval-form automorph is a pure slot
+// permutation, so the op carries the COPY sentinel; recover the source's
+// recorded modulus and bind it (source + result) so a tagged SRP automorph is
+// probe-serializable on transport.
 template <auto OpFn>
 std::expected<void, HazeInternalError> unary_pi_op(DevAddr dst, DevAddr src,
                                                    uint64_t index) noexcept {

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -39,10 +39,6 @@ namespace haze {
 
 namespace fhetch = niobium::fhetch;
 
-// The modulus-independent copy sentinel (kCopyModulus, in epoch.hpp): the
-// simulator reads it as "no reduction", so sr_addps(x, 0, kCopyModulus) is a
-// pure copy.
-
 EpochState &EpochState::instance() noexcept {
     static EpochState inst;
     return inst;
@@ -132,10 +128,8 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
 void EpochState::store_compute_result_locked(DevAddr addr, niobium::fhetch::Polynomial poly,
                                              uint64_t modulus) noexcept {
     poly_map_.insert_or_assign(addr, std::move(poly));
-    // Track the residue's real modulus so a later modulus-less copy/automorph
-    // of this address can recover it. A result whose op had no modulus
-    // (kCopyModulus) drops any stale entry rather than keeping the previous
-    // occupant's value.
+    // A no-modulus (kCopyModulus) result drops any stale entry so a later
+    // copy/automorph can't recover a previous occupant's modulus here.
     if (modulus != kCopyModulus)
         addr_modulus_.insert_or_assign(addr, modulus);
     else
@@ -177,12 +171,9 @@ std::expected<void, HazeInternalError> EpochState::tag_output_locked(DevAddr add
 
 std::expected<void, HazeInternalError> EpochState::copy_result_locked(DevAddr dst, DevAddr src,
                                                                       uint64_t modulus) noexcept {
-    // The op always carries the COPY sentinel (the executor lowers ADDI imm=0
-    // at modulus-table index 0 as a register copy). The residue's real modulus
-    // rides as address->modulus metadata so the output can be probe-serialized:
-    // the caller supplies it (MRP D2D passes base[i]), else it's recovered from
-    // the source's recorded modulus (a compute-produced SRP value carries one).
-    // Only a never-modulus-bound source (raw opaque H2D buffer) stays sentinel.
+    // The op carries the COPY sentinel (the executor lowers ADDI imm=0 at
+    // modulus-table index 0 as a register copy); the real modulus rides as
+    // metadata. Recover it from the source when the caller passed none.
     auto src_poly = lookup_or_create_locked(src);
     if (!src_poly)
         return std::unexpected(src_poly.error());

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -181,10 +181,12 @@ std::expected<void, HazeInternalError> EpochState::copy_result_locked(DevAddr ds
         modulus = recorded_modulus_locked(src);
     auto copy = fhetch::sr_addps(*src_poly, fhetch::Scalar::from_int(0), kCopyModulus);
     if (modulus != kCopyModulus) {
-        // Bind the source too: one only ever touched by copies would
-        // otherwise stay sentinel-bound and load under the synthetic prime.
+        // Bind the source too (a node only touched by copies would otherwise
+        // stay sentinel-bound), and record src's modulus to match the binding
+        // so a later copy/automorph of src recovers it.
         fhetch::bind_modulus(*src_poly, modulus);
         fhetch::bind_modulus(copy, modulus);
+        addr_modulus_.insert_or_assign(src, modulus);
     }
     store_compute_result_locked(dst, std::move(copy), modulus);
     return {};

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -39,9 +39,9 @@ namespace haze {
 
 namespace fhetch = niobium::fhetch;
 
-// fhetch's modulus-independent copy sentinel (TraceWriter COPY_MODULUS_VALUE)
-// lives as copy_result_locked's default argument in epoch.hpp: the simulator
-// reads it as "no reduction", so sr_addps(x, 0, sentinel) is a pure copy.
+// The modulus-independent copy sentinel (kCopyModulus, in epoch.hpp): the
+// simulator reads it as "no reduction", so sr_addps(x, 0, kCopyModulus) is a
+// pure copy.
 
 EpochState &EpochState::instance() noexcept {
     static EpochState inst;
@@ -94,6 +94,7 @@ void EpochState::invalidate(DevAddr addr) noexcept {
     // unconditional double-erase is simpler than tagging addrs by owner.
     poly_map_.erase(addr);
     pending_outputs_.erase(addr);
+    addr_modulus_.erase(addr);
     // A recycled allocation leading a new group gets a fresh name rather
     // than colliding with a possibly-pending group from its previous life.
     mrp_in_names_.erase(addr);
@@ -128,9 +129,22 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
     return poly;
 }
 
-void EpochState::store_compute_result_locked(DevAddr addr,
-                                             niobium::fhetch::Polynomial poly) noexcept {
+void EpochState::store_compute_result_locked(DevAddr addr, niobium::fhetch::Polynomial poly,
+                                             uint64_t modulus) noexcept {
     poly_map_.insert_or_assign(addr, std::move(poly));
+    // Track the residue's real modulus so a later modulus-less copy/automorph
+    // of this address can recover it. A result whose op had no modulus
+    // (kCopyModulus) drops any stale entry rather than keeping the previous
+    // occupant's value.
+    if (modulus != kCopyModulus)
+        addr_modulus_.insert_or_assign(addr, modulus);
+    else
+        addr_modulus_.erase(addr);
+}
+
+uint64_t EpochState::recorded_modulus_locked(DevAddr addr) const noexcept {
+    auto it = addr_modulus_.find(addr);
+    return it == addr_modulus_.end() ? kCopyModulus : it->second;
 }
 
 std::expected<void, HazeInternalError> EpochState::tag_output_locked(DevAddr addr) {
@@ -164,21 +178,24 @@ std::expected<void, HazeInternalError> EpochState::tag_output_locked(DevAddr add
 std::expected<void, HazeInternalError> EpochState::copy_result_locked(DevAddr dst, DevAddr src,
                                                                       uint64_t modulus) noexcept {
     // The op always carries the COPY sentinel (the executor lowers ADDI imm=0
-    // at modulus-table index 0 as a register copy). When the caller
-    // knows the residue's real modulus (MRP D2D passes base[i]), bind it as
-    // address->modulus metadata so the output can be probe-serialized.
+    // at modulus-table index 0 as a register copy). The residue's real modulus
+    // rides as address->modulus metadata so the output can be probe-serialized:
+    // the caller supplies it (MRP D2D passes base[i]), else it's recovered from
+    // the source's recorded modulus (a compute-produced SRP value carries one).
+    // Only a never-modulus-bound source (raw opaque H2D buffer) stays sentinel.
     auto src_poly = lookup_or_create_locked(src);
     if (!src_poly)
         return std::unexpected(src_poly.error());
-    constexpr uint64_t kSentinel = 0xFFFFFFFFFFFFFFFFULL;
-    auto copy = fhetch::sr_addps(*src_poly, fhetch::Scalar::from_int(0), kSentinel);
-    if (modulus != kSentinel) {
+    if (modulus == kCopyModulus)
+        modulus = recorded_modulus_locked(src);
+    auto copy = fhetch::sr_addps(*src_poly, fhetch::Scalar::from_int(0), kCopyModulus);
+    if (modulus != kCopyModulus) {
         // Bind the source too: one only ever touched by copies would
         // otherwise stay sentinel-bound and load under the synthetic prime.
         fhetch::bind_modulus(*src_poly, modulus);
         fhetch::bind_modulus(copy, modulus);
     }
-    store_compute_result_locked(dst, std::move(copy));
+    store_compute_result_locked(dst, std::move(copy), modulus);
     return {};
 }
 
@@ -449,6 +466,7 @@ std::expected<void, HazeInternalError> EpochState::do_materialize_locked(bool ru
 void EpochState::clear_state_locked() noexcept {
     poly_map_.clear();
     pending_outputs_.clear();
+    addr_modulus_.clear();
     known_mrp_groups_.clear();
     pending_mrp_groups_.clear();
     addr_to_mrp_groups_.clear();

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -29,9 +29,8 @@
 
 namespace haze {
 
-// fhetch's modulus-independent copy sentinel (TraceWriter COPY_MODULUS_VALUE):
-// the executor lowers ADDI imm=0 at modulus-table index 0 as a register copy.
-// Used as the "modulus unknown" marker for the addr->modulus tracking below.
+// fhetch's copy sentinel (TraceWriter COPY_MODULUS_VALUE); doubles as the
+// "modulus unknown" marker for the addr->modulus tracking below.
 inline constexpr uint64_t kCopyModulus = 0xFFFFFFFFFFFFFFFFULL;
 
 // Singleton tracking the polymap, pending outputs, and recording flag for
@@ -88,9 +87,7 @@ class EpochState {
         HAZE_REQUIRES(mutex_);
 
     // Real modulus last recorded for `addr` by a modulus-carrying op, or
-    // kCopyModulus if none is known (raw input, or a result whose op had no
-    // modulus). Lets the modulus-less SRP copy/automorph paths recover the
-    // source's modulus instead of falling back to the bridge's scaffold prime.
+    // kCopyModulus if none (raw input, or a result whose op had no modulus).
     uint64_t recorded_modulus_locked(DevAddr addr) const noexcept HAZE_REQUIRES(mutex_);
 
     // Declare `addr` an output (idempotent); it must name a value bound in
@@ -172,10 +169,8 @@ class EpochState {
     // pending_outputs_ is the addr-keyed subset that names the outputs.
     std::unordered_map<DevAddr, niobium::fhetch::Polynomial> poly_map_ HAZE_GUARDED_BY(mutex_);
     std::unordered_map<DevAddr, std::string> pending_outputs_ HAZE_GUARDED_BY(mutex_);
-    // addr -> real modulus recorded by the last modulus-carrying op that wrote
-    // it; consulted by copy_result_locked / the SRP automorph to recover a
-    // source modulus. Kept in lockstep with poly_map_ writes; cleared per
-    // epoch and dropped on invalidate.
+    // addr -> real modulus from the last modulus-carrying op that wrote it.
+    // Kept in lockstep with poly_map_; cleared per epoch, dropped on invalidate.
     std::unordered_map<DevAddr, uint64_t> addr_modulus_ HAZE_GUARDED_BY(mutex_);
     // MRP-shaped output groupings, keyed by leading-dst-derived name.
     // Registration is latest-write-wins — identical re-registration is a

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -29,6 +29,11 @@
 
 namespace haze {
 
+// fhetch's modulus-independent copy sentinel (TraceWriter COPY_MODULUS_VALUE):
+// the executor lowers ADDI imm=0 at modulus-table index 0 as a register copy.
+// Used as the "modulus unknown" marker for the addr->modulus tracking below.
+inline constexpr uint64_t kCopyModulus = 0xFFFFFFFFFFFFFFFFULL;
+
 // Singleton tracking the polymap, pending outputs, and recording flag for
 // the active epoch; replay_and_populate() drains it at flush time. Public
 // methods take mutex_; _locked variants require it held via EpochSession
@@ -74,9 +79,19 @@ class EpochState {
     lookup_or_create_locked(DevAddr addr) HAZE_REQUIRES(mutex_);
 
     // Bind `addr` to `poly`. Output-hood is declared explicitly via
-    // tag_output_locked, not inferred from being computed.
-    void store_compute_result_locked(DevAddr addr, niobium::fhetch::Polynomial poly) noexcept
+    // tag_output_locked, not inferred from being computed. `modulus` records
+    // the residue's real modulus (kCopyModulus = "unknown") so a later
+    // pass-through copy / eval-form automorph of this address can recover and
+    // bind it; see recorded_modulus_locked.
+    void store_compute_result_locked(DevAddr addr, niobium::fhetch::Polynomial poly,
+                                     uint64_t modulus = kCopyModulus) noexcept
         HAZE_REQUIRES(mutex_);
+
+    // Real modulus last recorded for `addr` by a modulus-carrying op, or
+    // kCopyModulus if none is known (raw input, or a result whose op had no
+    // modulus). Lets the modulus-less SRP copy/automorph paths recover the
+    // source's modulus instead of falling back to the bridge's scaffold prime.
+    uint64_t recorded_modulus_locked(DevAddr addr) const noexcept HAZE_REQUIRES(mutex_);
 
     // Declare `addr` an output (idempotent); it must name a value bound in
     // poly_map_ or it is a caller error. Tagging any residue of a known MRP
@@ -84,11 +99,13 @@ class EpochState {
     std::expected<void, HazeInternalError> tag_output_locked(DevAddr addr) HAZE_REQUIRES(mutex_);
 
     // Record a pass-through copy dst <- src. Pass the residue's real modulus
-    // when known (MRP D2D has base[i]) so the output can be probe-serialized
-    // on transport; the sentinel default covers the SRP D2D path (opaque
-    // buffer, no modulus known) on the local simulator.
+    // when the caller knows it (MRP D2D has base[i]); otherwise the modulus is
+    // recovered from the source's recorded_modulus_locked, so a copy of a
+    // compute-produced (or otherwise modulus-bound) SRP value is still
+    // probe-serializable on transport. Only a copy of a never-modulus-bound
+    // address (raw opaque H2D buffer) stays sentinel-only.
     std::expected<void, HazeInternalError>
-    copy_result_locked(DevAddr dst, DevAddr src, uint64_t modulus = 0xFFFFFFFFFFFFFFFFULL) noexcept
+    copy_result_locked(DevAddr dst, DevAddr src, uint64_t modulus = kCopyModulus) noexcept
         HAZE_REQUIRES(mutex_);
 
     // Eagerly tag the H2D'd shadow bytes at `addr` as a fhetch input.
@@ -155,6 +172,11 @@ class EpochState {
     // pending_outputs_ is the addr-keyed subset that names the outputs.
     std::unordered_map<DevAddr, niobium::fhetch::Polynomial> poly_map_ HAZE_GUARDED_BY(mutex_);
     std::unordered_map<DevAddr, std::string> pending_outputs_ HAZE_GUARDED_BY(mutex_);
+    // addr -> real modulus recorded by the last modulus-carrying op that wrote
+    // it; consulted by copy_result_locked / the SRP automorph to recover a
+    // source modulus. Kept in lockstep with poly_map_ writes; cleared per
+    // epoch and dropped on invalidate.
+    std::unordered_map<DevAddr, uint64_t> addr_modulus_ HAZE_GUARDED_BY(mutex_);
     // MRP-shaped output groupings, keyed by leading-dst-derived name.
     // Registration is latest-write-wins — identical re-registration is a
     // no-op, a different-shaped registration replaces the group and evicts

--- a/src/core/mrp_polymap.cpp
+++ b/src/core/mrp_polymap.cpp
@@ -65,7 +65,7 @@ std::expected<void, HazeInternalError> store_mrp_locked(void *const *dst_polys,
     addrs.reserve(len);
     for (std::size_t i = 0; i < len; ++i) {
         DevAddr a = to_dev_addr(dst_polys[i]);
-        epoch().store_compute_result_locked(a, mrp[base[i]]);
+        epoch().store_compute_result_locked(a, mrp[base[i]], base[i]);
         addrs.push_back(a);
     }
     if (len > 1) {

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -17,9 +17,30 @@
 
 namespace haze::test {
 
-// Combined integration setup: reset, ring dim, bridge CC init, align haze's
-// ciphertext modulus with OpenFHE's picked prime, configure device. Returns
-// the picked modulus so callers stay in lockstep with the .ct round-trip.
+// MODULUS CONTRACT:
+// For ops that carry a real modulus, the .fhetch trace's modulus table is
+// authoritative: both replay paths reconstruct under it — the in-process
+// simulator rebuilds each NativePoly's params from the trace modulus
+// (libnbfhetch auto_facade), and the transport bridge re-installs the trace
+// moduli onto input .bin towers and output templates (install_trace_*_moduli).
+// Verified by "trace modulus is authoritative ..." in test_hardware_format.cpp,
+// which sets the trace modulus to a prime distinct from the one the bridge's
+// scaffold cryptocontext.dat is built around and confirms the result tracks the
+// trace.
+//
+// EXCEPTION — modulus-less SRP ops: an opaque SRP hazeMemcpy(D2D) and a bare
+// SRP hazeAutomorph emit the COPY_MODULUS sentinel with no real modulus to
+// bind, so their OUTPUT template falls back to the bridge's scaffold prime
+// (the one hazeReplayBridgeInitCryptoContext "picks"). For those the trace is
+// NOT authoritative, so this setup aligns slot 0 to the scaffold prime and
+// returns it: tests then generate inputs and oracles against the same value
+// and the modulus-less outputs stay consistent. (Tests that only use
+// modulus-carrying ops would work with any prime; the MRP variants of copy /
+// automorph bind base[i] and are trace-authoritative.)
+
+// Combined integration setup: reset, ring dim, bridge CC init, align slot to
+// the bridge's scaffold prime (see contract above), configure device. Returns
+// that prime so callers stay in lockstep with the .ct round-trip.
 inline uint64_t setup_integration_compute_config(uint64_t ring_dim = 4096,
                                                  uint64_t desired_modulus = 576460752303415297ULL,
                                                  int mod_idx = 0) {
@@ -33,12 +54,11 @@ inline uint64_t setup_integration_compute_config(uint64_t ring_dim = 4096,
     return picked;
 }
 
-// Three-prime variant of the setup above for MRP cases: same sequence, all
-// three modulus slots set before the single hazeConfigureDevice. Slots 1 and
-// 2 get the suite's standard NTT-friendly companion primes; slot 0 gets the
-// bridge-picked prime (not the raw request) so callers stay in lockstep with
-// the .ct round-trip even if the bridge ever picks a different prime.
-// Returns the configured base, index-aligned with the modulus slots.
+// Three-prime variant for MRP cases: all three slots set before the single
+// hazeConfigureDevice. Slot 0 is the bridge's scaffold prime (see the
+// modulus-less exception in the contract above); slots 1 and 2 are the suite's
+// NTT-friendly companion primes. Returns the configured base, index-aligned
+// with the modulus slots.
 inline std::vector<uint64_t>
 setup_integration_mrp3_config(uint64_t ring_dim = 4096,
                               uint64_t desired_modulus = 576460752303415297ULL) {

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -20,7 +20,8 @@ namespace haze::test {
 // MODULUS CONTRACT (single source of truth): the values passed to
 // hazeSetCiphertextModulus ARE the .fhetch trace moduli, and both replay paths
 // reconstruct under them; hazeReplayBridgeInitCryptoContext's scaffold prime is
-// overwritten at reconstruct and never consulted for results. So tests set the
+// overwritten with the trace primes at synthesis (bridge switch_tower_modulus)
+// and never consulted for results. So tests set the
 // slot to the intended prime and oracle against it (verified by "trace modulus
 // is authoritative ..." in test_hardware_format.cpp). Modulus-less SRP ops are
 // trace-authoritative too — haze recovers and binds the source modulus — except

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -17,63 +17,58 @@
 
 namespace haze::test {
 
-// MODULUS CONTRACT:
-// For ops that carry a real modulus, the .fhetch trace's modulus table is
-// authoritative: both replay paths reconstruct under it — the in-process
-// simulator rebuilds each NativePoly's params from the trace modulus
-// (libnbfhetch auto_facade), and the transport bridge re-installs the trace
-// moduli onto input .bin towers and output templates (install_trace_*_moduli).
-// Verified by "trace modulus is authoritative ..." in test_hardware_format.cpp,
-// which sets the trace modulus to a prime distinct from the one the bridge's
-// scaffold cryptocontext.dat is built around and confirms the result tracks the
-// trace.
+// MODULUS CONTRACT (single source of truth):
+// The .fhetch trace's modulus table is authoritative for replay. The values
+// passed to hazeSetCiphertextModulus ARE the trace moduli; both replay paths
+// reconstruct under them — the in-process simulator rebuilds each NativePoly's
+// params from the trace modulus (libnbfhetch auto_facade), and the transport
+// bridge re-installs the trace moduli onto input .bin towers and output
+// templates (install_trace_*_moduli). hazeReplayBridgeInitCryptoContext only
+// builds a scaffold cryptocontext.dat whose OpenFHE-generated prime is
+// overwritten at reconstruct time, so it is NOT consulted for results — tests
+// use the intended prime directly and compute oracles against the same value.
+// Verified by "trace modulus is authoritative ..." in test_hardware_format.cpp
+// (sets the trace modulus to a prime distinct from desired and from the
+// scaffold prime; result tracks the trace).
 //
-// EXCEPTION — modulus-less SRP ops: an opaque SRP hazeMemcpy(D2D) and a bare
-// SRP hazeAutomorph emit the COPY_MODULUS sentinel with no real modulus to
-// bind, so their OUTPUT template falls back to the bridge's scaffold prime
-// (the one hazeReplayBridgeInitCryptoContext "picks"). For those the trace is
-// NOT authoritative, so this setup aligns slot 0 to the scaffold prime and
-// returns it: tests then generate inputs and oracles against the same value
-// and the modulus-less outputs stay consistent. (Tests that only use
-// modulus-carrying ops would work with any prime; the MRP variants of copy /
-// automorph bind base[i] and are trace-authoritative.)
+// Modulus-less SRP ops (opaque hazeMemcpy(D2D), bare hazeAutomorph) emit the
+// COPY_MODULUS sentinel, but haze recovers the source's recorded modulus and
+// binds it (epoch.cpp copy_result_locked / unary_pi_op), so they are
+// trace-authoritative too. Only a copy of a never-modulus-bound address (raw
+// opaque H2D buffer) has no modulus to recover.
 
-// Combined integration setup: reset, ring dim, bridge CC init, align slot to
-// the bridge's scaffold prime (see contract above), configure device. Returns
-// that prime so callers stay in lockstep with the .ct round-trip.
+// Combined integration setup: reset, ring dim, bridge CC init, set the
+// ciphertext modulus, configure device. Returns the modulus it set so callers
+// generate inputs and oracles against the same (authoritative) value.
 inline uint64_t setup_integration_compute_config(uint64_t ring_dim = 4096,
-                                                 uint64_t desired_modulus = 576460752303415297ULL,
+                                                 uint64_t modulus = 576460752303415297ULL,
                                                  int mod_idx = 0) {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
-    uint64_t picked = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, desired_modulus, &picked) == HAZE_SUCCESS);
-    REQUIRE(picked != 0);
-    REQUIRE(hazeSetCiphertextModulus(mod_idx, picked) == HAZE_SUCCESS);
+    uint64_t scaffold = 0; // built then overwritten from the trace; not used for results
+    REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, modulus, &scaffold) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(mod_idx, modulus) == HAZE_SUCCESS);
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
-    return picked;
+    return modulus;
 }
 
 // Three-prime variant for MRP cases: all three slots set before the single
-// hazeConfigureDevice. Slot 0 is the bridge's scaffold prime (see the
-// modulus-less exception in the contract above); slots 1 and 2 are the suite's
-// NTT-friendly companion primes. Returns the configured base, index-aligned
-// with the modulus slots.
+// hazeConfigureDevice, each to its intended (trace-authoritative) prime: slot
+// 0 the requested modulus, slots 1 and 2 the suite's NTT-friendly companion
+// primes. Returns the configured base, index-aligned with the modulus slots.
 inline std::vector<uint64_t>
-setup_integration_mrp3_config(uint64_t ring_dim = 4096,
-                              uint64_t desired_modulus = 576460752303415297ULL) {
+setup_integration_mrp3_config(uint64_t ring_dim = 4096, uint64_t modulus = 576460752303415297ULL) {
     constexpr uint64_t kQ1 = 576460752303439873ULL;
     constexpr uint64_t kQ2 = 576460752303702017ULL;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
-    uint64_t picked = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, desired_modulus, &picked) == HAZE_SUCCESS);
-    REQUIRE(picked != 0);
-    REQUIRE(hazeSetCiphertextModulus(0, picked) == HAZE_SUCCESS);
+    uint64_t scaffold = 0; // built then overwritten from the trace; not used for results
+    REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, modulus, &scaffold) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(0, modulus) == HAZE_SUCCESS);
     REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
     REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
-    return {picked, kQ1, kQ2};
+    return {modulus, kQ1, kQ2};
 }
 
 // a + b mod q for a, b in [0, q): one conditional subtract, no overflow for

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -17,25 +17,14 @@
 
 namespace haze::test {
 
-// MODULUS CONTRACT (single source of truth):
-// The .fhetch trace's modulus table is authoritative for replay. The values
-// passed to hazeSetCiphertextModulus ARE the trace moduli; both replay paths
-// reconstruct under them — the in-process simulator rebuilds each NativePoly's
-// params from the trace modulus (libnbfhetch auto_facade), and the transport
-// bridge re-installs the trace moduli onto input .bin towers and output
-// templates (install_trace_*_moduli). hazeReplayBridgeInitCryptoContext only
-// builds a scaffold cryptocontext.dat whose OpenFHE-generated prime is
-// overwritten at reconstruct time, so it is NOT consulted for results — tests
-// use the intended prime directly and compute oracles against the same value.
-// Verified by "trace modulus is authoritative ..." in test_hardware_format.cpp
-// (sets the trace modulus to a prime distinct from desired and from the
-// scaffold prime; result tracks the trace).
-//
-// Modulus-less SRP ops (opaque hazeMemcpy(D2D), bare hazeAutomorph) emit the
-// COPY_MODULUS sentinel, but haze recovers the source's recorded modulus and
-// binds it (epoch.cpp copy_result_locked / unary_pi_op), so they are
-// trace-authoritative too. Only a copy of a never-modulus-bound address (raw
-// opaque H2D buffer) has no modulus to recover.
+// MODULUS CONTRACT (single source of truth): the values passed to
+// hazeSetCiphertextModulus ARE the .fhetch trace moduli, and both replay paths
+// reconstruct under them; hazeReplayBridgeInitCryptoContext's scaffold prime is
+// overwritten at reconstruct and never consulted for results. So tests set the
+// slot to the intended prime and oracle against it (verified by "trace modulus
+// is authoritative ..." in test_hardware_format.cpp). Modulus-less SRP ops are
+// trace-authoritative too — haze recovers and binds the source modulus — except
+// a copy of a never-modulus-bound (raw H2D) address, which has none.
 
 // Combined integration setup: reset, ring dim, bridge CC init, set the
 // ciphertext modulus, configure device. Returns the modulus it set so callers

--- a/test/test_d2d_copy.cpp
+++ b/test/test_d2d_copy.cpp
@@ -23,24 +23,6 @@ namespace {
 constexpr uint64_t kRingDim = 4096;
 constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
 
-// Three-prime MRP config for the hazeMemcpyMrp cases; returns the base
-// [picked, q1, q2] with picked the bridge-aligned prime for residue 0.
-std::vector<uint64_t> setup_mrp3_config() {
-    constexpr uint64_t kQ0 = 576460752303415297ULL;
-    constexpr uint64_t kQ1 = 576460752303439873ULL;
-    constexpr uint64_t kQ2 = 576460752303702017ULL;
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    uint64_t picked = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
-    REQUIRE(picked != 0);
-    REQUIRE(hazeSetCiphertextModulus(0, picked) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
-    return {picked, kQ1, kQ2};
-}
-
 } // namespace
 
 TEST_CASE("hazeMemcpy(D2D) copies a compute-produced polynomial via IR", "[integration]") {
@@ -214,7 +196,7 @@ TEST_CASE("hazeMemcpy(D2D) promotes an H2D'd source through the IR copy", "[inte
 }
 
 TEST_CASE("hazeMemcpyMrp(D2D) copies a compute-produced MRP via per-residue IR", "[integration]") {
-    const auto base = setup_mrp3_config();
+    const auto base = haze::test::setup_integration_mrp3_config();
     const std::vector<std::vector<uint64_t>> res = {
         haze::test::make_residue(base[0], /*seed=*/1, kRingDim),
         haze::test::make_residue(base[1], /*seed=*/2, kRingDim),
@@ -252,7 +234,7 @@ TEST_CASE("hazeMemcpyMrp(D2D) copies a compute-produced MRP via per-residue IR",
 
 TEST_CASE("hazeMemcpyMrp(D2D) promotes H2D'd sources and registers the output group",
           "[integration]") {
-    const auto base = setup_mrp3_config();
+    const auto base = haze::test::setup_integration_mrp3_config();
     const std::vector<std::vector<uint64_t>> res = {
         haze::test::make_residue(base[0], /*seed=*/4, kRingDim),
         haze::test::make_residue(base[1], /*seed=*/5, kRingDim),
@@ -283,7 +265,7 @@ TEST_CASE("hazeMemcpyMrp(D2D) promotes H2D'd sources and registers the output gr
 }
 
 TEST_CASE("hazeMemcpyMrp round-trips H2D then D2H per residue", "[integration]") {
-    const auto base = setup_mrp3_config();
+    const auto base = haze::test::setup_integration_mrp3_config();
     const std::vector<std::vector<uint64_t>> res = {
         haze::test::make_residue(base[0], /*seed=*/7, kRingDim),
         haze::test::make_residue(base[1], /*seed=*/8, kRingDim),
@@ -308,7 +290,7 @@ TEST_CASE("hazeMemcpyMrp round-trips H2D then D2H per residue", "[integration]")
 
 TEST_CASE("hazeMemcpyMrp(D2D) from a never-written source returns SOURCE_UNAVAILABLE",
           "[integration]") {
-    const auto base = setup_mrp3_config();
+    const auto base = haze::test::setup_integration_mrp3_config();
     auto src = haze::test::allocate_dst_residues(3, kBytes); // never written
     auto dst = haze::test::allocate_dst_residues(3, kBytes);
 
@@ -348,7 +330,7 @@ TEST_CASE("hazeMemcpyMrp(D2D) with base_len 1 copies without registering a group
 }
 
 TEST_CASE("hazeMemcpyMrp rejects malformed arguments", "[integration]") {
-    const auto base = setup_mrp3_config();
+    const auto base = haze::test::setup_integration_mrp3_config();
     auto dst = haze::test::allocate_dst_residues(3, kBytes);
     auto src = haze::test::allocate_dst_residues(3, kBytes);
     const auto csrc = haze::test::to_const(src);

--- a/test/test_d2d_copy.cpp
+++ b/test/test_d2d_copy.cpp
@@ -180,13 +180,10 @@ TEST_CASE("hazeMemcpy(D2D) promotes an H2D'd source through the IR copy", "[inte
     // which promotes the shadow bytes into a tagged fhetch input, then
     // emits the copy IR. Round-trip bytes must match the original H2D.
     //
-    // Transport limitation: this source is H2D'd raw and never touched by a
-    // modulus-carrying op, so haze has no recorded modulus to bind to the copy
-    // (a compute-produced source WOULD be recovered — see copy_result_locked).
-    // The copy output keeps the COPY sentinel, which the transport replay's
-    // trace-modulus contract rejects at probe serialization ("SetValues():
-    // Parameter mismatch"). Use hazeMemcpyMrp with a base (even base_len=1)
-    // when the residue's modulus is known — that path replays on FUNC_SIM.
+    // Transport limitation (the SKIP below): a raw-H2D source never touched by
+    // a modulus-carrying op has no recorded modulus, so the copy stays sentinel
+    // and isn't replayable. A compute-produced source would be — see
+    // copy_result_locked.
     if (const char *target = std::getenv("HAZE_TARGET");
         target != nullptr && target[0] != '\0' && std::string_view{target} != "local")
         SKIP("D2D copy of a never-modulus-bound source (raw H2D, no compute) has no "

--- a/test/test_d2d_copy.cpp
+++ b/test/test_d2d_copy.cpp
@@ -180,16 +180,17 @@ TEST_CASE("hazeMemcpy(D2D) promotes an H2D'd source through the IR copy", "[inte
     // which promotes the shadow bytes into a tagged fhetch input, then
     // emits the copy IR. Round-trip bytes must match the original H2D.
     //
-    // Transport limitation: the SRP D2D of an opaque buffer has no modulus to
-    // bind the copy to, so its output carries the COPY sentinel, which the
-    // transport replay's trace-modulus contract rejects at probe
-    // serialization ("SetValues(): Parameter mismatch"). Use hazeMemcpyMrp
-    // with a base (even base_len=1) when the residue's modulus is known —
-    // that path replays on FUNC_SIM.
+    // Transport limitation: this source is H2D'd raw and never touched by a
+    // modulus-carrying op, so haze has no recorded modulus to bind to the copy
+    // (a compute-produced source WOULD be recovered — see copy_result_locked).
+    // The copy output keeps the COPY sentinel, which the transport replay's
+    // trace-modulus contract rejects at probe serialization ("SetValues():
+    // Parameter mismatch"). Use hazeMemcpyMrp with a base (even base_len=1)
+    // when the residue's modulus is known — that path replays on FUNC_SIM.
     if (const char *target = std::getenv("HAZE_TARGET");
         target != nullptr && target[0] != '\0' && std::string_view{target} != "local")
-        SKIP("sentinel-modulus SRP D2D copy is not replayable on transport targets; "
-             "use hazeMemcpyMrp with a base when the modulus is known");
+        SKIP("D2D copy of a never-modulus-bound source (raw H2D, no compute) has no "
+             "modulus to recover; not replayable on transport — use hazeMemcpyMrp with a base");
     const uint64_t q = haze::test::setup_integration_compute_config();
     (void)q;
 

--- a/test/test_hardware_format.cpp
+++ b/test/test_hardware_format.cpp
@@ -696,3 +696,57 @@ TEST_CASE("data-format transport: NTT round trip and automorph under data format
     }
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
+
+// The trace's modulus table — not the bridge's scaffold cryptocontext.dat
+// prime — is authoritative for replay. Three distinct valid primes are in
+// play: kQ0 (the desired modulus requested of the bridge), `picked` (what
+// OpenFHE's GenCryptoContext actually built cryptocontext.dat around), and the
+// trace modulus we set (kQ1). The add is crafted to WRAP — a+b lands in
+// [picked, kQ1) — so reducing mod kQ1 (no wrap) and mod picked (wrap) give
+// different results. The result must equal the kQ1 oracle, proving the
+// install-trace machinery makes the trace authoritative on this target.
+TEST_CASE("trace modulus is authoritative over the bridge's scaffold prime",
+          "[integration][modulus]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    uint64_t picked = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
+    REQUIRE(picked != kQ0);
+    REQUIRE(picked != kQ1);
+    // picked < kQ1 holds for these constants; the wrap window [picked, kQ1)
+    // below relies on it.
+    REQUIRE(picked < kQ1);
+    REQUIRE(hazeSetCiphertextModulus(0, kQ1) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+
+    // a = kQ1 - 7, b = 11  =>  a + b = kQ1 + 4.
+    //   mod kQ1    = 4              (trace authoritative)
+    //   mod picked = (kQ1-picked)+4 (scaffold prime authoritative)
+    // a is a valid residue mod kQ1 but exceeds picked, so the two paths can't
+    // coincide.
+    std::vector<uint64_t> va(kRingDim, kQ1 - 7);
+    std::vector<uint64_t> vb(kRingDim, 11);
+    const uint64_t expect_kq1 = 4;
+    const uint64_t expect_picked = (kQ1 - picked) + 4;
+    REQUIRE(expect_kq1 != expect_picked);
+
+    void *pa = nullptr;
+    void *pb = nullptr;
+    void *sum = nullptr;
+    REQUIRE(hazeMalloc(&pa, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&pb, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&sum, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(pa, va.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(pb, vb.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeAdd(sum, pa, pb, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(sum) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    std::vector<uint64_t> out(kRingDim, 0);
+    REQUIRE(hazeMemcpy(out.data(), sum, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    for (uint64_t k = 0; k < kRingDim; ++k) {
+        INFO("slot " << k << " picked=" << picked);
+        REQUIRE(out[k] == expect_kq1);
+    }
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}

--- a/test/test_hardware_format.cpp
+++ b/test/test_hardware_format.cpp
@@ -107,21 +107,23 @@ std::string json_value_text(const std::string &doc, const std::string &key) {
 class EnvGuard {
   public:
     explicit EnvGuard(std::vector<const char *> names) : names_(std::move(names)) {
+        // setenv/unsetenv are POSIX (<cstdlib> is the nearest standard header —
+        // hence the include-cleaner suppressions); the discarded return only
+        // fails on a null/invalid name, which these literals are not.
         for (const char *name : names_) {
             const char *old = std::getenv(name);
             saved_.emplace_back(old != nullptr, old != nullptr ? old : "");
-            // setenv/unsetenv are POSIX; <cstdlib> is the closest standard
-            // header. Return value discarded: only fails on a null/invalid
-            // name, which these literals are not.
-            static_cast<void>(::unsetenv(name)); // NOLINT(misc-include-cleaner)
+            // NOLINTNEXTLINE(misc-include-cleaner)
+            static_cast<void>(::unsetenv(name));
         }
     }
     ~EnvGuard() {
         for (size_t i = 0; i < names_.size(); ++i) {
             if (saved_[i].first) {
-                static_cast<void>(::setenv(names_[i], saved_[i].second.c_str(),
-                                           1)); // NOLINT(misc-include-cleaner)
+                // NOLINTNEXTLINE(misc-include-cleaner)
+                static_cast<void>(::setenv(names_[i], saved_[i].second.c_str(), 1));
             } else {
+                // NOLINTNEXTLINE(misc-include-cleaner)
                 static_cast<void>(::unsetenv(names_[i]));
             }
         }
@@ -708,10 +710,8 @@ TEST_CASE("trace modulus is authoritative over the bridge's scaffold prime",
     REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
-    REQUIRE(picked != kQ0);
-    REQUIRE(picked != kQ1);
-    // picked < kQ1 holds for these constants; the wrap window [picked, kQ1)
-    // below relies on it.
+    // The only prerequisite: the scaffold prime sits below the trace prime, so
+    // the wrap window [picked, kQ1) used below is non-empty (and picked != kQ1).
     REQUIRE(picked < kQ1);
     REQUIRE(hazeSetCiphertextModulus(0, kQ1) == HAZE_SUCCESS);
     REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);

--- a/test/test_hardware_format.cpp
+++ b/test/test_hardware_format.cpp
@@ -110,16 +110,19 @@ class EnvGuard {
         for (const char *name : names_) {
             const char *old = std::getenv(name);
             saved_.emplace_back(old != nullptr, old != nullptr ? old : "");
-            // setenv/unsetenv are POSIX; <cstdlib> is the closest standard header.
-            ::unsetenv(name); // NOLINT(misc-include-cleaner)
+            // setenv/unsetenv are POSIX; <cstdlib> is the closest standard
+            // header. Return value discarded: only fails on a null/invalid
+            // name, which these literals are not.
+            static_cast<void>(::unsetenv(name)); // NOLINT(misc-include-cleaner)
         }
     }
     ~EnvGuard() {
         for (size_t i = 0; i < names_.size(); ++i) {
             if (saved_[i].first) {
-                ::setenv(names_[i], saved_[i].second.c_str(), 1); // NOLINT(misc-include-cleaner)
+                static_cast<void>(::setenv(names_[i], saved_[i].second.c_str(),
+                                           1)); // NOLINT(misc-include-cleaner)
             } else {
-                ::unsetenv(names_[i]);
+                static_cast<void>(::unsetenv(names_[i]));
             }
         }
     }
@@ -324,6 +327,50 @@ TEST_CASE("data format on local target is rejected at flush", "[unit][hwfmt]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
 
+TEST_CASE("data format rejected at flush keeps the in-flight recording", "[integration][hwfmt]") {
+    // The flush guard early-returns before replay_and_populate, leaving the
+    // epoch open. After the config is corrected the same recording must still
+    // materialize — the op is not silently dropped. Pinned local so the
+    // rejection fires regardless of the harness target.
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    uint64_t picked = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(0, picked) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    REQUIRE(hazeSetTarget("local") == HAZE_SUCCESS);
+
+    std::vector<uint64_t> vals(kRingDim);
+    for (uint64_t i = 0; i < kRingDim; ++i)
+        vals[i] = (i * 3 + 1) % picked;
+    void *src = nullptr;
+    void *dst = nullptr;
+    REQUIRE(hazeMalloc(&src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&dst, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(src, vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeMulScalar(dst, src, 3, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(dst) == HAZE_SUCCESS);
+
+    // Enable the data format and flush: rejected on the local target.
+    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
+    REQUIRE(hazeSetBitReversal(1) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_ERROR_NOT_SUPPORTED);
+
+    // Correct the config; the same recorded op now materializes.
+    REQUIRE(hazeSetMontgomery(0) == HAZE_SUCCESS);
+    REQUIRE(hazeSetBitReversal(0) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    std::vector<uint64_t> out(kRingDim, 0);
+    REQUIRE(hazeMemcpy(out.data(), dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    for (uint64_t k = 0; k < kRingDim; ++k) {
+        INFO("slot " << k);
+        REQUIRE(out[k] == niobium::mod_arith::mulmod(vals[k], 3, picked));
+    }
+
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
 TEST_CASE("record-time: recording stays ordinary-form with switchmodulus markers",
           "[unit][hwfmt]") {
     EnvGuard guard({"HAZE_MONTGOMERY", "HAZE_BIT_REVERSAL"});
@@ -399,6 +446,11 @@ TEST_CASE("store_input_element keeps values ordinary under the data format", "[u
     });
     REQUIRE(found_raw_input);
 
+    // This case drove niobium::compiler() directly with --niobium_hw;
+    // hazeDeviceReset only clears CompilerBackend's initialized_ flag, so
+    // reset the compiler too or the next ensure_initialized() re-init's an
+    // already-running, --niobium_hw instance.
+    cc.reset();
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
 

--- a/test/test_hardware_format.cpp
+++ b/test/test_hardware_format.cpp
@@ -750,3 +750,48 @@ TEST_CASE("trace modulus is authoritative over the bridge's scaffold prime",
     }
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
+
+// Input residues in [scaffold_prime, trace_prime) must survive serialization.
+// The bridge builds the input ciphertext from OpenFHE's scaffold prime, which
+// is SMALLER than the trace prime here (measured picked < kQ0), so a residue
+// in that window would wrap if filled before the modulus was rebased to the
+// trace prime. synthesize rebases each tower first, so the .bin carries the
+// exact trace prime and the value round-trips. Random residues land in this
+// ~3.4M-wide window with negligible probability, so this pins it explicitly.
+TEST_CASE("input residues above the scaffold prime survive .bin synthesis",
+          "[integration][modulus]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    uint64_t picked = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
+    REQUIRE(picked < kQ0); // the wrap window [picked, kQ0) below relies on it
+    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+
+    // Seed the wrap window: values that exceed the scaffold prime but are
+    // valid mod the trace prime. A scalar-mul by 1 is the identity, so each
+    // output must equal its input exactly.
+    std::vector<uint64_t> vals(kRingDim);
+    for (uint64_t i = 0; i < kRingDim; ++i)
+        vals[i] = (i % 5 == 0) ? (kQ0 - 1 - (i % 7)) // in [picked, kQ0)
+                               : (i * 11 + 3) % picked;
+    vals[1] = picked;     // exact lower edge of the window
+    vals[2] = picked - 1; // just below — control
+
+    void *src = nullptr;
+    void *dst = nullptr;
+    REQUIRE(hazeMalloc(&src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&dst, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(src, vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeMulScalar(dst, src, 1, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(dst) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    std::vector<uint64_t> out(kRingDim, 0);
+    REQUIRE(hazeMemcpy(out.data(), dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    for (uint64_t k = 0; k < kRingDim; ++k) {
+        INFO("slot " << k << " in=" << vals[k] << " picked=" << picked << " kQ0=" << kQ0);
+        REQUIRE(out[k] == vals[k]);
+    }
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}

--- a/test/test_hardware_format.cpp
+++ b/test/test_hardware_format.cpp
@@ -697,14 +697,11 @@ TEST_CASE("data-format transport: NTT round trip and automorph under data format
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
 
-// The trace's modulus table — not the bridge's scaffold cryptocontext.dat
-// prime — is authoritative for replay. Three distinct valid primes are in
-// play: kQ0 (the desired modulus requested of the bridge), `picked` (what
-// OpenFHE's GenCryptoContext actually built cryptocontext.dat around), and the
-// trace modulus we set (kQ1). The add is crafted to WRAP — a+b lands in
-// [picked, kQ1) — so reducing mod kQ1 (no wrap) and mod picked (wrap) give
-// different results. The result must equal the kQ1 oracle, proving the
-// install-trace machinery makes the trace authoritative on this target.
+// Three distinct valid primes are in play: kQ0 (requested of the bridge),
+// `picked` (what GenCryptoContext built cryptocontext.dat around), and the
+// trace modulus we set (kQ1). The add wraps into [picked, kQ1) so mod-kQ1 (no
+// wrap) and mod-picked (wrap) differ; the result must equal the kQ1 oracle,
+// confirming the trace modulus — not the scaffold prime — drives replay.
 TEST_CASE("trace modulus is authoritative over the bridge's scaffold prime",
           "[integration][modulus]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
@@ -751,13 +748,11 @@ TEST_CASE("trace modulus is authoritative over the bridge's scaffold prime",
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
 
-// Input residues in [scaffold_prime, trace_prime) must survive serialization.
-// The bridge builds the input ciphertext from OpenFHE's scaffold prime, which
-// is SMALLER than the trace prime here (measured picked < kQ0), so a residue
-// in that window would wrap if filled before the modulus was rebased to the
-// trace prime. synthesize rebases each tower first, so the .bin carries the
-// exact trace prime and the value round-trips. Random residues land in this
-// ~3.4M-wide window with negligible probability, so this pins it explicitly.
+// Input residues in [scaffold_prime, trace_prime) must round-trip: the scaffold
+// prime is smaller than the trace prime (picked < kQ0), so such a value would
+// wrap if filled before the tower was rebased (synthesize rebases first).
+// Random residues hit this ~3.4M-wide window with negligible probability, so
+// this pins it explicitly.
 TEST_CASE("input residues above the scaffold prime survive .bin synthesis",
           "[integration][modulus]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);


### PR DESCRIPTION
Makes the `.fhetch` trace modulus table the single source of truth for replay, and removes the bridge's post-hoc `install_trace_*_moduli` machinery.

- **Propagate source modulus** (`epoch`/`compute`): haze tracks `addr->modulus` (recorded by every modulus-carrying op); `copy_result_locked` and the SRP automorph recover and `bind_modulus` it. Opaque `hazeMemcpy(D2D)` and bare `hazeAutomorph` of a compute-produced value are now trace-authoritative — closing the modulus-less SRP exception. Only a never-modulus-bound source (raw H2D, no compute) stays sentinel.
- **Drop the picked-alignment** in `setup_integration_*`: tests set the slot to the intended prime and compare oracles against it; the bridge scaffold prime is never consulted for results.
- **Rebase tower moduli pre-fill** (`replay_bridge`): `switch_tower_modulus` re-bases each tower to its exact trace prime before filling (on zeros), so `.bin` and templates carry the real primes at synthesis. Deletes both `install_trace_input_moduli` and `install_trace_output_moduli`, and fixes a latent wrap — the scaffold prime is smaller than the trace prime, so an input residue in [scaffold, trace) could be reduced before the old post-fill switch.
- New `[integration][modulus]` tests: trace-modulus authority (third distinct prime, wrapping add) and the [scaffold, trace) input-residue window.

Validated: local 193 cases / 1.78M assertions; transport 132 passed / 1 skipped / 0 failed; montgomery byte-exact `[hwfmt]` transport tests pass.
