### PR TITLE
test(readme): extract and run examples as CI gate

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Run e2e suite (public C ABI + stock OpenFHE, decrypt-verified)
         run: nix develop --command make test-e2e MODE=release
 
+      - name: Run README example checks (C + C++ extracted from README.md)
+        run: nix develop --command make test-readme MODE=release
+
       - name: Upload build logs on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -412,6 +412,10 @@ the first `hazeMalloc`. Non-polynomial scratch (pointer arrays, twiddle
 tables, kernel-arg packs) goes through `hazeHostAlloc` or ordinary host
 malloc, not `hazeMalloc`.
 
+`hazeMallocMrp` / `hazeFreeMrp` (backed by `DeviceAllocator::allocate_many`
+/ `free_many`) batch an MRP group under a single lock acquisition, reusing
+the single-poly logic; `allocate_many` rolls back on a partial failure.
+
 `DevAddr` is an `enum class : uintptr_t` cast from / to `void*` only at
 the C ABI boundary. `kHbmBase = 0x4000000000ULL` keeps haze-allocated
 addresses above FHETCH's synthetic address range (< `0x1000000000`).

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ HAZE_RUNS_DIR = $(CURDIR)/$(BUILD_DIR)/runs
         config build \
         config-openfhe build-openfhe \
         config-test-openfhe build-test-openfhe \
-        test-unit test-sim test-e2e test-transport test-isolation test test-all \
+        test-unit test-sim test-e2e test-readme test-transport test-isolation test test-all \
         clean clean-runs
 
 # ==============================================================================
@@ -155,11 +155,12 @@ Usage: make <target> [MODE=debug|release]
     test-unit           Run unit suite (HAZE_TARGET=local; no FHE math)
     test-sim            Run sim suite (HAZE_TARGET=local; in-process simulator)
     test-e2e            Run e2e suite (public C ABI + stock OpenFHE, decrypt)
+    test-readme         Compile + run the README examples (C + C++)
     test-transport      Run integration suite via nbcc_fhetch_replay
                         (requires NIOBIUM_COMPILER_ROOT)
     test-isolation      Assert libhaze.so exports only the haze* C ABI
     test                Default: test-unit + test-sim + test-e2e + test-isolation
-    test-all            test + test-transport
+    test-all            test + test-readme + test-transport
 
   Cleanup:
     clean-runs          Remove test runs/ artifacts
@@ -313,9 +314,15 @@ test-e2e: build ## Run the e2e suite (public C ABI + stock OpenFHE, decrypt-veri
 	@cd "$(HAZE_RUNS_DIR)" && \
 	  HAZE_TARGET=local "$(CURDIR)/$(BUILD_DIR)/haze_e2e_tests"
 
+test-readme: build ## Compile + run the README examples (C + C++) via the local simulator
+	@BUILD_DIR="$(BUILD_DIR)" \
+	 STOCK_OPENFHE_DIR="$(STOCK_OPENFHE_INSTALL_DIR)" \
+	 HAZE_RUNS_DIR="$(HAZE_RUNS_DIR)" \
+	 scripts/test_readme_examples.sh
+
 test: test-unit test-sim test-e2e test-isolation ## Run default test suites + isolation guard (no transport dependency)
 
-test-all: test-unit test-sim test-e2e test-isolation test-transport ## Run everything (incl. transport path)
+test-all: test-unit test-sim test-e2e test-readme test-isolation test-transport ## Run everything (incl. README examples + transport path)
 
 # ==============================================================================
 # Cleanup

--- a/README.md
+++ b/README.md
@@ -90,57 +90,286 @@ simulator internals, see the companion repository:
 
 ## Recording an FHE op
 
-The example below configures the device, records a pointwise add of two
-polynomials, replays through the in-process simulator, and reads the result:
+Two runnable examples show the same libhaze operation — a 22-limb ciphertext
+add — first in pure C, then in C++ wrapped in real CKKS. Both configure a
+22-limb RNS modulus chain at ring dimension `N = 65536` and run the identical
+C-ABI sequence (configure -> H2D -> per-residue `hazeAdd` -> tag -> flush ->
+D2H) through the in-process simulator; they differ only in the surrounding
+crypto. Both are extracted and gated in CI (`make test-readme`), so the code
+below cannot silently rot: `scripts/test_readme_examples.sh` compiles and runs
+each one against the shipped `libhaze`.
 
+### C — raw 22-limb add, verified per residue
+
+The C example links only `libhaze` (OpenFHE has no C API, so a `.c` translation
+unit cannot encrypt or decrypt). It adds two polynomials on each of the 22
+residues and checks the recorded modular sums directly: `1 + 2 == 3` in every
+coefficient of every limb.
+
+<!-- readme-example:begin lang=c name=quickstart -->
 ```c
 #include <haze/haze.h>
+#include <haze/replay_bridge.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+
+/* A 22-limb RNS modulus chain at ring dimension N = 65536 — the shape a CKKS
+   ciphertext carries (see the C++ example below). Each limb is a distinct
+   NTT-friendly ~60-bit prime (q = 1 mod 2N). */
+enum { kNumLimbs = 22 };
 
 int main(void) {
-    const uint64_t ring_dim = 4096;
+    const uint64_t ring_dim = 65536;
     const size_t   bytes    = ring_dim * sizeof(uint64_t);
-    const uint64_t modulus  = 576460752303415297ULL;
-    const int      mod_idx  = 0;
+
+    static const uint64_t q[kNumLimbs] = {
+        576460752308273153ULL, 576460752315482113ULL, 576460752319021057ULL,
+        576460752319414273ULL, 576460752321642497ULL, 576460752325705729ULL,
+        576460752328327169ULL, 576460752329113601ULL, 576460752329506817ULL,
+        576460752329900033ULL, 576460752331210753ULL, 576460752337502209ULL,
+        576460752340123649ULL, 576460752342876161ULL, 576460752347201537ULL,
+        576460752347332609ULL, 576460752352837633ULL, 576460752354017281ULL,
+        576460752355065857ULL, 576460752355459073ULL, 576460752358604801ULL,
+        576460752364240897ULL,
+    };
 
     /* ---- Configure the FHE parameter set. ---- */
     hazeSetRingDimension(ring_dim);
-    hazeSetCiphertextModulus(mod_idx, modulus);
+    /* The local simulator reconstructs ciphertext values from a CryptoContext;
+       seed one for (N, q[0]). The moduli set next stay authoritative. */
+    uint64_t picked = 0;
+    hazeReplayBridgeInitCryptoContext(ring_dim, q[0], &picked);
+    for (int i = 0; i < kNumLimbs; ++i)
+        hazeSetCiphertextModulus(i, q[i]);
     hazeConfigureDevice();
 
-    /* ---- Allocate three device polynomials. ---- */
-    void *d_a = NULL, *d_b = NULL, *d_dst = NULL;
-    hazeMalloc(&d_a,   bytes);
-    hazeMalloc(&d_b,   bytes);
-    hazeMalloc(&d_dst, bytes);
-
-    /* ---- Stage host inputs and record the add. ---- */
-    uint64_t a[ring_dim], b[ring_dim], result[ring_dim];
+    /* ---- Allocate device polynomials; stage host inputs (a = 1, b = 2). ---- */
+    void *d_a[kNumLimbs], *d_b[kNumLimbs], *d_dst[kNumLimbs];
+    uint64_t *a = malloc(bytes), *b = malloc(bytes), *result = malloc(bytes);
+    if (a == NULL || b == NULL || result == NULL) return 2;
     for (uint64_t i = 0; i < ring_dim; ++i) { a[i] = 1; b[i] = 2; }
-    hazeMemcpy(d_a, a, bytes, HAZE_MEMCPY_HOST_TO_DEVICE);
-    hazeMemcpy(d_b, b, bytes, HAZE_MEMCPY_HOST_TO_DEVICE);
 
-    hazeAdd(d_dst, d_a, d_b, mod_idx, /*stream=*/NULL);
+    for (int i = 0; i < kNumLimbs; ++i) {
+        hazeMalloc(&d_a[i],   bytes);
+        hazeMalloc(&d_b[i],   bytes);
+        hazeMalloc(&d_dst[i], bytes);
+        hazeMemcpy(d_a[i], a, bytes, HAZE_MEMCPY_HOST_TO_DEVICE);
+        hazeMemcpy(d_b[i], b, bytes, HAZE_MEMCPY_HOST_TO_DEVICE);
+    }
 
-    /* ---- Declare the output, run the recorded program, then read it back. ---- */
-    hazeTagOutput(d_dst);
+    /* ---- Record one pointwise add per residue. ---- */
+    for (int i = 0; i < kNumLimbs; ++i)
+        hazeAdd(d_dst[i], d_a[i], d_b[i], /*mod_idx=*/i, /*stream=*/NULL);
+
+    /* ---- Declare the outputs, run the recorded program, read them back. ---- */
+    for (int i = 0; i < kNumLimbs; ++i)
+        hazeTagOutput(d_dst[i]);
     hazeFlush();
-    hazeMemcpy(result, d_dst, bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
 
-    printf("result[0] = %llu\n", (unsigned long long)result[0]);  /* 3 */
+    int ok = 1;
+    for (int i = 0; i < kNumLimbs && ok; ++i) {
+        hazeMemcpy(result, d_dst[i], bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
+        for (uint64_t k = 0; k < ring_dim; ++k)
+            if (result[k] != 3) { /* (1 + 2) mod q_i == 3 for every prime */
+                printf("limb %d coeff %llu = %llu (expected 3)\n", i,
+                       (unsigned long long)k, (unsigned long long)result[k]);
+                ok = 0;
+                break;
+            }
+    }
 
-    hazeFree(d_a);
-    hazeFree(d_b);
-    hazeFree(d_dst);
+    for (int i = 0; i < kNumLimbs; ++i) {
+        hazeFree(d_a[i]);
+        hazeFree(d_b[i]);
+        hazeFree(d_dst[i]);
+    }
+    free(a);
+    free(b);
+    free(result);
+
+    if (!ok) return 1;
+    printf("readme-c: OK\n");
     return 0;
 }
 ```
+<!-- readme-example:end -->
+
+Buffers are heap-allocated (22 residues at `N = 65536` is ~11 MB of coefficients,
+far past a safe stack). `hazeReplayBridgeInitCryptoContext` seeds the
+CryptoContext the local simulator uses to reconstruct ciphertext values; the
+per-residue primes set with `hazeSetCiphertextModulus` remain authoritative for
+the results.
+
+### C++ — the same add over a real CKKS ciphertext, decrypt-verified
+
+The C++ example is the realistic capstone: a genuine CKKS ciphertext add. A
+consumer's own stock OpenFHE handles `keygen` / `encrypt` / `decrypt`; libhaze
+performs the compute. OpenFHE derives the 22-limb chain at `N = 65536`; haze is
+configured from the moduli read off that context, both ciphertexts' `(c0, c1)`
+limbs are added per residue, and the haze-computed result is injected back into
+an OpenFHE ciphertext shell and decrypted to confirm the slots equal `x1 + x2`.
+
+<!-- readme-example:begin lang=cpp name=ckks22 -->
+```cpp
+#include <openfhe.h>
+
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+using namespace lbcrypto;
+
+// Per-tower uint64 limbs of one ciphertext polynomial (c0 or c1).
+static std::vector<std::vector<uint64_t>> extract_chain(const DCRTPoly &poly, uint64_t n) {
+    const std::size_t towers = poly.GetNumOfElements();
+    std::vector<std::vector<uint64_t>> chain(towers, std::vector<uint64_t>(n));
+    for (std::size_t t = 0; t < towers; ++t) {
+        const auto &vals = poly.GetElementAtIndex(static_cast<uint32_t>(t)).GetValues();
+        for (uint64_t i = 0; i < n; ++i)
+            chain[t][i] = vals[i].ConvertToInt<uint64_t>();
+    }
+    return chain;
+}
+
+int main() {
+    const auto t_start = std::chrono::steady_clock::now();
+
+    // ---- Build a 22-limb CKKS context with stock OpenFHE. ----
+    CCParams<CryptoContextCKKSRNS> params;
+    params.SetMultiplicativeDepth(21);     // 22 RNS towers (depth + 1)
+    params.SetScalingModSize(55);
+    params.SetFirstModSize(60);
+    params.SetScalingTechnique(FIXEDAUTO); // tower count is exactly depth + 1
+    params.SetSecurityLevel(HEStd_128_classic);
+    params.SetBatchSize(8);
+    auto cc = GenCryptoContext(params);
+    cc->Enable(PKE);
+    cc->Enable(KEYSWITCH);
+    cc->Enable(LEVELEDSHE);
+    auto keys = cc->KeyGen();
+
+    const uint64_t N = cc->GetRingDimension();
+    const std::size_t bytes = static_cast<std::size_t>(N) * sizeof(uint64_t);
+    std::vector<uint64_t> q_base;
+    for (const auto &p : cc->GetCryptoParameters()->GetElementParams()->GetParams())
+        q_base.push_back(p->GetModulus().ConvertToInt<uint64_t>());
+    const std::size_t towers = q_base.size();
+    if (N != 65536 || towers != 22) {
+        std::fprintf(stderr, "unexpected chain: N=%llu towers=%zu\n", (unsigned long long)N,
+                     towers);
+        return 1;
+    }
+
+    // ---- Encrypt two packed real-valued vectors. ----
+    const std::vector<double> x1 = {0.25, 0.5, 0.75, 1.0, 2.0, 3.0, 4.0, 5.0};
+    const std::vector<double> x2 = {1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0};
+    auto ct1 = cc->Encrypt(keys.publicKey, cc->MakeCKKSPackedPlaintext(x1));
+    auto ct2 = cc->Encrypt(keys.publicKey, cc->MakeCKKSPackedPlaintext(x2));
+
+    // ---- Configure haze for the same chain (moduli read off the context). ----
+    hazeDeviceReset();
+    hazeSetRingDimension(N);
+    uint64_t picked = 0;
+    hazeReplayBridgeInitCryptoContext(N, q_base[0], &picked);
+    for (std::size_t i = 0; i < towers; ++i)
+        hazeSetCiphertextModulus(static_cast<int>(i), q_base[i]);
+    hazeConfigureDevice();
+
+    // ---- Stage each ciphertext's (c0, c1) limbs to the device. ----
+    auto h2d = [&](const std::vector<std::vector<uint64_t>> &chain) {
+        std::vector<void *> ptrs(chain.size(), nullptr);
+        for (std::size_t t = 0; t < chain.size(); ++t) {
+            hazeMalloc(&ptrs[t], bytes);
+            hazeMemcpy(ptrs[t], chain[t].data(), bytes, HAZE_MEMCPY_HOST_TO_DEVICE);
+        }
+        return ptrs;
+    };
+    const auto a0 = h2d(extract_chain(ct1->GetElements()[0], N));
+    const auto a1 = h2d(extract_chain(ct1->GetElements()[1], N));
+    const auto b0 = h2d(extract_chain(ct2->GetElements()[0], N));
+    const auto b1 = h2d(extract_chain(ct2->GetElements()[1], N));
+
+    std::vector<void *> r0(towers, nullptr), r1(towers, nullptr);
+    for (std::size_t t = 0; t < towers; ++t) {
+        hazeMalloc(&r0[t], bytes);
+        hazeMalloc(&r1[t], bytes);
+    }
+
+    // ---- Record the homomorphic add: one pointwise add per residue, on both
+    //      ciphertext polynomials. A CKKS add is independent per limb. ----
+    for (std::size_t t = 0; t < towers; ++t) {
+        hazeAdd(r0[t], a0[t], b0[t], static_cast<int>(t), nullptr);
+        hazeAdd(r1[t], a1[t], b1[t], static_cast<int>(t), nullptr);
+    }
+    for (std::size_t t = 0; t < towers; ++t) {
+        hazeTagOutput(r0[t]);
+        hazeTagOutput(r1[t]);
+    }
+    hazeFlush();
+
+    // ---- Read the haze-computed limbs back (pure shadow reads). ----
+    std::vector<std::vector<uint64_t>> res0(towers, std::vector<uint64_t>(N));
+    std::vector<std::vector<uint64_t>> res1(towers, std::vector<uint64_t>(N));
+    for (std::size_t t = 0; t < towers; ++t) {
+        hazeMemcpy(res0[t].data(), r0[t], bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
+        hazeMemcpy(res1[t].data(), r1[t], bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
+    }
+
+    // ---- Inject the limbs into a correctly-shaped OpenFHE shell and decrypt. ----
+    auto shell = cc->EvalAdd(ct1, ct2)->Clone();
+    auto inject = [&](std::size_t elem, const std::vector<std::vector<uint64_t>> &rows) {
+        auto &towers_vec = shell->GetElements()[elem].GetAllElements();
+        for (std::size_t t = 0; t < towers; ++t) {
+            auto &np = towers_vec[t];
+            NativeVector nv(static_cast<uint32_t>(N), NativeInteger(np.GetModulus()));
+            for (uint64_t i = 0; i < N; ++i)
+                nv[i] = NativeInteger(rows[t][i]);
+            np.SetValues(nv, np.GetFormat());
+        }
+    };
+    inject(0, res0);
+    inject(1, res1);
+
+    Plaintext out;
+    cc->Decrypt(keys.secretKey, shell, &out);
+    out->SetLength(x1.size());
+    const auto slots = out->GetRealPackedValue();
+
+    double max_err = 0.0;
+    for (std::size_t i = 0; i < x1.size(); ++i)
+        max_err = std::fmax(max_err, std::fabs(slots[i] - (x1[i] + x2[i])));
+    if (max_err > 1e-6) {
+        std::fprintf(stderr, "decryption mismatch: max_err=%.3e\n", max_err);
+        return 1;
+    }
+
+    const double elapsed =
+        std::chrono::duration<double>(std::chrono::steady_clock::now() - t_start).count();
+    std::printf("readme-cpp: OK (%.2f s)\n", elapsed);
+    return 0;
+}
+```
+<!-- readme-example:end -->
+
+The `(c0, c1)` extraction and injection touch OpenFHE directly, but they run
+before recording starts (first `hazeAdd`) and after it stops (`hazeFlush`), so
+they never enter the trace. Because this example links a consumer's own stock
+OpenFHE — a different build than the instrumented one hidden inside `libhaze` —
+verification is by decryption, not bit-exact RNS equality.
 
 Replace `hazeAdd` with any sequence of `hazeMul`, `hazeNTT`, `hazeAutomorph`,
 `hazeBasisConvert`, ... and the recording layer captures every op in execution
 order. `test/test_compute.cpp` and `test/test_basis_convert.cpp` exercise the
-full surface; they are useful as worked examples.
+full surface; the `test/e2e/` suite builds the CKKS operation set (add,
+mult + relin, rotate, rescale) on the same C ABI.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -438,13 +438,15 @@ Build:
 
 Test:
   test-unit         Unit suite (HAZE_TARGET=local; no FHE math).
-  test-sim          [integration] suite via the in-process FHETCH
-                    simulator (HAZE_TARGET=local). Validates FHE math
-                    without external binaries.
+  test-sim          Sim suite via the in-process FHETCH simulator
+                    (HAZE_TARGET=local). Validates FHE math.
+  test-e2e          E2E suite (public C ABI + stock OpenFHE, decrypt).
+  test-readme       Compile + run the README examples (C + C++).
   test-transport    [integration] suite via nbcc_fhetch_replay
                     (opt-in; requires NIOBIUM_COMPILER_ROOT).
-  test              Default: test-unit + test-sim.
-  test-all          test-unit + test-sim + test-transport.
+  test-isolation    Assert libhaze exports only the haze* C ABI.
+  test              Default: test-unit + test-sim + test-e2e + test-isolation.
+  test-all          test + test-readme + test-transport.
 
 Cleanup:
   clean-runs        Remove test runs/ artifacts.

--- a/README.md
+++ b/README.md
@@ -114,9 +114,8 @@ sums directly: `1 + 2 == 3` in every coefficient of every limb.
 #include <stdio.h>
 #include <stdlib.h>
 
-/* A 22-limb RNS modulus chain at ring dimension N = 65536 — the shape a CKKS
-   ciphertext carries (see the C++ example below). Each limb is a distinct
-   NTT-friendly ~60-bit prime (q = 1 mod 2N). */
+/* 22-limb RNS modulus chain at ring dimension N = 65536, matching a CKKS
+   ciphertext. Each limb is a distinct NTT-friendly ~60-bit prime (q = 1 mod 2N). */
 enum { kNumLimbs = 22 };
 
 int main(void) {
@@ -136,44 +135,40 @@ int main(void) {
 
     /* ---- Configure the FHE parameter set. ---- */
     hazeSetRingDimension(ring_dim);
-    /* The local simulator reconstructs ciphertext values from a CryptoContext;
-       seed one for (N, q[0]). The moduli set next stay authoritative. */
+    /* Seed the CryptoContext the local simulator uses to reconstruct values. */
     uint64_t picked = 0;
     hazeReplayBridgeInitCryptoContext(ring_dim, q[0], &picked);
     for (int i = 0; i < kNumLimbs; ++i)
         hazeSetCiphertextModulus(i, q[i]);
     hazeConfigureDevice();
 
-    /* ---- Allocate device polynomials; stage host inputs (a = 1, b = 2). ---- */
+    /* ---- Allocate the MRP groups; stage host inputs (a = 1, b = 2). ---- */
     void *d_a[kNumLimbs], *d_b[kNumLimbs], *d_dst[kNumLimbs];
     const void *h_a[kNumLimbs], *h_b[kNumLimbs];
     void *h_res[kNumLimbs];
 
     uint64_t *a = malloc(bytes), *b = malloc(bytes);
-    uint64_t *result = malloc((size_t)kNumLimbs * bytes); /* one row per residue */
+    uint64_t *result = malloc((size_t)kNumLimbs * bytes);
     if (a == NULL || b == NULL || result == NULL) return 2;
     for (uint64_t i = 0; i < ring_dim; ++i) { a[i] = 1; b[i] = 2; }
 
+    hazeMallocMrp(d_a,   kNumLimbs, bytes);
+    hazeMallocMrp(d_b,   kNumLimbs, bytes);
+    hazeMallocMrp(d_dst, kNumLimbs, bytes);
     for (int i = 0; i < kNumLimbs; ++i) {
-        hazeMalloc(&d_a[i],   bytes);
-        hazeMalloc(&d_b[i],   bytes);
-        hazeMalloc(&d_dst[i], bytes);
-        h_a[i]   = a; /* every residue stages the same host data here */
+        h_a[i]   = a;
         h_b[i]   = b;
         h_res[i] = result + (size_t)i * ring_dim;
     }
 
-    /* ---- Stage both inputs to the device as whole MRP groups. ---- */
+    /* ---- Stage the inputs, record the add, read the results: one MRP op
+           each over the whole 22-limb base. ---- */
     hazeMemcpyMrp(d_a, h_a, bytes, HAZE_MEMCPY_HOST_TO_DEVICE, q, kNumLimbs);
     hazeMemcpyMrp(d_b, h_b, bytes, HAZE_MEMCPY_HOST_TO_DEVICE, q, kNumLimbs);
-
-    /* ---- Record the add as one MRP op over the whole 22-limb base. ---- */
     hazeAddMrp(d_dst, (const void *const *)d_a, (const void *const *)d_b, q, kNumLimbs,
                /*stream=*/NULL);
 
-    /* ---- Declare the outputs, run, then read the whole group back at once. ---- */
-    for (int i = 0; i < kNumLimbs; ++i)
-        hazeTagOutput(d_dst[i]);
+    hazeTagOutput(d_dst[0]); /* tagging one residue tags the whole group */
     hazeFlush();
     hazeMemcpyMrp(h_res, (const void *const *)d_dst, bytes, HAZE_MEMCPY_DEVICE_TO_HOST, q,
                   kNumLimbs);
@@ -190,11 +185,9 @@ int main(void) {
             }
     }
 
-    for (int i = 0; i < kNumLimbs; ++i) {
-        hazeFree(d_a[i]);
-        hazeFree(d_b[i]);
-        hazeFree(d_dst[i]);
-    }
+    hazeFreeMrp(d_a,   kNumLimbs);
+    hazeFreeMrp(d_b,   kNumLimbs);
+    hazeFreeMrp(d_dst, kNumLimbs);
     free(a);
     free(b);
     free(result);
@@ -205,12 +198,6 @@ int main(void) {
 }
 ```
 <!-- readme-example:end -->
-
-Buffers are heap-allocated (22 residues at `N = 65536` is ~11 MB of coefficients,
-far past a safe stack). `hazeReplayBridgeInitCryptoContext` seeds the
-CryptoContext the local simulator uses to reconstruct ciphertext values; the
-per-residue primes set with `hazeSetCiphertextModulus` remain authoritative for
-the results.
 
 ### C++ — the same add over a real CKKS ciphertext, decrypt-verified
 
@@ -299,11 +286,10 @@ int main() {
     auto h2d = [&](const std::vector<std::vector<uint64_t>> &chain) {
         const std::size_t n = chain.size();
         std::vector<void *> ptrs(n, nullptr);
+        hazeMallocMrp(ptrs.data(), n, bytes);
         std::vector<const void *> src(n, nullptr);
-        for (std::size_t t = 0; t < n; ++t) {
-            hazeMalloc(&ptrs[t], bytes);
+        for (std::size_t t = 0; t < n; ++t)
             src[t] = chain[t].data();
-        }
         hazeMemcpyMrp(ptrs.data(), src.data(), bytes, HAZE_MEMCPY_HOST_TO_DEVICE,
                       q_base.data(), n);
         return ptrs;
@@ -314,19 +300,15 @@ int main() {
     const auto b1 = h2d(extract_chain(ct2->GetElements()[1], N));
 
     std::vector<void *> r0(towers, nullptr), r1(towers, nullptr);
-    for (std::size_t t = 0; t < towers; ++t) {
-        hazeMalloc(&r0[t], bytes);
-        hazeMalloc(&r1[t], bytes);
-    }
+    hazeMallocMrp(r0.data(), towers, bytes);
+    hazeMallocMrp(r1.data(), towers, bytes);
 
     // ---- Record the homomorphic add: one MRP op over the whole 22-limb base
     //      per ciphertext polynomial (c0, c1). ----
     hazeAddMrp(r0.data(), a0.data(), b0.data(), q_base.data(), towers, nullptr);
     hazeAddMrp(r1.data(), a1.data(), b1.data(), q_base.data(), towers, nullptr);
-    for (std::size_t t = 0; t < towers; ++t) {
-        hazeTagOutput(r0[t]);
-        hazeTagOutput(r1[t]);
-    }
+    hazeTagOutput(r0[0]); // tagging one residue tags the whole group
+    hazeTagOutput(r1[0]);
     hazeFlush();
 
     // ---- Read both result polynomials back as whole MRP groups (shadow reads). ----
@@ -342,8 +324,18 @@ int main() {
     hazeMemcpyMrp(res1_ptrs.data(), r1.data(), bytes, HAZE_MEMCPY_DEVICE_TO_HOST,
                   q_base.data(), towers);
 
-    // ---- Inject the limbs into a correctly-shaped OpenFHE shell and decrypt. ----
-    auto shell = cc->EvalAdd(ct1, ct2)->Clone();
+    // ---- Release the device groups; the rest is host-side OpenFHE. ----
+    hazeFreeMrp(a0.data(), a0.size());
+    hazeFreeMrp(a1.data(), a1.size());
+    hazeFreeMrp(b0.data(), b0.size());
+    hazeFreeMrp(b1.data(), b1.size());
+    hazeFreeMrp(r0.data(), r0.size());
+    hazeFreeMrp(r1.data(), r1.size());
+
+    // ---- Inject the limbs into a shell of the right shape and decrypt. The
+    //      shell is ct1 (level 0, 22 towers, scale 1 — same shape as the sum),
+    //      a non-answer: a no-op inject would decrypt to x1, not x1 + x2. ----
+    auto shell = ct1->Clone();
     auto inject = [&](std::size_t elem, const std::vector<std::vector<uint64_t>> &rows) {
         auto &towers_vec = shell->GetElements()[elem].GetAllElements();
         for (std::size_t t = 0; t < towers; ++t) {
@@ -362,12 +354,12 @@ int main() {
     out->SetLength(x1.size());
     const auto slots = out->GetRealPackedValue();
 
-    double max_err = 0.0;
-    for (std::size_t i = 0; i < x1.size(); ++i)
-        max_err = std::fmax(max_err, std::fabs(slots[i] - (x1[i] + x2[i])));
-    if (max_err > 1e-6) {
-        std::fprintf(stderr, "decryption mismatch: max_err=%.3e\n", max_err);
-        return 1;
+    for (std::size_t i = 0; i < x1.size(); ++i) {
+        const double err = std::fabs(slots[i] - (x1[i] + x2[i]));
+        if (!(err <= 1e-6)) { // negated compare so a NaN slot (corrupt decrypt) also fails
+            std::fprintf(stderr, "slot %zu = %.6f, want %.6f\n", i, slots[i], x1[i] + x2[i]);
+            return 1;
+        }
     }
 
     const double elapsed =
@@ -378,17 +370,12 @@ int main() {
 ```
 <!-- readme-example:end -->
 
-The `(c0, c1)` extraction and injection touch OpenFHE directly, but they run
-before recording starts (first `hazeAdd`) and after it stops (`hazeFlush`), so
-they never enter the trace. Because this example links a consumer's own stock
-OpenFHE — a different build than the instrumented one hidden inside `libhaze` —
-verification is by decryption, not bit-exact RNS equality.
-
-Replace `hazeAdd` with any sequence of `hazeMul`, `hazeNTT`, `hazeAutomorph`,
-`hazeBasisConvert`, ... and the recording layer captures every op in execution
-order. `test/test_compute.cpp` and `test/test_basis_convert.cpp` exercise the
-full surface; the `test/e2e/` suite builds the CKKS operation set (add,
-mult + relin, rotate, rescale) on the same C ABI.
+Replace `hazeAddMrp` with any sequence of `hazeMulMrp`, `hazeNTTMrp`,
+`hazeAutomorphMrp`, `hazeBasisConvert`, ... and the recording layer captures
+every op in execution order. `test/test_compute.cpp` and
+`test/test_basis_convert.cpp` exercise the full surface; the `test/e2e/` suite
+builds the CKKS operation set (add, mult + relin, rotate, rescale) on the same
+C ABI.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ simulator internals, see the companion repository:
 Two runnable examples show the same libhaze operation — a 22-limb ciphertext
 add — first in pure C, then in C++ wrapped in real CKKS. Both configure a
 22-limb RNS modulus chain at ring dimension `N = 65536` and run the identical
-C-ABI sequence (configure -> H2D -> per-residue `hazeAdd` -> tag -> flush ->
-D2H) through the in-process simulator; they differ only in the surrounding
+C-ABI sequence (configure -> H2D -> `hazeAddMrp` over the base -> tag -> flush
+-> D2H) through the in-process simulator; they differ only in the surrounding
 crypto. Both are extracted and gated in CI (`make test-readme`), so the code
 below cannot silently rot: `scripts/test_readme_examples.sh` compiles and runs
 each one against the shipped `libhaze`.
@@ -102,9 +102,9 @@ each one against the shipped `libhaze`.
 ### C — raw 22-limb add, verified per residue
 
 The C example links only `libhaze` (OpenFHE has no C API, so a `.c` translation
-unit cannot encrypt or decrypt). It adds two polynomials on each of the 22
-residues and checks the recorded modular sums directly: `1 + 2 == 3` in every
-coefficient of every limb.
+unit cannot encrypt or decrypt). It adds two polynomials across all 22 residues
+in a single `hazeAddMrp` call over the base, then checks the recorded modular
+sums directly: `1 + 2 == 3` in every coefficient of every limb.
 
 <!-- readme-example:begin lang=c name=quickstart -->
 ```c
@@ -146,7 +146,11 @@ int main(void) {
 
     /* ---- Allocate device polynomials; stage host inputs (a = 1, b = 2). ---- */
     void *d_a[kNumLimbs], *d_b[kNumLimbs], *d_dst[kNumLimbs];
-    uint64_t *a = malloc(bytes), *b = malloc(bytes), *result = malloc(bytes);
+    const void *h_a[kNumLimbs], *h_b[kNumLimbs];
+    void *h_res[kNumLimbs];
+
+    uint64_t *a = malloc(bytes), *b = malloc(bytes);
+    uint64_t *result = malloc((size_t)kNumLimbs * bytes); /* one row per residue */
     if (a == NULL || b == NULL || result == NULL) return 2;
     for (uint64_t i = 0; i < ring_dim; ++i) { a[i] = 1; b[i] = 2; }
 
@@ -154,26 +158,33 @@ int main(void) {
         hazeMalloc(&d_a[i],   bytes);
         hazeMalloc(&d_b[i],   bytes);
         hazeMalloc(&d_dst[i], bytes);
-        hazeMemcpy(d_a[i], a, bytes, HAZE_MEMCPY_HOST_TO_DEVICE);
-        hazeMemcpy(d_b[i], b, bytes, HAZE_MEMCPY_HOST_TO_DEVICE);
+        h_a[i]   = a; /* every residue stages the same host data here */
+        h_b[i]   = b;
+        h_res[i] = result + (size_t)i * ring_dim;
     }
 
-    /* ---- Record one pointwise add per residue. ---- */
-    for (int i = 0; i < kNumLimbs; ++i)
-        hazeAdd(d_dst[i], d_a[i], d_b[i], /*mod_idx=*/i, /*stream=*/NULL);
+    /* ---- Stage both inputs to the device as whole MRP groups. ---- */
+    hazeMemcpyMrp(d_a, h_a, bytes, HAZE_MEMCPY_HOST_TO_DEVICE, q, kNumLimbs);
+    hazeMemcpyMrp(d_b, h_b, bytes, HAZE_MEMCPY_HOST_TO_DEVICE, q, kNumLimbs);
 
-    /* ---- Declare the outputs, run the recorded program, read them back. ---- */
+    /* ---- Record the add as one MRP op over the whole 22-limb base. ---- */
+    hazeAddMrp(d_dst, (const void *const *)d_a, (const void *const *)d_b, q, kNumLimbs,
+               /*stream=*/NULL);
+
+    /* ---- Declare the outputs, run, then read the whole group back at once. ---- */
     for (int i = 0; i < kNumLimbs; ++i)
         hazeTagOutput(d_dst[i]);
     hazeFlush();
+    hazeMemcpyMrp(h_res, (const void *const *)d_dst, bytes, HAZE_MEMCPY_DEVICE_TO_HOST, q,
+                  kNumLimbs);
 
     int ok = 1;
     for (int i = 0; i < kNumLimbs && ok; ++i) {
-        hazeMemcpy(result, d_dst[i], bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
+        const uint64_t *r = (const uint64_t *)h_res[i];
         for (uint64_t k = 0; k < ring_dim; ++k)
-            if (result[k] != 3) { /* (1 + 2) mod q_i == 3 for every prime */
+            if (r[k] != 3) { /* (1 + 2) mod q_i == 3 for every prime */
                 printf("limb %d coeff %llu = %llu (expected 3)\n", i,
-                       (unsigned long long)k, (unsigned long long)result[k]);
+                       (unsigned long long)k, (unsigned long long)r[k]);
                 ok = 0;
                 break;
             }
@@ -207,8 +218,9 @@ The C++ example is the realistic capstone: a genuine CKKS ciphertext add. A
 consumer's own stock OpenFHE handles `keygen` / `encrypt` / `decrypt`; libhaze
 performs the compute. OpenFHE derives the 22-limb chain at `N = 65536`; haze is
 configured from the moduli read off that context, both ciphertexts' `(c0, c1)`
-limbs are added per residue, and the haze-computed result is injected back into
-an OpenFHE ciphertext shell and decrypted to confirm the slots equal `x1 + x2`.
+polynomials are added with one `hazeAddMrp` per polynomial over the 22-limb
+base, and the haze-computed result is injected back into an OpenFHE ciphertext
+shell and decrypted to confirm the slots equal `x1 + x2`.
 
 <!-- readme-example:begin lang=cpp name=ckks22 -->
 ```cpp
@@ -283,13 +295,17 @@ int main() {
         hazeSetCiphertextModulus(static_cast<int>(i), q_base[i]);
     hazeConfigureDevice();
 
-    // ---- Stage each ciphertext's (c0, c1) limbs to the device. ----
+    // ---- Stage each ciphertext's (c0, c1) limbs to the device as one MRP group. ----
     auto h2d = [&](const std::vector<std::vector<uint64_t>> &chain) {
-        std::vector<void *> ptrs(chain.size(), nullptr);
-        for (std::size_t t = 0; t < chain.size(); ++t) {
+        const std::size_t n = chain.size();
+        std::vector<void *> ptrs(n, nullptr);
+        std::vector<const void *> src(n, nullptr);
+        for (std::size_t t = 0; t < n; ++t) {
             hazeMalloc(&ptrs[t], bytes);
-            hazeMemcpy(ptrs[t], chain[t].data(), bytes, HAZE_MEMCPY_HOST_TO_DEVICE);
+            src[t] = chain[t].data();
         }
+        hazeMemcpyMrp(ptrs.data(), src.data(), bytes, HAZE_MEMCPY_HOST_TO_DEVICE,
+                      q_base.data(), n);
         return ptrs;
     };
     const auto a0 = h2d(extract_chain(ct1->GetElements()[0], N));
@@ -303,25 +319,28 @@ int main() {
         hazeMalloc(&r1[t], bytes);
     }
 
-    // ---- Record the homomorphic add: one pointwise add per residue, on both
-    //      ciphertext polynomials. A CKKS add is independent per limb. ----
-    for (std::size_t t = 0; t < towers; ++t) {
-        hazeAdd(r0[t], a0[t], b0[t], static_cast<int>(t), nullptr);
-        hazeAdd(r1[t], a1[t], b1[t], static_cast<int>(t), nullptr);
-    }
+    // ---- Record the homomorphic add: one MRP op over the whole 22-limb base
+    //      per ciphertext polynomial (c0, c1). ----
+    hazeAddMrp(r0.data(), a0.data(), b0.data(), q_base.data(), towers, nullptr);
+    hazeAddMrp(r1.data(), a1.data(), b1.data(), q_base.data(), towers, nullptr);
     for (std::size_t t = 0; t < towers; ++t) {
         hazeTagOutput(r0[t]);
         hazeTagOutput(r1[t]);
     }
     hazeFlush();
 
-    // ---- Read the haze-computed limbs back (pure shadow reads). ----
+    // ---- Read both result polynomials back as whole MRP groups (shadow reads). ----
     std::vector<std::vector<uint64_t>> res0(towers, std::vector<uint64_t>(N));
     std::vector<std::vector<uint64_t>> res1(towers, std::vector<uint64_t>(N));
+    std::vector<void *> res0_ptrs(towers), res1_ptrs(towers);
     for (std::size_t t = 0; t < towers; ++t) {
-        hazeMemcpy(res0[t].data(), r0[t], bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
-        hazeMemcpy(res1[t].data(), r1[t], bytes, HAZE_MEMCPY_DEVICE_TO_HOST);
+        res0_ptrs[t] = res0[t].data();
+        res1_ptrs[t] = res1[t].data();
     }
+    hazeMemcpyMrp(res0_ptrs.data(), r0.data(), bytes, HAZE_MEMCPY_DEVICE_TO_HOST,
+                  q_base.data(), towers);
+    hazeMemcpyMrp(res1_ptrs.data(), r1.data(), bytes, HAZE_MEMCPY_DEVICE_TO_HOST,
+                  q_base.data(), towers);
 
     // ---- Inject the limbs into a correctly-shaped OpenFHE shell and decrypt. ----
     auto shell = cc->EvalAdd(ct1, ct2)->Clone();

--- a/flake.nix
+++ b/flake.nix
@@ -571,6 +571,32 @@
             touch "$out"
           '';
 
+          # README examples: extract the fenced C + C++ examples from README.md,
+          # compile each against the shipped libhaze (+ stock OpenFHE for the
+          # C++ one), and run them through the in-process FHETCH simulator.
+          # Docs-as-tests: the published snippets cannot drift without failing
+          # CI. Points the script at the prebuilt store paths (no rebuild) and
+          # runs in $TMPDIR so no recording artifacts land in the source root.
+          readme-examples =
+            pkgs.runCommand "haze-readme-examples"
+              {
+                nativeBuildInputs = [ pkgs.clang ];
+                HAZE_LIB_DIR = "${p.haze}/lib";
+                HAZE_INCLUDE_DIR = "${p.haze}/include";
+                # replay_bridge.h is not installed into the haze package's
+                # include dir; supply it straight from the source tree.
+                HAZE_BRIDGE_INCLUDE_DIR = "${./replay_bridge/include}";
+                STOCK_OPENFHE_DIR = "${p.openfhe-stock}";
+                README = "${./README.md}";
+                CC = "clang";
+                CXX = "clang++";
+              }
+              ''
+                export HAZE_RUNS_DIR="$TMPDIR/runs"
+                bash ${./scripts/test_readme_examples.sh}
+                touch "$out"
+              '';
+
           # Isolation guard: assert the shipped libhaze exports ONLY the haze* C
           # ABI (no leaked OpenFHE symbols), the property that lets it coexist
           # with another OpenFHE in one process. A leak wouldn't fail the build,

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -101,6 +101,36 @@ HAZE_API hazeError_t hazeMemcpyMrp(void *const *dst, const void *const *src, siz
                                    hazeMemcpyKind kind, const uint64_t *base,
                                    size_t base_len) HAZE_NOEXCEPT;
 
+// Per-residue (MRP) allocation. hazeMallocMrp reserves `count` device
+// polynomials for one MRP group and writes their addresses into
+// `ptrs[0..count)`. `count` is the group's residue count (the `base_len`
+// passed to the MRP compute ops); `size` is the bytes per residue and must
+// equal the configured polynomial size (ring_dim * sizeof(uint64_t)) — same
+// rule and same error (HAZE_ERROR_ALLOC_TOO_SMALL) as hazeMalloc, and
+// hazeSetRingDimension must precede the first allocation (else
+// HAZE_ERROR_CONFIGERR). The group is reserved under a single allocator lock
+// rather than `count` separate hazeMalloc calls. Like hazeMalloc/hazeFree,
+// these are pure allocator operations and are not recorded into the trace.
+//
+// Partial-failure rollback: if the i-th reservation fails, the 0..i-1 already
+// reserved are freed and the error returned, so nothing leaks and `ptrs` is
+// left unwritten. On success every ptrs[j] is non-null. `count == 0` is a
+// success no-op (empty group), but `ptrs == NULL` is checked first, so
+// (NULL, 0) returns HAZE_ERROR_INVALID_VALUE; a `count` above the device
+// modulus envelope (hazeDeviceProp::maxCiphertextModuli) is rejected the same
+// way rather than attempting an unbounded reservation.
+HAZE_API hazeError_t hazeMallocMrp(void **ptrs, size_t count, size_t size) HAZE_NOEXCEPT;
+
+// Free the `count`-residue MRP group in `ptrs[0..count)` (addresses from
+// hazeMallocMrp or any `count` hazeMalloc results) under a single allocator
+// lock. Every address is freed even if one fails; the first error is
+// returned. NULL entries are skipped, matching hazeFree(NULL). Freeing an
+// address that is not currently allocated (e.g. a double free) returns
+// HAZE_ERROR_UNKNOWN_ADDRESS. `count == 0` is a no-op, but `ptrs == NULL` is
+// checked first so (NULL, 0) returns HAZE_ERROR_INVALID_VALUE; a `count`
+// above the device modulus envelope is rejected the same way.
+HAZE_API hazeError_t hazeFreeMrp(void *const *ptrs, size_t count) HAZE_NOEXCEPT;
+
 // Declare `ptr` an output of the in-flight recording (tagging any one residue
 // of an MRP value tags the whole value). HAZE_ERROR_SOURCE_UNAVAILABLE if `ptr`
 // names no recorded value; a later H2D to a tagged address drops the tag. A

--- a/scripts/test_readme_examples.sh
+++ b/scripts/test_readme_examples.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# test_readme_examples.sh - extract, compile, and run the README examples.
+#
+# Usage:
+#   scripts/test_readme_examples.sh            # extract + compile + run (the check)
+#   scripts/test_readme_examples.sh --check    # alias for the default
+#   scripts/test_readme_examples.sh --help
+#
+# Docs-as-tests: the two fenced examples in README.md (a pure-C 22-limb raw add
+# and a C++ 22-limb CKKS add) are the source of truth. This script pulls each
+# marked block out of README.md, compiles it against the shipped libhaze, runs
+# it through the in-process FHETCH simulator (HAZE_TARGET=local), and asserts
+# exit 0 plus the expected output token. It fails loudly if a marker region is
+# missing or a compile/run/assert fails, so the published code cannot rot.
+#
+# Resolves the repo root from `git rev-parse` (falls back to the script's
+# `$(dirname BASH_SOURCE)/..` outside a git checkout, e.g. inside a nix
+# derivation sandbox where the source tree has no .git).
+#
+# Environment overrides (all have defaults resolved from the repo root):
+#   BUILD_DIR                build tree name (default: build).
+#   HAZE_INCLUDE_DIR         public haze headers   (default: $root/include).
+#   HAZE_BRIDGE_INCLUDE_DIR  replay-bridge header  (default:
+#                            $root/replay_bridge/include). The C example calls
+#                            hazeReplayBridgeInitCryptoContext, declared there.
+#   HAZE_LIB_DIR             dir holding libhaze.*  (default: $root/$BUILD_DIR).
+#   STOCK_OPENFHE_DIR        stock OpenFHE prefix   (default:
+#                            $root/vendor/lib/openfhe-stock). C++ only.
+#   HAZE_RUNS_DIR            writable dir the examples run in so libnbfhetch's
+#                            program_dir stays out of the source root (default:
+#                            $root/$BUILD_DIR/runs).
+#   CC / CXX                 compilers (default: cc / c++).
+
+set -euo pipefail
+
+case "${1:-}" in
+    -h | --help)
+        sed -n '/^# Usage:/,/^$/p' "$0" | sed 's/^# \?//'
+        exit 0
+        ;;
+    --check | "") ;;
+    *)
+        printf '%s: unknown argument: %s\n' "$(basename "$0")" "$1" >&2
+        exit 2
+        ;;
+esac
+
+if root=$(git rev-parse --show-toplevel 2>/dev/null); then
+    cd "$root"
+else
+    root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+    cd "$root"
+fi
+
+readme="${README:-$root/README.md}"
+build_dir="${BUILD_DIR:-build}"
+haze_include_dir="${HAZE_INCLUDE_DIR:-$root/include}"
+haze_bridge_include_dir="${HAZE_BRIDGE_INCLUDE_DIR:-$root/replay_bridge/include}"
+haze_lib_dir="${HAZE_LIB_DIR:-$root/$build_dir}"
+stock_openfhe_dir="${STOCK_OPENFHE_DIR:-$root/vendor/lib/openfhe-stock}"
+runs_dir="${HAZE_RUNS_DIR:-$root/$build_dir/runs}"
+cc="${CC:-cc}"
+cxx="${CXX:-c++}"
+
+[[ -f "$readme" ]] || {
+    printf 'error: README not found: %s\n' "$readme" >&2
+    exit 1
+}
+[[ -d "$haze_lib_dir" ]] || {
+    printf 'error: HAZE_LIB_DIR not found: %s (build libhaze first)\n' "$haze_lib_dir" >&2
+    exit 1
+}
+
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/readme-examples.XXXXXX")
+trap 'rm -rf "$scratch"' EXIT
+
+# Pull the fenced code of the readme-example region named $1 out of the README,
+# stripping the ``` fence lines. Prints to stdout; empty output means the region
+# was absent or malformed.
+extract_block() {
+    local name="$1"
+    awk -v want="$name" '
+        /^<!-- readme-example:begin / { active = ($0 ~ ("name=" want " ")); next }
+        /^<!-- readme-example:end/    { if (active) exit; next }
+        active && /^```/              { infence = !infence; next }
+        active && infence             { print }
+    ' "$readme"
+}
+
+extract_to() {
+    local name="$1" out="$2"
+    extract_block "$name" >"$out"
+    [[ -s "$out" ]] || {
+        printf 'error: README region name=%s is missing or empty\n' "$name" >&2
+        exit 1
+    }
+}
+
+extract_to quickstart "$scratch/quickstart.c"
+extract_to ckks22 "$scratch/ckks22.cpp"
+
+printf '[readme] compiling C example (quickstart.c)\n'
+"$cc" -std=c11 -O2 \
+    -I"$haze_include_dir" -I"$haze_bridge_include_dir" \
+    "$scratch/quickstart.c" \
+    -L"$haze_lib_dir" -lhaze \
+    -Wl,-rpath,"$haze_lib_dir" \
+    -o "$scratch/quickstart"
+
+printf '[readme] compiling C++ example (ckks22.cpp)\n'
+"$cxx" -std=c++17 -O2 \
+    -I"$haze_include_dir" -I"$haze_bridge_include_dir" \
+    -isystem "$stock_openfhe_dir/include/openfhe" \
+    -isystem "$stock_openfhe_dir/include/openfhe/core" \
+    -isystem "$stock_openfhe_dir/include/openfhe/pke" \
+    -isystem "$stock_openfhe_dir/include/openfhe/binfhe" \
+    "$scratch/ckks22.cpp" \
+    -L"$haze_lib_dir" -lhaze \
+    -L"$stock_openfhe_dir/lib" -lOPENFHEpke -lOPENFHEbinfhe -lOPENFHEcore \
+    -pthread \
+    -Wl,-rpath,"$haze_lib_dir" -Wl,-rpath,"$stock_openfhe_dir/lib" \
+    -o "$scratch/ckks22"
+
+# Run $bin from the runs dir under the local simulator; assert exit 0 and that
+# $token appears in its output. Prints elapsed wall seconds and the token line.
+run_example() {
+    local label="$1" bin="$2" token="$3"
+    mkdir -p "$runs_dir"
+    local start end out rc
+    start=$(date +%s)
+    if out="$(cd "$runs_dir" && HAZE_TARGET=local "$bin" 2>&1)"; then rc=0; else rc=$?; fi
+    end=$(date +%s)
+    if [[ $rc -ne 0 ]]; then
+        printf '[readme] %s FAILED: exit %d\n' "$label" "$rc" >&2
+        printf '%s\n' "$out" >&2
+        return 1
+    fi
+    if ! grep -qF "$token" <<<"$out"; then
+        printf '[readme] %s FAILED: token %s not found in output\n' "$label" "$token" >&2
+        printf '%s\n' "$out" >&2
+        return 1
+    fi
+    printf '[readme] %s passed in %ds wall — %s\n' \
+        "$label" "$((end - start))" "$(grep -F "$token" <<<"$out" | tail -n1)"
+}
+
+run_example "C example" "$scratch/quickstart" "readme-c: OK"
+run_example "C++ example" "$scratch/ckks22" "readme-cpp: OK"
+
+printf '[readme] all README examples compiled and passed\n'

--- a/scripts/test_readme_examples.sh
+++ b/scripts/test_readme_examples.sh
@@ -80,7 +80,7 @@ trap 'rm -rf "$scratch"' EXIT
 extract_block() {
     local name="$1"
     awk -v want="$name" '
-        /^<!-- readme-example:begin / { active = ($0 ~ ("name=" want " ")); next }
+        /^<!-- readme-example:begin / { active = (index($0, "name=" want " ") > 0); next }
         /^<!-- readme-example:end/    { if (active) exit; next }
         active && /^```/              { infence = !infence; next }
         active && infence             { print }
@@ -108,6 +108,7 @@ printf '[readme] compiling C example (quickstart.c)\n'
     -o "$scratch/quickstart"
 
 printf '[readme] compiling C++ example (ckks22.cpp)\n'
+# C++17 rather than the repo's C++23: the example is a portable consumer snippet.
 "$cxx" -std=c++17 -O2 \
     -I"$haze_include_dir" -I"$haze_bridge_include_dir" \
     -isystem "$stock_openfhe_dir/include/openfhe" \

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -13,15 +13,18 @@
 #include "common/errors.hpp"
 #include "common/handle.hpp"
 #include "core/allocator.hpp"
+#include "core/device.hpp"
 #include "core/epoch.hpp"
 #include "core/mrp_polymap.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstdlib>
 #include <expected>
 #include <haze/haze.h>
 #include <haze/haze_types.h>
 #include <unistd.h>
+#include <vector>
 
 extern "C" hazeError_t hazeMalloc(void **ptr, size_t size) noexcept {
     if (ptr == nullptr)
@@ -37,6 +40,47 @@ extern "C" hazeError_t hazeFree(void *ptr) noexcept {
     if (ptr != nullptr)
         haze::epoch().invalidate(haze::to_dev_addr(ptr));
     return set_internal_result(haze::allocator().free(haze::to_dev_addr(ptr)));
+}
+
+extern "C" hazeError_t hazeMallocMrp(void **ptrs, size_t count, size_t size) noexcept {
+    // ptrs is checked before count, so (NULL, 0) returns INVALID_VALUE.
+    if (ptrs == nullptr)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    // Bound count to the device modulus envelope before any reservation so an
+    // absurd value cannot throw std::length_error across this noexcept boundary.
+    if (count > static_cast<size_t>(haze::kMaxCiphertextModuli))
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    auto result = haze::allocator().allocate_many(count, size);
+    if (!result)
+        return set_error(haze::to_public_error(result.error()));
+    // On success the allocator returns exactly `count` addresses; only then
+    // is `ptrs` written (rollback leaves it untouched).
+    for (size_t i = 0; i < count; ++i)
+        ptrs[i] = haze::to_void_ptr((*result)[i]);
+    return HAZE_SUCCESS;
+}
+
+extern "C" hazeError_t hazeFreeMrp(void *const *ptrs, size_t count) noexcept {
+    // ptrs is checked before count, so (NULL, 0) returns INVALID_VALUE.
+    if (ptrs == nullptr)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    // Bound count before the reservation below (same noexcept concern as
+    // hazeMallocMrp).
+    if (count > static_cast<size_t>(haze::kMaxCiphertextModuli))
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    // Mirror hazeFree: drop each live address's epoch polymap binding first.
+    // epoch().invalidate takes (and releases) the epoch lock before the
+    // single allocator lock in free_many, preserving the epoch -> allocator
+    // lock order.
+    std::vector<haze::DevAddr> addrs;
+    addrs.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        const haze::DevAddr addr = haze::to_dev_addr(ptrs[i]);
+        if (ptrs[i] != nullptr)
+            haze::epoch().invalidate(addr);
+        addrs.push_back(addr);
+    }
+    return set_internal_result(haze::allocator().free_many(addrs));
 }
 
 extern "C" hazeError_t hazeMallocAsync(void **ptr, size_t size, hazeStream_t /*stream*/) noexcept {

--- a/src/core/allocator.cpp
+++ b/src/core/allocator.cpp
@@ -16,10 +16,12 @@
 #include "common/handle.hpp"
 #include "common/thread_safety.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <expected>
 #include <haze/haze_types.h>
+#include <span>
 #include <utility>
 #include <vector>
 
@@ -51,9 +53,8 @@ size_t DeviceAllocator::polynomial_size() const noexcept {
     return poly_bytes_;
 }
 
-std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate(size_t bytes) noexcept {
-    HazeLockGuard lock(mutex_);
-
+std::expected<void, HazeInternalError>
+DeviceAllocator::validate_poly_size_locked(size_t bytes) const noexcept {
     // Polynomial size must be configured (via Config::set_ring_dimension)
     // before any allocation. HAZE's device space is FHETCH-addressable
     // storage — without a known polynomial size we cannot serve it.
@@ -73,21 +74,25 @@ std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate(size_t bytes
                               "DeviceAllocator::allocate: size != polynomial bytes");
         return std::unexpected(HazeInternalError::AllocTooSmall);
     }
+    return {};
+}
 
-    // Recycle from the free list when available. The shadow_data_
-    // entry was already evicted at hazeFree time; the recycled DevAddr
-    // starts in the same "no shadow, no data" state as a fresh one.
+std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate_one_locked() noexcept {
+    // Recycle from the free list when available. Both the shadow_data_ entry
+    // and alloc_set_ membership were dropped at hazeFree time, so a pooled
+    // DevAddr must NOT currently be live; if it is, pool_free_ and alloc_set_
+    // have desynced (a double-push or a live addr wrongly pooled).
     if (!pool_free_.empty()) {
         DevAddr addr = pool_free_.back();
         pool_free_.pop_back();
         if (alloc_set_.contains(addr)) {
-            return addr;
+            record_internal_error(HazeInternalError::PoolMapDesync,
+                                  "DeviceAllocator::allocate (recycled addr already live)");
+            return std::unexpected(HazeInternalError::PoolMapDesync);
         }
-        // pool_free_ entry without an alloc_set_ peer means internal
-        // state is corrupt; fail rather than mint a fresh DevAddr.
-        record_internal_error(HazeInternalError::PoolMapDesync,
-                              "DeviceAllocator::allocate (pool_free_ -> alloc_set_)");
-        return std::unexpected(HazeInternalError::PoolMapDesync);
+        // Re-establish liveness for the recycled addr.
+        alloc_set_.insert(addr);
+        return addr;
     }
 
     // Fresh allocation: bump the address counter by exactly poly_bytes_.
@@ -99,22 +104,84 @@ std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate(size_t bytes
     return addr;
 }
 
+std::expected<void, HazeInternalError> DeviceAllocator::free_one_locked(DevAddr addr) noexcept {
+    if (!alloc_set_.contains(addr)) {
+        // Not live: an unknown address or a double free. Reject rather than
+        // re-pool it — re-pooling would later hand the same DevAddr out to two
+        // live allocations (aliasing).
+        record_internal_error(HazeInternalError::UnknownAddress, "DeviceAllocator::free");
+        return std::unexpected(HazeInternalError::UnknownAddress);
+    }
+    // Lifetime ends here: drop liveness and the shadow bytes, and pool the
+    // DevAddr for the next allocate() to recycle.
+    alloc_set_.erase(addr);
+    shadow_data_.erase(addr);
+    pool_free_.push_back(addr);
+    return {};
+}
+
+std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate(size_t bytes) noexcept {
+    HazeLockGuard lock(mutex_);
+    if (auto ok = validate_poly_size_locked(bytes); !ok) {
+        return std::unexpected(ok.error());
+    }
+    return allocate_one_locked();
+}
+
+std::expected<std::vector<DevAddr>, HazeInternalError>
+DeviceAllocator::allocate_many(size_t count, size_t bytes) noexcept {
+    std::vector<DevAddr> out;
+    if (count == 0) {
+        return out; // Empty MRP group: nothing to reserve.
+    }
+    HazeLockGuard lock(mutex_);
+    if (auto ok = validate_poly_size_locked(bytes); !ok) {
+        return std::unexpected(ok.error());
+    }
+    // The C-ABI shim bounds `count` to kMaxCiphertextModuli before calling in,
+    // so this reservation can never request an unbounded size.
+    out.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        auto addr = allocate_one_locked();
+        if (!addr) {
+            // Roll back everything reserved in THIS call so nothing leaks and
+            // no partially-populated result escapes. Each `done` was just
+            // reserved, so free_one_locked cannot fail on it.
+            for (DevAddr done : out) {
+                [[maybe_unused]] const auto rolled_back = free_one_locked(done);
+            }
+            return std::unexpected(addr.error());
+        }
+        out.push_back(*addr);
+    }
+    return out;
+}
+
 std::expected<void, HazeInternalError> DeviceAllocator::free(DevAddr addr) noexcept {
     if (to_uintptr(addr) == 0) {
         // hazeFree(nullptr) matches CUDA semantics: silent success.
         return {};
     }
     HazeLockGuard lock(mutex_);
-    if (!alloc_set_.contains(addr)) {
-        record_internal_error(HazeInternalError::UnknownAddress, "DeviceAllocator::free");
-        return std::unexpected(HazeInternalError::UnknownAddress);
+    return free_one_locked(addr);
+}
+
+std::expected<void, HazeInternalError>
+DeviceAllocator::free_many(std::span<const DevAddr> addrs) noexcept {
+    if (addrs.empty()) {
+        return {};
     }
-    // Evict the shadow — those bytes are no longer the user's to read.
-    // The DevAddr stays in alloc_set_ and goes onto the free list for
-    // the next allocate() to recycle.
-    shadow_data_.erase(addr);
-    pool_free_.push_back(addr);
-    return {};
+    HazeLockGuard lock(mutex_);
+    std::expected<void, HazeInternalError> first_error{};
+    for (DevAddr addr : addrs) {
+        if (to_uintptr(addr) == 0) {
+            continue; // Null entry: skip, matching hazeFree(nullptr).
+        }
+        if (auto freed = free_one_locked(addr); !freed && first_error) {
+            first_error = std::unexpected(freed.error());
+        }
+    }
+    return first_error;
 }
 
 std::expected<std::vector<uint64_t>, HazeInternalError>

--- a/src/core/allocator.hpp
+++ b/src/core/allocator.hpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <expected>
 #include <haze/haze_types.h>
+#include <span>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -92,6 +93,25 @@ class DeviceAllocator {
     std::expected<DevAddr, HazeInternalError> allocate(size_t bytes) noexcept HAZE_EXCLUDES(mutex_);
     std::expected<void, HazeInternalError> free(DevAddr addr) noexcept HAZE_EXCLUDES(mutex_);
 
+    // Batched allocate/free for an MRP group: the mutex is taken ONCE for
+    // all `count` residues (not once per residue). Both reuse the single-poly
+    // logic under the lock.
+    //
+    // allocate_many reserves `count` polynomials of `bytes` each (each must
+    // equal the configured polynomial size, same contract as allocate). On
+    // any per-residue failure the polys already reserved in this call are
+    // freed and the error returned, so nothing leaks; on success the result
+    // holds exactly `count` addresses. count == 0 yields an empty result.
+    std::expected<std::vector<DevAddr>, HazeInternalError> allocate_many(size_t count,
+                                                                         size_t bytes) noexcept
+        HAZE_EXCLUDES(mutex_);
+
+    // free_many attempts every address; zero-valued (null) entries are
+    // skipped (hazeFree(nullptr) semantics). It frees all of them and returns
+    // the first error encountered, if any.
+    std::expected<void, HazeInternalError> free_many(std::span<const DevAddr> addrs) noexcept
+        HAZE_EXCLUDES(mutex_);
+
     // Bulk operations on a single allocation. Each path validates count
     // against the allocation size.
     std::expected<void, HazeInternalError> copy_h2d(DevAddr dst, const void *src,
@@ -152,8 +172,16 @@ class DeviceAllocator {
 
     friend class test::AllocatorTestAccess;
 
-    // Helper (caller holds mutex_).
+    // Helpers (caller holds mutex_). validate_poly_size_locked enforces the
+    // ring-dim-set + single-size contract; allocate_one_locked and
+    // free_one_locked are the single-poly bodies shared by the scalar and
+    // batched entry points so the logic lives in one place.
     void clear_pool_locked() noexcept HAZE_REQUIRES(mutex_);
+    std::expected<void, HazeInternalError> validate_poly_size_locked(size_t bytes) const noexcept
+        HAZE_REQUIRES(mutex_);
+    std::expected<DevAddr, HazeInternalError> allocate_one_locked() noexcept HAZE_REQUIRES(mutex_);
+    std::expected<void, HazeInternalError> free_one_locked(DevAddr addr) noexcept
+        HAZE_REQUIRES(mutex_);
 
     // mutex_ protects all state below. Lock order across HAZE: callers
     // already holding EpochState::mutex_ may re-enter here (epoch →

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -25,7 +25,6 @@ namespace {
 inline constexpr int kDeviceCount = 1;
 inline constexpr size_t kHbmSize = 16ULL * 1024 * 1024 * 1024; // 16 GB
 inline constexpr int kNumRegisters = 64;
-inline constexpr int kMaxCiphertextModuli = 64;
 inline constexpr int kNumHbmBanks = 8;
 // Ring dimension exponents 10..16 → N = 1024..65536.
 inline constexpr int kSupportedRingDimExponents[] = {10, 11, 12, 13, 14, 15, 16};

--- a/src/core/device.hpp
+++ b/src/core/device.hpp
@@ -19,6 +19,13 @@
 
 namespace haze {
 
+// Device ciphertext-modulus envelope (reported as
+// hazeDeviceProp::maxCiphertextModuli). Also the upper bound on an MRP
+// group's residue count: a valid group cannot span more residues than the
+// device supports moduli, so the C-ABI batch entry points reject a larger
+// `count` rather than attempting an unbounded reservation.
+inline constexpr int kMaxCiphertextModuli = 64;
+
 // Single-device runtime state. Only one device exists; the only valid
 // device index is 0. Free functions instead of a class — a class adds
 // nothing over a one-int counter and a couple of getters.

--- a/test/allocator_test_access.hpp
+++ b/test/allocator_test_access.hpp
@@ -27,6 +27,25 @@ class AllocatorTestAccess {
         std::forward<F>(f)(it->second.data(), it->second.size());
         return true;
     }
+
+    // Number of live DevAddrs (alloc_set_ membership). Lets a test assert
+    // that a failed allocation leaves nothing allocated.
+    static std::size_t alloc_set_size(const DeviceAllocator &a) noexcept {
+        HazeLockGuard lock(a.mutex_);
+        return a.alloc_set_.size();
+    }
+
+    // Push a DevAddr to the FRONT of the free list. allocate pops from the
+    // back, so a free list of [wedge, recyclable] makes a two-poly batch
+    // recycle `recyclable` first, then pop `wedge`. Passing a still-LIVE addr
+    // as `wedge` makes that second pop hit the "recycled addr already live"
+    // PoolMapDesync path — the only way to exercise allocate_many's mid-batch
+    // rollback (unreachable via the public API otherwise). Depends on the
+    // allocator's LIFO free-list discipline.
+    static void push_front_pool_entry(DeviceAllocator &a, DevAddr addr) noexcept {
+        HazeLockGuard lock(a.mutex_);
+        a.pool_free_.insert(a.pool_free_.begin(), addr);
+    }
 };
 
 } // namespace haze::test

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -1,4 +1,9 @@
 // Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+#include "allocator_test_access.hpp"
+#include "common/handle.hpp"
+#include "core/allocator.hpp"
+#include "core/device.hpp"
+
 #include <algorithm>
 #include <catch2/catch_test_macros.hpp>
 #include <cstddef>
@@ -238,4 +243,261 @@ TEST_CASE("hazePointerGetAttributes rejects null attrs out-pointer", "[unit]") {
     int stack_local = 0;
     REQUIRE(hazePointerGetAttributes(nullptr, &stack_local) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
+}
+
+// ---------------------------------------------------------------------------
+// hazeMallocMrp / hazeFreeMrp — batched MRP-group allocation.
+// ---------------------------------------------------------------------------
+
+TEST_CASE("hazeMallocMrp allocates a usable group that hazeFreeMrp releases", "[unit]") {
+    constexpr size_t kN = 4096;
+    constexpr size_t kBytes = kN * sizeof(uint64_t);
+    constexpr size_t kCount = 4;
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kN) == HAZE_SUCCESS);
+
+    void *ptrs[kCount] = {};
+    REQUIRE(hazeMallocMrp(ptrs, kCount, kBytes) == HAZE_SUCCESS);
+    for (size_t i = 0; i < kCount; ++i) {
+        REQUIRE(ptrs[i] != nullptr);
+        for (size_t j = i + 1; j < kCount; ++j)
+            REQUIRE(ptrs[i] != ptrs[j]);
+    }
+
+    // Each poly is a normal allocation: H2D then D2H round-trips.
+    std::vector<uint64_t> src(kN);
+    for (size_t i = 0; i < kN; ++i)
+        src[i] = static_cast<uint64_t>(i) + 1;
+    for (void *ptr : ptrs) {
+        REQUIRE(hazeMemcpy(ptr, src.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+        std::vector<uint64_t> dst(kN, 0);
+        REQUIRE(hazeMemcpy(dst.data(), ptr, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        REQUIRE(dst == src);
+    }
+    REQUIRE(hazeFreeMrp(ptrs, kCount) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeMallocMrp/hazeFreeMrp round-trip recycles the group", "[unit]") {
+    constexpr size_t kBytes = 4096 * sizeof(uint64_t);
+    constexpr size_t kCount = 3;
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+
+    void *g1[kCount] = {};
+    REQUIRE(hazeMallocMrp(g1, kCount, kBytes) == HAZE_SUCCESS);
+    const std::vector<void *> first(g1, g1 + kCount);
+    REQUIRE(hazeFreeMrp(g1, kCount) == HAZE_SUCCESS);
+
+    void *g2[kCount] = {};
+    REQUIRE(hazeMallocMrp(g2, kCount, kBytes) == HAZE_SUCCESS);
+    for (void *addr : g2)
+        REQUIRE(std::ranges::find(first, addr) != first.end());
+    REQUIRE(hazeFreeMrp(g2, kCount) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeMallocMrp with count 0 is a success no-op", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    void *const sentinel = reinterpret_cast<void *>(0x5A5A);
+    void *ptrs[1] = {sentinel};
+    REQUIRE(hazeMallocMrp(ptrs, 0, 32768) == HAZE_SUCCESS);
+    REQUIRE(ptrs[0] == sentinel); // left untouched
+}
+
+TEST_CASE("hazeMallocMrp before hazeSetRingDimension is rejected", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    void *ptrs[2] = {};
+    REQUIRE(hazeMallocMrp(ptrs, 2, 32768) == HAZE_ERROR_CONFIGERR);
+    hazeGetLastError();
+}
+
+TEST_CASE("hazeMallocMrp with null ptrs is rejected", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    REQUIRE(hazeMallocMrp(nullptr, 4, 32768) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+}
+
+TEST_CASE("hazeMallocMrp with wrong size is rejected and allocates nothing", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    const auto &alloc = haze::DeviceAllocator::instance();
+    REQUIRE(haze::test::AllocatorTestAccess::alloc_set_size(alloc) == 0);
+
+    void *ptrs[3] = {reinterpret_cast<void *>(0xA), reinterpret_cast<void *>(0xB),
+                     reinterpret_cast<void *>(0xC)};
+    // ring_dim=4096 -> polynomial bytes = 32768; an 8KB request fails.
+    REQUIRE(hazeMallocMrp(ptrs, 3, 8192) == HAZE_ERROR_ALLOC_TOO_SMALL);
+    hazeGetLastError();
+    // Validation fails before any reservation: ptrs untouched, nothing live.
+    REQUIRE(ptrs[0] == reinterpret_cast<void *>(0xA));
+    REQUIRE(ptrs[2] == reinterpret_cast<void *>(0xC));
+    REQUIRE(haze::test::AllocatorTestAccess::alloc_set_size(alloc) == 0);
+}
+
+TEST_CASE("hazeMallocMrp rolls back reserved polys on a mid-batch failure", "[unit]") {
+    constexpr size_t kBytes = 4096 * sizeof(uint64_t);
+    auto &alloc = haze::DeviceAllocator::instance();
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+
+    // p stays live; r is freed so the batch can recycle it as residue 0.
+    void *p = nullptr;
+    void *r = nullptr;
+    REQUIRE(hazeMalloc(&p, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&r, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(r) == HAZE_SUCCESS);
+    const size_t live_before = haze::test::AllocatorTestAccess::alloc_set_size(alloc);
+
+    // Wedge a still-live addr (p) in front of the recyclable r: the batch
+    // recycles r for residue 0, then pops p for residue 1 and hits the
+    // "recycled addr already live" desync, forcing rollback of residue 0.
+    haze::test::AllocatorTestAccess::push_front_pool_entry(alloc, haze::to_dev_addr(p));
+
+    void *ptrs[2] = {reinterpret_cast<void *>(0x1111), reinterpret_cast<void *>(0x2222)};
+    REQUIRE(hazeMallocMrp(ptrs, 2, kBytes) == HAZE_ERROR_INTERNAL);
+    hazeGetLastError();
+
+    // Rollback freed the recycled residue: nothing extra is live, ptrs untouched.
+    REQUIRE(haze::test::AllocatorTestAccess::alloc_set_size(alloc) == live_before);
+    REQUIRE(ptrs[0] == reinterpret_cast<void *>(0x1111));
+
+    // Clear the injected corruption before the next case.
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeFreeMrp with null ptrs is rejected", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeFreeMrp(nullptr, 2) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+}
+
+TEST_CASE("hazeFreeMrp with count 0 is a success no-op", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    void *ptrs[1] = {nullptr};
+    REQUIRE(hazeFreeMrp(ptrs, 0) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeFreeMrp skips null entries and frees the rest", "[unit]") {
+    constexpr size_t kBytes = 4096 * sizeof(uint64_t);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    void *a = nullptr;
+    void *b = nullptr;
+    REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&b, kBytes) == HAZE_SUCCESS);
+
+    void *group[3] = {a, nullptr, b}; // middle entry null -> skipped
+    REQUIRE(hazeFreeMrp(group, 3) == HAZE_SUCCESS);
+
+    // Both real addresses were freed into the pool: the next two allocations
+    // recycle them (proving neither the null entry nor its neighbours were
+    // dropped).
+    void *r0 = nullptr;
+    void *r1 = nullptr;
+    REQUIRE(hazeMalloc(&r0, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&r1, kBytes) == HAZE_SUCCESS);
+    REQUIRE((r0 == a || r0 == b));
+    REQUIRE((r1 == a || r1 == b));
+    REQUIRE(r0 != r1);
+    REQUIRE(hazeFree(r0) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(r1) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeMallocMrp rejects an out-of-range count without allocating", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    const auto &alloc = haze::DeviceAllocator::instance();
+    void *ptrs[1] = {reinterpret_cast<void *>(0x1234)};
+
+    // count = SIZE_MAX and count = cap+1 both reject before any reserve, so
+    // the giant reservation is never attempted (no abort, no OOM).
+    REQUIRE(hazeMallocMrp(ptrs, SIZE_MAX, 32768) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    REQUIRE(hazeMallocMrp(ptrs, static_cast<size_t>(haze::kMaxCiphertextModuli) + 1, 32768) ==
+            HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+
+    REQUIRE(ptrs[0] == reinterpret_cast<void *>(0x1234)); // untouched
+    REQUIRE(haze::test::AllocatorTestAccess::alloc_set_size(alloc) == 0);
+}
+
+TEST_CASE("hazeFreeMrp rejects an out-of-range count", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    void *ptrs[1] = {nullptr};
+    REQUIRE(hazeFreeMrp(ptrs, SIZE_MAX) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    REQUIRE(hazeFreeMrp(ptrs, static_cast<size_t>(haze::kMaxCiphertextModuli) + 1) ==
+            HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+}
+
+TEST_CASE("hazeFree of an already-freed address is rejected", "[unit]") {
+    constexpr size_t kBytes = 4096 * sizeof(uint64_t);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    void *p = nullptr;
+    REQUIRE(hazeMalloc(&p, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(p) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(p) == HAZE_ERROR_UNKNOWN_ADDRESS); // double free rejected
+    hazeGetLastError();
+}
+
+TEST_CASE("malloc after free does not alias a second live allocation", "[unit]") {
+    constexpr size_t kBytes = 4096 * sizeof(uint64_t);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    void *a = nullptr;
+    REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(a) == HAZE_SUCCESS);
+    void *b = nullptr;
+    void *c = nullptr;
+    REQUIRE(hazeMalloc(&b, kBytes) == HAZE_SUCCESS); // recycles a
+    REQUIRE(hazeMalloc(&c, kBytes) == HAZE_SUCCESS); // fresh
+    REQUIRE(b != c);                                 // two live allocations, no aliasing
+    REQUIRE(hazeFree(b) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(c) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeFreeMrp of an already-freed group is rejected and does not alias", "[unit]") {
+    constexpr size_t kBytes = 4096 * sizeof(uint64_t);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    void *g[1] = {};
+    REQUIRE(hazeMallocMrp(g, 1, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeFreeMrp(g, 1) == HAZE_SUCCESS);
+    REQUIRE(hazeFreeMrp(g, 1) == HAZE_ERROR_UNKNOWN_ADDRESS); // double free rejected
+    hazeGetLastError();
+
+    // The rejected second free must not have re-pooled the addr: two live
+    // allocations get distinct addresses.
+    void *x = nullptr;
+    void *y = nullptr;
+    REQUIRE(hazeMalloc(&x, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&y, kBytes) == HAZE_SUCCESS);
+    REQUIRE(x != y);
+    REQUIRE(hazeFree(x) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(y) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeFreeMrp frees every entry and returns the first error", "[unit]") {
+    constexpr size_t kBytes = 4096 * sizeof(uint64_t);
+    auto &alloc = haze::DeviceAllocator::instance();
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    void *a = nullptr;
+    void *bad = nullptr;
+    void *b = nullptr;
+    REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&bad, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&b, kBytes) == HAZE_SUCCESS);
+    // Pre-free `bad` so freeing it again inside the group is an error.
+    REQUIRE(hazeFree(bad) == HAZE_SUCCESS);
+    const size_t live_before = haze::test::AllocatorTestAccess::alloc_set_size(alloc); // a, b
+
+    void *group[3] = {a, bad, b};
+    REQUIRE(hazeFreeMrp(group, 3) == HAZE_ERROR_UNKNOWN_ADDRESS); // first (and only) error
+    hazeGetLastError();
+    // Despite bad's error, a and b were still freed: two fewer live.
+    REQUIRE(haze::test::AllocatorTestAccess::alloc_set_size(alloc) == live_before - 2);
 }


### PR DESCRIPTION
Turn the two README examples into docs-as-tests so the published snippets cannot silently rot. 

scripts/test_readme_examples.sh extracts each marked block and runs it through the in-process simulator. Gated three ways: a make test-readme target, a build-test workflow step, and a readme-examples flake check.

Additionally fixes a double free bug.