### PR TITLE
chore: switch niobium-fhetch submodule to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "vendor/niobium-fhetch"]
 	path = vendor/niobium-fhetch
-	url = git@github.com:NiobiumInc/niobium-fhetch.git
+	url = https://github.com/NiobiumInc/niobium-fhetch.git
 [submodule "vendor/openfhe"]
 	path = vendor/openfhe
 	url = https://github.com/openfheorg/openfhe-development.git


### PR DESCRIPTION
## What
Switch the `vendor/niobium-fhetch` submodule URL in `.gitmodules` from SSH to HTTPS. (`vendor/openfhe` is already HTTPS.)

## Why
This repo is reachable as a nested submodule of the public `fetch-by-similarity-submission` tree. A keyless `--recurse-submodules` clone currently fails on `git@github.com:NiobiumInc/niobium-fhetch.git`; the target repo is public, so HTTPS works anonymously.

SSH-preferring contributors can opt back in globally with:
```
git config --global url."git@github.com:".insteadOf "https://github.com/"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)