### PR TITLE
ci: migrate to public repo — drop private submodule workarounds

### DIFF
--- a/.github/workflows/build-matrix.yml
+++ b/.github/workflows/build-matrix.yml
@@ -25,11 +25,6 @@ jobs:
   build:
     name: build ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
-    # Skip on fork PRs: the org App token needed for the private niobium-fhetch
-    # submodule isn't available there.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -43,18 +38,9 @@ jobs:
             # macOS-only: build the Catch2 suite and run unit + sim tests here.
             run_tests: true
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Checkout (with private niobium-fhetch submodule)
+      - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
           fetch-depth: 1
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,27 +18,10 @@ jobs:
   build-test:
     name: Build + sim tests (nix devshell)
     runs-on: ubuntu-latest
-    # Skip on fork PRs: org App token is not available, so private
-    # submodules cannot be cloned.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      # Same App-token pattern as niobium-client/.github/workflows/ci.yml,
-      # bumped to the current major. Lets us read the private
-      # niobium-fhetch submodule that GITHUB_TOKEN cannot reach.
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Checkout (with private niobium-fhetch submodule)
+      - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
           fetch-depth: 1
 
@@ -87,21 +70,6 @@ jobs:
           key: ubuntu-latest-openfhe-haze-${{ hashFiles('flake.lock') }}-${{ steps.openfhe_rev.outputs.rev }}-${{ steps.openfhe_rev.outputs.stock_rev }}
           restore-keys: |
             ubuntu-latest-openfhe-haze-${{ hashFiles('flake.lock') }}-
-
-      - name: Rewrite niobium-fhetch submodule URL for token auth
-        # nix issue #13324: with `inputs.self.submodules = true` in
-        # flake.nix, nix's flake source ingestion re-fetches the
-        # submodule from its declared URL. .gitmodules registers it
-        # via SSH and the runner has no SSH key. actions/checkout's
-        # transient HTTPS rewrite does not carry into nix's git
-        # fetcher. Rewriting .gitmodules + .git/config to HTTPS with
-        # the App token covers nix. Same step in flake-check.yml.
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git config -f .gitmodules submodule.vendor/niobium-fhetch.url \
-            "https://x-access-token:${APP_TOKEN}@github.com/NiobiumInc/niobium-fhetch.git"
-          git submodule sync vendor/niobium-fhetch
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22

--- a/.github/workflows/dispatch-to-niobium-client.yml
+++ b/.github/workflows/dispatch-to-niobium-client.yml
@@ -13,17 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Dispatch haze_main_push to niobium-client
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           HAZE_SHA: ${{ github.sha }}
         run: |
           jq -n \

--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -21,22 +21,10 @@ jobs:
   lint:
     name: clang-tidy
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Checkout (with private niobium-fhetch submodule)
+      - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
           fetch-depth: 1
 
@@ -81,21 +69,6 @@ jobs:
             echo "Run scripts/sync-openfhe-stock-rev.sh and commit flake.lock."
             exit 1
           fi
-
-      - name: Configure git to use App token for github.com fetches
-        # The runner has no SSH key, so rewrite ssh://git@github.com/ ->
-        # https with the App token; nix's libgit2 fetcher honors insteadOf
-        # for the niobium-fhetch input and its ?submodules=1 sub-fetches.
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          # --add: insteadOf is multivalued, both forms must coexist.
-          git config --global --add \
-            "url.https://x-access-token:${APP_TOKEN}@github.com/.insteadOf" \
-            "ssh://git@github.com/"
-          git config --global --add \
-            "url.https://x-access-token:${APP_TOKEN}@github.com/.insteadOf" \
-            "git@github.com:"
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
@@ -167,22 +140,10 @@ jobs:
   flake-check:
     name: pure-nix build
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
-      - name: Checkout (with private niobium-fhetch submodule)
+      - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           submodules: recursive
           fetch-depth: 1
 
@@ -228,20 +189,6 @@ jobs:
             echo "Run scripts/sync-openfhe-stock-rev.sh and commit flake.lock."
             exit 1
           fi
-
-      - name: Configure git to use App token for github.com fetches
-        # See lint job: rewrites SSH github.com URLs to HTTPS with the
-        # App token so libgit2 (used by nix's git fetcher) can pull
-        # the niobium-fhetch flake input and its sub-submodules.
-        env:
-          APP_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          git config --global --add \
-            "url.https://x-access-token:${APP_TOKEN}@github.com/.insteadOf" \
-            "ssh://git@github.com/"
-          git config --global --add \
-            "url.https://x-access-token:${APP_TOKEN}@github.com/.insteadOf" \
-            "git@github.com:"
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22

--- a/.github/workflows/openfhe-bump.yml
+++ b/.github/workflows/openfhe-bump.yml
@@ -20,7 +20,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read # writes happen via the App token below, not GITHUB_TOKEN
+  contents: write
+  pull-requests: write
 
 concurrency:
   group: openfhe-bump-${{ github.repository }}
@@ -30,22 +31,10 @@ jobs:
   bump:
     runs-on: ubuntu-latest
     steps:
-      # Same App-token pattern as build-test.yml; used here to push the bump
-      # branch and open the PR (GITHUB_TOKEN can't trigger downstream CI).
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
-          # vendor/openfhe is public; the private niobium-fhetch submodule isn't
-          # needed for a bump, so don't recurse.
+          token: ${{ github.token }}
           submodules: false
           fetch-depth: 0
 
@@ -57,7 +46,7 @@ jobs:
       - name: Resolve latest upstream release vs vendored rev
         id: cmp
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           tag=$(gh api repos/openfheorg/openfhe-development/releases/latest --jq '.tag_name')
@@ -100,7 +89,7 @@ jobs:
       - name: Bump submodule + flake input, open/update PR
         if: steps.cmp.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.cmp.outputs.tag }}
           NEW_REV: ${{ steps.cmp.outputs.new_rev }}
         run: |

--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -16,16 +16,16 @@ jobs:
   full-review:
     name: PR - Full Code Review
     runs-on: ubuntu-latest
-    if: |
+    if: >-
       (github.event_name == 'pull_request' &&
-       (github.event.action == 'opened' || github.event.action == 'reopened') &&
-       (github.event.pull_request.author_association == 'MEMBER' ||
-        github.event.pull_request.author_association == 'OWNER')) ||
+      (github.event.action == 'opened' || github.event.action == 'reopened') &&
+      (github.event.pull_request.author_association == 'MEMBER' ||
+      github.event.pull_request.author_association == 'OWNER')) ||
       (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@claude') &&
-       (github.event.comment.author_association == 'MEMBER' ||
-        github.event.comment.author_association == 'OWNER'))
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '@claude') &&
+      (github.event.comment.author_association == 'MEMBER' ||
+      github.event.comment.author_association == 'OWNER'))
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -110,11 +110,11 @@ jobs:
   partial-review:
     name: PR - Partial Code Review
     runs-on: ubuntu-latest
-    if: |
+    if: >-
       github.event_name == 'pull_request' &&
       github.event.action == 'synchronize' &&
       (github.event.pull_request.author_association == 'MEMBER' ||
-       github.event.pull_request.author_association == 'OWNER')
+      github.event.pull_request.author_association == 'OWNER')
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -23,18 +23,9 @@ jobs:
         github.event.issue.pull_request &&
         contains(github.event.comment.body, '@claude')))
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 1
 
       - name: Get changed files
@@ -48,7 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ github.token }}
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 45
@@ -120,18 +111,9 @@ jobs:
       github.event.action == 'synchronize' &&
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 2
 
       - name: Get files changed in latest push
@@ -146,7 +128,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
-          github_token: ${{ steps.app-token.outputs.token }}
+          github_token: ${{ github.token }}
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 25

--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -17,11 +17,15 @@ jobs:
     name: PR - Full Code Review
     runs-on: ubuntu-latest
     if: |
-      (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'issue_comment') &&
-      ((github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')) ||
-       (github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@claude')))
+      (github.event_name == 'pull_request' &&
+       (github.event.action == 'opened' || github.event.action == 'reopened') &&
+       (github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'OWNER')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude') &&
+       (github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER'))
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,7 +42,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY_PUBLIC_REPOS }}
           github_token: ${{ github.token }}
           claude_args: |
             --model claude-sonnet-4-6
@@ -109,7 +113,8 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.event.action == 'synchronize' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event.pull_request.author_association == 'MEMBER' ||
+       github.event.pull_request.author_association == 'OWNER')
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -127,7 +132,7 @@ jobs:
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY }}
+          anthropic_api_key: ${{ secrets.CLAUDE_API_KEY_PUBLIC_REPOS }}
           github_token: ${{ github.token }}
           claude_args: |
             --model claude-sonnet-4-6

--- a/.github/workflows/pr-claude-code-review.yml
+++ b/.github/workflows/pr-claude-code-review.yml
@@ -17,10 +17,11 @@ jobs:
     name: PR - Full Code Review
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')) ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@claude'))
+      (github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'issue_comment') &&
+      ((github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened')) ||
+       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude')))
     steps:
       - name: Generate token
         id: app-token
@@ -115,7 +116,9 @@ jobs:
     name: PR - Partial Code Review
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'pull_request' && github.event.action == 'synchronize'
+      github.event_name == 'pull_request' &&
+      github.event.action == 'synchronize' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Generate token
         id: app-token

--- a/.github/workflows/scanoss.yml
+++ b/.github/workflows/scanoss.yml
@@ -100,7 +100,7 @@ jobs:
   trigger-ort:
     name: Trigger ORT Scan
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Check if ORT scan needed
         id: check

--- a/.github/workflows/scanoss.yml
+++ b/.github/workflows/scanoss.yml
@@ -25,24 +25,16 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: SCANOSS Delta Scan
         uses: scanoss/gha-code-scan@v1
         with:
           api.key: ${{ secrets.SCANOSS_API_KEY }}
-          github.token: ${{ steps.app-token.outputs.token }}
+          github.token: ${{ github.token }}
           policies: copyleft
           policies.halt_on_failure: false
           scanMode: delta
@@ -54,18 +46,10 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Remove non-source files that crash SCANOSS
         run: |
@@ -90,43 +74,9 @@ jobs:
         uses: scanoss/gha-code-scan@v1
         with:
           api.key: ${{ secrets.SCANOSS_API_KEY }}
-          github.token: ${{ steps.app-token.outputs.token }}
+          github.token: ${{ github.token }}
           policies: copyleft
           policies.halt_on_failure: false
           scanMode: full
           dependencies.enabled: false
           output.filepath: scanoss-results.json
-
-  trigger-ort:
-    name: Trigger ORT Scan
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check if ORT scan needed
-        id: check
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 2
-
-      - name: Skip if only NOTICE changed
-        id: filter
-        run: |
-          CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "FORCE_SCAN")
-          if [ "$(echo "$CHANGED" | grep -v '^NOTICE$' | grep -v '^$')" = "" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Trigger ORT scan via webhook
-        if: steps.filter.outputs.skip != 'true'
-        run: |
-          REPO_NAME="${GITHUB_REPOSITORY#*/}"
-          HTTP_CODE=$(curl -s -o /tmp/ort-response.json -w "%{http_code}" -X POST "${{ vars.ORT_WEBHOOK_URL }}/scan" -H "Authorization: Bearer ${{ secrets.ORT_WEBHOOK_TOKEN }}" -H "Content-Type: application/json" -d "{\"repo\": \"${REPO_NAME}\"}")
-          echo "HTTP $HTTP_CODE"
-          cat /tmp/ort-response.json
-          if [ "$HTTP_CODE" = "202" ]; then
-            echo "::notice::ORT scan triggered for $REPO_NAME"
-          else
-            echo "::warning::ORT webhook returned $HTTP_CODE — scan may not have started"
-          fi

--- a/flake.lock
+++ b/flake.lock
@@ -26,12 +26,12 @@
         "revCount": 108,
         "submodules": true,
         "type": "git",
-        "url": "ssh://git@github.com/NiobiumInc/niobium-fhetch.git"
+        "url": "https://github.com/NiobiumInc/niobium-fhetch.git"
       },
       "original": {
         "submodules": true,
         "type": "git",
-        "url": "ssh://git@github.com/NiobiumInc/niobium-fhetch.git"
+        "url": "https://github.com/NiobiumInc/niobium-fhetch.git"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -6,13 +6,12 @@
 
     # External pin of niobium-fhetch (with its openfhe / json sub-submodules),
     # consumed only by the hermetic mkPackages derivations. `flake = false`
-    # keeps it lazy so `nix develop` never resolves it, sparing the dev shell
-    # the SSH-auth dependency `self.submodules = true` would impose (nix
-    # #13324). The vendor/niobium-fhetch submodule stays the source of truth
-    # for non-nix `make build`; CI gates that its rev matches the one pinned
+    # keeps it lazy so `nix develop` never resolves it (nix #13324).
+    # The vendor/niobium-fhetch submodule stays the source of truth for
+    # non-nix `make build`; CI gates that its rev matches the one pinned
     # here, and scripts/sync-fhetch-rev.sh realigns them after a bump.
     niobium-fhetch-src = {
-      url = "git+ssh://git@github.com/NiobiumInc/niobium-fhetch.git?submodules=1";
+      url = "git+https://github.com/NiobiumInc/niobium-fhetch.git?submodules=1";
       flake = false;
     };
 


### PR DESCRIPTION
## Summary

  - **build-test, flake-check, build-matrix**: remove App-token checkout,
    niobium-fhetch URL rewrite / `insteadOf` steps, and fork-PR skip guards.
    niobium-fhetch is now public — submodules clone anonymously over HTTPS,
    and external forks receive full CI.
  - **flake.nix / flake.lock**: switch `niobium-fhetch-src` input from
    `git+ssh` to `git+https`.
  - **scanoss**: move `trigger-ort` job off `self-hosted` to `ubuntu-latest`.
    Self-hosted runners are disabled for public repos by default — this was
    the immediate blocker when the repo went public.
  - **pr-claude-code-review**: add fork guard to `full-review` and
    `partial-review`. `CLAUDE_API_KEY` and the App token are not available
    for fork PRs; without the guard both jobs were failing silently on every
    external PR.