### PR TITLE
refactor(core): extract MrpGroupRegistry from EpochState

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ add_library(haze_objs OBJECT
   src/core/device.cpp
   src/core/epoch.cpp
   src/core/mrp_polymap.cpp
+  src/core/mrp_registry.cpp
   src/core/polynomial_io.cpp
   src/core/stream.cpp
   # Shared leaf utilities.
@@ -435,6 +436,7 @@ add_executable(haze_tests
   test/test_replay_bridge_program_dir.cpp
   test/test_hardware_format.cpp
   test/test_invariant_regressions.cpp
+  test/test_mrp_registry.cpp
   # End-to-end OpenFHE-pipeline tests (real encrypt/decrypt around haze ops).
   # Tagged [integration][e2e] in Catch2 so they run under haze_sim_tests.
   # `ops.cpp` is the shared per-mode operation library these tests build on.

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -20,8 +20,6 @@
 #include "core/config.hpp"
 #include "core/polynomial_io.hpp"
 
-#include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <expected>
@@ -74,45 +72,17 @@ std::expected<void, HazeInternalError> EpochState::require_recording_locked() co
     return std::unexpected(HazeInternalError::BackendInitFailed);
 }
 
-void EpochState::evict_mrp_group_locked(const std::string &name) noexcept {
-    auto group_it = known_mrp_groups_.find(name);
-    if (group_it == known_mrp_groups_.end())
-        return;
-    for (DevAddr member : group_it->second.addrs) {
-        auto o = addr_to_mrp_groups_.find(member);
-        if (o == addr_to_mrp_groups_.end())
-            continue;
-        o->second.erase(name);
-        if (o->second.empty())
-            addr_to_mrp_groups_.erase(o);
-    }
-    known_mrp_groups_.erase(group_it);
-    pending_mrp_groups_.erase(name);
-}
-
 void EpochState::invalidate(DevAddr addr) noexcept {
     HazeLockGuard lock(mutex_);
-    // Drop any MRP group that names addr so a recycled allocation can't
-    // bind a stale group entry to a new polynomial at replay time.
-    if (auto rev_it = addr_to_mrp_groups_.find(addr); rev_it != addr_to_mrp_groups_.end()) {
-        // Move the names out and erase addr's entry first: evict's per-member
-        // sweep edits the reverse map (would invalidate rev_it) and skips addr
-        // for free (replaces the old `if (other == addr) continue;` guard).
-        auto group_names = std::move(rev_it->second);
-        addr_to_mrp_groups_.erase(rev_it);
-        for (const auto &name : group_names)
-            evict_mrp_group_locked(name);
-    }
+    // Drop any MRP group (and leading-addr names) so a recycled allocation
+    // can't bind stale group state to a new polynomial at replay time.
+    mrp_.invalidate(addr);
     // pending_outputs_ is a subset of poly_map_; erase-on-miss is O(1), so
     // unconditional double-erase is simpler than tagging addrs by owner.
     poly_map_.erase(addr);
     pending_outputs_.erase(addr);
     addr_modulus_.erase(addr);
     input_addrs_.erase(addr);
-    // A recycled allocation leading a new group gets a fresh name rather
-    // than colliding with a possibly-pending group from its previous life.
-    mrp_in_names_.erase(addr);
-    mrp_out_names_.erase(addr);
 }
 
 std::expected<niobium::fhetch::Polynomial, HazeInternalError>
@@ -169,6 +139,11 @@ uint64_t EpochState::recorded_modulus_locked(DevAddr addr) const noexcept {
     return it == addr_modulus_.end() ? kCopyModulus : it->second;
 }
 
+void EpochState::ensure_output_tag_locked(DevAddr addr) {
+    if (!pending_outputs_.contains(addr))
+        pending_outputs_.emplace(addr, "haze_out_" + std::to_string(output_counter_++));
+}
+
 std::expected<void, HazeInternalError> EpochState::tag_output_locked(DevAddr addr) {
     if (!poly_map_.contains(addr)) {
         record_internal_error(HazeInternalError::SourceUnavailable,
@@ -176,24 +151,12 @@ std::expected<void, HazeInternalError> EpochState::tag_output_locked(DevAddr add
         return std::unexpected(HazeInternalError::SourceUnavailable);
     }
     // An MRP residue tags every residue of its group and promotes the group.
-    if (auto rev = addr_to_mrp_groups_.find(addr); rev != addr_to_mrp_groups_.end()) {
-        // Registration keeps an addr in at most one group (and erases empty
-        // reverse entries), so this set holds exactly one name; the loop is
-        // kept as defense in depth should that invariant ever relax.
-        assert(rev->second.size() == 1);
-        for (const auto &group_name : rev->second) {
-            auto g = known_mrp_groups_.find(group_name);
-            if (g == known_mrp_groups_.end())
-                continue;
-            for (DevAddr a : g->second.addrs)
-                if (!pending_outputs_.contains(a))
-                    pending_outputs_.emplace(a, "haze_out_" + std::to_string(output_counter_++));
-            pending_mrp_groups_.insert(group_name);
-        }
+    if (auto members = mrp_.mark_group_output(addr)) {
+        for (DevAddr a : *members)
+            ensure_output_tag_locked(a);
         return {};
     }
-    if (!pending_outputs_.contains(addr))
-        pending_outputs_.emplace(addr, "haze_out_" + std::to_string(output_counter_++));
+    ensure_output_tag_locked(addr);
     return {};
 }
 
@@ -254,84 +217,21 @@ std::expected<void, HazeInternalError> EpochState::tag_h2d_input_locked(DevAddr 
 
 void EpochState::tag_mrp_input_if_new_locked(const std::string &name, const fhetch::MRP &mrp) {
     // Dedup so each name reaches fhetch exactly once.
-    if (auto [it, inserted] = mrp_input_tagged_names_.insert(name); inserted) {
-        fhetch::tag_input(*it, mrp);
-    }
+    if (mrp_.mark_input_tagged(name))
+        fhetch::tag_input(name, mrp);
 }
 
 std::expected<void, HazeInternalError>
-EpochState::register_mrp_output_group_locked(std::span<const DevAddr> addrs,
-                                             std::span<const uint64_t> moduli, std::string &&name) {
-    // One device address per modulus; a mismatch is a programming bug in
-    // the fan-out helper, surfaced rather than dropped silently.
-    if (addrs.size() != moduli.size()) {
-        std::ostringstream body;
-        body << "register_mrp_output_group_locked('" << name << "'): addrs.size()=" << addrs.size()
-             << " != moduli.size()=" << moduli.size();
-        record_internal_error(HazeInternalError::MrpGroupAddrModuliMismatch, body.str().c_str());
-        return std::unexpected(HazeInternalError::MrpGroupAddrModuliMismatch);
-    }
-    // Latest-write-wins registration. Identical re-registration (same op
-    // re-run, e.g. an in-place accumulation loop) is a cheap no-op; anything
-    // else replaces stale group state so a tagged readback assembles the
-    // membership of the most recent write, never a stale addr list / moduli.
-    auto existing = known_mrp_groups_.find(name);
-    if (existing != known_mrp_groups_.end() && existing->second.addrs.size() == addrs.size() &&
-        std::equal(addrs.begin(), addrs.end(), existing->second.addrs.begin()) &&
-        std::equal(moduli.begin(), moduli.end(), existing->second.moduli.begin())) {
-        // Safe to skip the conflict sweep below: any competing registration
-        // since this group's last write would have evicted it (existing would
-        // be end()), so no other group can claim these addrs right now.
-        return {};
-    }
-
-    // Any other group claiming one of the new addrs is falsified by this
-    // write: its multi-residue claim no longer describes what the addr holds.
-    // Evict it wholesale (mirrors invalidate() on free). Members keep their
-    // poly_map_ bindings and per-residue tags as standalone SRP values.
-    for (DevAddr a : addrs) {
-        auto rev = addr_to_mrp_groups_.find(a);
-        if (rev == addr_to_mrp_groups_.end())
-            continue;
-        // Copy: evict_mrp_group_locked edits the reverse map under us.
-        std::vector<std::string> conflicting(rev->second.begin(), rev->second.end());
-        for (const auto &other : conflicting)
-            if (other != name)
-                evict_mrp_group_locked(other);
-    }
-
-    if (existing != known_mrp_groups_.end()) {
-        // Same name, new shape (e.g. an in-place rescale re-using dst[0] with
-        // fewer residues): replace membership in place. pending_mrp_groups_
-        // stores names, so an already-tagged group exports the replacement.
-        for (DevAddr old_addr : existing->second.addrs) {
-            auto o = addr_to_mrp_groups_.find(old_addr);
-            if (o == addr_to_mrp_groups_.end())
-                continue;
-            o->second.erase(name);
-            if (o->second.empty())
-                addr_to_mrp_groups_.erase(o);
-        }
-        existing->second.addrs.assign(addrs.begin(), addrs.end());
-        existing->second.moduli.assign(moduli.begin(), moduli.end());
+EpochState::record_mrp_group_locked(std::span<const DevAddr> addrs,
+                                    std::span<const uint64_t> moduli, std::string &&name) {
+    auto was_pending = mrp_.record_mrp_group(addrs, moduli, std::move(name));
+    if (!was_pending)
+        return std::unexpected(was_pending.error());
+    // Replacing an already-pending group: every member needs an output tag
+    // for flush-time shadow population (tagging is idempotent).
+    if (*was_pending)
         for (DevAddr a : addrs)
-            addr_to_mrp_groups_[a].insert(name);
-        // A tagged group's members each carry a per-residue output tag so
-        // flush-time shadow population covers them; extend that to members
-        // introduced by the replacement.
-        if (pending_mrp_groups_.contains(name)) {
-            for (DevAddr a : addrs)
-                if (!pending_outputs_.contains(a))
-                    pending_outputs_.emplace(a, "haze_out_" + std::to_string(output_counter_++));
-        }
-        return {};
-    }
-
-    auto [it, inserted] = known_mrp_groups_.try_emplace(std::move(name));
-    it->second.addrs.assign(addrs.begin(), addrs.end());
-    it->second.moduli.assign(moduli.begin(), moduli.end());
-    for (DevAddr a : addrs)
-        addr_to_mrp_groups_[a].insert(it->first);
+            ensure_output_tag_locked(a);
     return {};
 }
 
@@ -350,36 +250,33 @@ std::expected<void, HazeInternalError> EpochState::tag_pending_outputs_locked() 
         fhetch::tag_output(name, it->second);
     }
 
-    // Also tag each MRP group as a fhetch MRP output so external callers
-    // can pull the multi-residue view via fhetch::result(name, MRP&).
-    // pending_mrp_groups_ holds names; resolve through known_mrp_groups_ so
-    // the membership exported is the latest registration for that name.
-    for (const auto &name : pending_mrp_groups_) {
-        auto g_it = known_mrp_groups_.find(name);
-        if (g_it == known_mrp_groups_.end()) {
-            // pending ⊆ known is maintained by registration/eviction; a miss
-            // here is a state-management bug, not recoverable.
+    // Also tag each pending MRP group as a fhetch MRP output so external
+    // callers can pull the multi-residue view via fhetch::result(name, MRP&);
+    // find() resolves the latest registration for the name.
+    for (const auto &name : mrp_.pending_names()) {
+        const auto *g = mrp_.find(name);
+        if (g == nullptr) {
+            // pending ⊆ known is a registry invariant; a miss is a bug.
             std::ostringstream body;
             body << "tag_pending_outputs_locked: pending MRP group '" << name
-                 << "' missing from known_mrp_groups_";
+                 << "' missing from the registry";
             record_internal_error(HazeInternalError::MissingPolyMapBinding, body.str().c_str());
             return std::unexpected(HazeInternalError::MissingPolyMapBinding);
         }
-        const auto &g = g_it->second;
         std::vector<std::pair<fhetch::Polynomial, uint64_t>> pairs;
-        pairs.reserve(g.addrs.size());
-        for (size_t i = 0; i < g.addrs.size(); ++i) {
-            auto it = poly_map_.find(g.addrs[i]);
+        pairs.reserve(g->addrs.size());
+        for (size_t i = 0; i < g->addrs.size(); ++i) {
+            auto it = poly_map_.find(g->addrs[i]);
             if (it == poly_map_.end()) {
                 // Group registered but its poly_map_ binding was invalidated before materialize.
                 std::ostringstream body;
                 body << "tag_pending_outputs_locked: MRP group '" << name << "' addr 0x" << std::hex
-                     << to_uintptr(g.addrs[i]) << std::dec << " missing from poly_map_";
+                     << to_uintptr(g->addrs[i]) << std::dec << " missing from poly_map_";
                 record_internal_error(HazeInternalError::MissingPolyMapBinding, body.str().c_str());
                 return std::unexpected(HazeInternalError::MissingPolyMapBinding);
             }
             // Polynomial copy is a shared_ptr refcount bump, not a deep clone.
-            pairs.emplace_back(it->second, g.moduli[i]);
+            pairs.emplace_back(it->second, g->moduli[i]);
         }
         fhetch::tag_output(name, fhetch::MRP::from_pairs(pairs));
     }
@@ -396,7 +293,7 @@ std::expected<void, HazeInternalError> EpochState::finalize_locked(bool run_repl
     // A half-clear desyncs haze from the vendor recorder — its start()
     // no-ops while running, so the next flush would emit both epochs'
     // nodes into one trace.
-    if (pending_outputs_.empty() && pending_mrp_groups_.empty()) {
+    if (pending_outputs_.empty() && !mrp_.has_pending()) {
         return {};
     }
 
@@ -507,30 +404,17 @@ void EpochState::clear_state_locked() noexcept {
     pending_outputs_.clear();
     addr_modulus_.clear();
     input_addrs_.clear();
-    known_mrp_groups_.clear();
-    pending_mrp_groups_.clear();
-    addr_to_mrp_groups_.clear();
-    mrp_input_tagged_names_.clear();
-    mrp_in_names_.clear();
-    mrp_out_names_.clear();
+    mrp_.clear();
     recording_ = false;
     input_counter_ = 0;
     output_counter_ = 0;
-    mrp_in_name_counter_ = 0;
-    mrp_out_name_counter_ = 0;
     // Mirror clears to libnbfhetch so a failed materialise can't leak
     // captures into the next epoch; pairs with EpochSession's setup.
     CompilerBackend::clear_captured();
 }
 
 std::string EpochState::mrp_group_name_locked(bool output, DevAddr leading) {
-    auto &names = output ? mrp_out_names_ : mrp_in_names_;
-    if (auto it = names.find(leading); it != names.end())
-        return it->second;
-    auto &counter = output ? mrp_out_name_counter_ : mrp_in_name_counter_;
-    std::string name = (output ? "haze_mrp_out_" : "haze_mrp_in_") + std::to_string(counter++);
-    names.emplace(leading, name);
-    return name;
+    return mrp_.group_name(output, leading);
 }
 
 std::expected<void, HazeInternalError> EpochState::tag_output(DevAddr addr) noexcept {

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -15,6 +15,7 @@
 #include "common/errors.hpp"
 #include "common/handle.hpp"
 #include "common/thread_safety.hpp"
+#include "core/mrp_registry.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -125,13 +126,13 @@ class EpochState {
     // fhetch::tag_output(name, MRP). Latest-write-wins on re-registration:
     // identical membership is a no-op, anything else replaces/evicts (see the
     // implementation for the full semantics).
-    std::expected<void, HazeInternalError>
-    register_mrp_output_group_locked(std::span<const DevAddr> addrs,
-                                     std::span<const uint64_t> moduli, std::string &&name)
+    std::expected<void, HazeInternalError> record_mrp_group_locked(std::span<const DevAddr> addrs,
+                                                                   std::span<const uint64_t> moduli,
+                                                                   std::string &&name)
         HAZE_REQUIRES(mutex_);
 
     // Pass-through to fhetch::tag_input(name, MRP), deduped by name. Unlike
-    // output groups (latest-write-wins, see register_mrp_output_group_locked),
+    // output groups (latest-write-wins, see record_mrp_group_locked),
     // input tags reach fhetch immediately and keep first-wins dedup —
     // input-side dst[0] reuse staleness is a known, separate limitation.
     void tag_mrp_input_if_new_locked(const std::string &name, const niobium::fhetch::MRP &mrp)
@@ -169,11 +170,8 @@ class EpochState {
 
     void clear_state_locked() noexcept HAZE_REQUIRES(mutex_);
 
-    // Drop one group wholesale: scrub every member's reverse-map entry, then
-    // erase the group from known_mrp_groups_ and pending_mrp_groups_. Members'
-    // poly_map_ bindings and per-residue output tags are untouched — they stay
-    // valid as standalone SRP values.
-    void evict_mrp_group_locked(const std::string &name) noexcept HAZE_REQUIRES(mutex_);
+    // Name `addr` as a pending output if it isn't one already.
+    void ensure_output_tag_locked(DevAddr addr) HAZE_REQUIRES(mutex_);
 
     // Lock order: see the canonical DAG in common/thread_safety.hpp
     // (epoch → {config, allocator}). Allocator-side code must never
@@ -189,39 +187,9 @@ class EpochState {
     // addr -> real modulus from the last modulus-carrying op that wrote it.
     // Kept in lockstep with poly_map_; cleared per epoch, dropped on invalidate.
     std::unordered_map<DevAddr, uint64_t> addr_modulus_ HAZE_GUARDED_BY(mutex_);
-    // MRP-shaped output groupings, keyed by leading-dst-derived name.
-    // Registration is latest-write-wins — identical re-registration is a
-    // no-op, a different-shaped registration replaces the group and evicts
-    // any other group claiming one of the new addrs (see
-    // register_mrp_output_group_locked).
-    struct PendingMrpGroup {
-        std::vector<DevAddr> addrs;   // residue addrs in encounter order
-        std::vector<uint64_t> moduli; // base[i] paired with addrs[i]
-    };
-    // Every MRP group seen this epoch; lets tag_output_locked expand a tagged
-    // residue to its whole ciphertext. Membership alone materializes nothing.
-    std::unordered_map<std::string, PendingMrpGroup> known_mrp_groups_ HAZE_GUARDED_BY(mutex_);
-    // Leading-addr → assigned group name backing mrp_group_name_locked.
-    std::unordered_map<DevAddr, std::string> mrp_in_names_ HAZE_GUARDED_BY(mutex_);
-    std::unordered_map<DevAddr, std::string> mrp_out_names_ HAZE_GUARDED_BY(mutex_);
-    uint64_t mrp_in_name_counter_ HAZE_GUARDED_BY(mutex_) = 0;
-    uint64_t mrp_out_name_counter_ HAZE_GUARDED_BY(mutex_) = 0;
-    // Names of the explicitly-tagged subset of known_mrp_groups_, emitted as
-    // fhetch MRP outputs at materialize time. Stored as names (resolved through
-    // known_mrp_groups_ at flush) so a latest-write-wins replacement of a
-    // group's membership is automatically what gets exported. Invariant: subset
-    // of known_mrp_groups_ keys, maintained by register_mrp_output_group_locked
-    // / evict_mrp_group_locked / clear_state_locked.
-    std::unordered_set<std::string> pending_mrp_groups_ HAZE_GUARDED_BY(mutex_);
-    // Reverse index addr → group names, kept in lockstep with
-    // known_mrp_groups_ so invalidate() drops stale registrations in O(group_size).
-    // After any registration completes, an addr belongs to AT MOST ONE group
-    // (conflicting claims are evicted); tag_output_locked's whole-group
-    // promotion relies on that invariant.
-    std::unordered_map<DevAddr, std::unordered_set<std::string>>
-        addr_to_mrp_groups_ HAZE_GUARDED_BY(mutex_);
-    // Dedup set for MRP input tags; reset by clear_state_locked.
-    std::unordered_set<std::string> mrp_input_tagged_names_ HAZE_GUARDED_BY(mutex_);
+    // MRP group bookkeeping (membership, pending export, stable names);
+    // invariants documented on the class.
+    MrpGroupRegistry mrp_ HAZE_GUARDED_BY(mutex_);
     uint64_t input_counter_ HAZE_GUARDED_BY(mutex_) = 0;
     uint64_t output_counter_ HAZE_GUARDED_BY(mutex_) = 0;
     bool recording_ HAZE_GUARDED_BY(mutex_) = false;

--- a/src/core/mrp_polymap.cpp
+++ b/src/core/mrp_polymap.cpp
@@ -108,8 +108,7 @@ std::expected<void, HazeInternalError> store_mrp_locked(void *const *dst_polys,
     }
     if (len > 1) {
         auto group_name = epoch().mrp_group_name_locked(/*output=*/true, addrs.front());
-        return epoch().register_mrp_output_group_locked(addrs, std::span(base, len),
-                                                        std::move(group_name));
+        return epoch().record_mrp_group_locked(addrs, std::span(base, len), std::move(group_name));
     }
     return {};
 }
@@ -187,8 +186,7 @@ copy_device_to_device_mrp(void *const *dst, const void *const *src, std::size_t 
     }
     if (len > 1) {
         auto group_name = epoch().mrp_group_name_locked(/*output=*/true, addrs.front());
-        return epoch().register_mrp_output_group_locked(addrs, std::span(base, len),
-                                                        std::move(group_name));
+        return epoch().record_mrp_group_locked(addrs, std::span(base, len), std::move(group_name));
     }
     return {};
 }

--- a/src/core/mrp_registry.cpp
+++ b/src/core/mrp_registry.cpp
@@ -1,0 +1,170 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#include "core/mrp_registry.hpp"
+
+#include "common/errors.hpp"
+#include "common/handle.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <span>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace haze {
+
+void MrpGroupRegistry::evict_group(const std::string &name) {
+    auto group_it = known_.find(name);
+    if (group_it == known_.end())
+        return;
+    for (DevAddr member : group_it->second.addrs) {
+        auto o = addr_to_groups_.find(member);
+        if (o == addr_to_groups_.end())
+            continue;
+        o->second.erase(name);
+        if (o->second.empty())
+            addr_to_groups_.erase(o);
+    }
+    known_.erase(group_it);
+    pending_.erase(name);
+}
+
+void MrpGroupRegistry::invalidate(DevAddr addr) {
+    if (auto rev_it = addr_to_groups_.find(addr); rev_it != addr_to_groups_.end()) {
+        // Detach addr's entry first: evict_group edits the reverse map.
+        auto group_names = std::move(rev_it->second);
+        addr_to_groups_.erase(rev_it);
+        for (const auto &name : group_names)
+            evict_group(name);
+    }
+    // A recycled allocation leading a new group gets a fresh name.
+    in_names_.erase(addr);
+    out_names_.erase(addr);
+}
+
+std::string MrpGroupRegistry::group_name(bool output, DevAddr leading) {
+    auto &names = output ? out_names_ : in_names_;
+    if (auto it = names.find(leading); it != names.end())
+        return it->second;
+    auto &counter = output ? out_counter_ : in_counter_;
+    std::string name = (output ? "haze_mrp_out_" : "haze_mrp_in_") + std::to_string(counter++);
+    names.emplace(leading, name);
+    return name;
+}
+
+bool MrpGroupRegistry::mark_input_tagged(const std::string &name) {
+    return input_tagged_.insert(name).second;
+}
+
+std::expected<bool, HazeInternalError>
+MrpGroupRegistry::record_mrp_group(std::span<const DevAddr> addrs, std::span<const uint64_t> moduli,
+                                   std::string &&name) {
+    if (addrs.size() != moduli.size()) {
+        std::ostringstream body;
+        body << "record_mrp_group('" << name << "'): addrs.size()=" << addrs.size()
+             << " != moduli.size()=" << moduli.size();
+        record_internal_error(HazeInternalError::MrpGroupAddrModuliMismatch, body.str().c_str());
+        return std::unexpected(HazeInternalError::MrpGroupAddrModuliMismatch);
+    }
+    // Identical re-registration (e.g. an in-place accumulation loop) is a
+    // no-op; a competing registration would already have evicted this group.
+    auto existing = known_.find(name);
+    if (existing != known_.end() && existing->second.addrs.size() == addrs.size() &&
+        std::equal(addrs.begin(), addrs.end(), existing->second.addrs.begin()) &&
+        std::equal(moduli.begin(), moduli.end(), existing->second.moduli.begin())) {
+        return false;
+    }
+
+    // Latest write wins: any other group claiming one of the new addrs no
+    // longer describes what that addr holds — evict it wholesale.
+    for (DevAddr a : addrs) {
+        auto rev = addr_to_groups_.find(a);
+        if (rev == addr_to_groups_.end())
+            continue;
+        std::vector<std::string> conflicting(rev->second.begin(), rev->second.end());
+        for (const auto &other : conflicting)
+            if (other != name)
+                evict_group(other);
+    }
+
+    if (existing != known_.end()) {
+        // Same name, new shape: replace membership in place.
+        for (DevAddr old_addr : existing->second.addrs) {
+            auto o = addr_to_groups_.find(old_addr);
+            if (o == addr_to_groups_.end())
+                continue;
+            o->second.erase(name);
+            if (o->second.empty())
+                addr_to_groups_.erase(o);
+        }
+        existing->second.addrs.assign(addrs.begin(), addrs.end());
+        existing->second.moduli.assign(moduli.begin(), moduli.end());
+        for (DevAddr a : addrs)
+            addr_to_groups_[a].insert(name);
+        return pending_.contains(name);
+    }
+
+    auto [it, inserted] = known_.try_emplace(std::move(name));
+    it->second.addrs.assign(addrs.begin(), addrs.end());
+    it->second.moduli.assign(moduli.begin(), moduli.end());
+    for (DevAddr a : addrs)
+        addr_to_groups_[a].insert(it->first);
+    return false;
+}
+
+std::optional<std::vector<DevAddr>> MrpGroupRegistry::mark_group_output(DevAddr addr) {
+    auto rev = addr_to_groups_.find(addr);
+    if (rev == addr_to_groups_.end())
+        return std::nullopt;
+    std::vector<DevAddr> members;
+    // At most one group per addr after any registration; the loop is defense
+    // in depth should that invariant ever relax.
+    for (const auto &gname : rev->second) {
+        auto g = known_.find(gname);
+        if (g == known_.end())
+            continue;
+        members.insert(members.end(), g->second.addrs.begin(), g->second.addrs.end());
+        pending_.insert(gname);
+    }
+    // No live group (every mapped name diverged/evicted) — nullopt so the
+    // caller falls through to SRP tagging rather than skipping `addr`.
+    if (members.empty())
+        return std::nullopt;
+    return members;
+}
+
+std::vector<std::string> MrpGroupRegistry::pending_names() const {
+    return {pending_.begin(), pending_.end()};
+}
+
+const MrpGroupRegistry::Group *MrpGroupRegistry::find(const std::string &name) const {
+    auto it = known_.find(name);
+    return it == known_.end() ? nullptr : &it->second;
+}
+
+void MrpGroupRegistry::clear() {
+    known_.clear();
+    pending_.clear();
+    addr_to_groups_.clear();
+    in_names_.clear();
+    out_names_.clear();
+    input_tagged_.clear();
+    in_counter_ = 0;
+    out_counter_ = 0;
+}
+
+} // namespace haze

--- a/src/core/mrp_registry.hpp
+++ b/src/core/mrp_registry.hpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#pragma once
+
+#include "common/errors.hpp"
+#include "common/handle.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <optional>
+#include <span>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace haze {
+
+// Bookkeeping for MRP (multi-residue) groupings within one epoch: which
+// addrs form a group, which groups are pending output export, and the
+// stable per-leading-addr group names. Pure value type — no locks, no
+// fhetch, no polymap; EpochState owns one instance under its mutex.
+//
+// Invariants (owned entirely by this class): an addr belongs to AT MOST
+// one group; registration is latest-write-wins (identical re-registration
+// is a no-op, any other overlap evicts the competing group wholesale);
+// pending names are always a subset of known names.
+class MrpGroupRegistry {
+  public:
+    struct Group {
+        std::vector<DevAddr> addrs;   // residue addrs in encounter order
+        std::vector<uint64_t> moduli; // base[i] paired with addrs[i]
+    };
+
+    // Drop every group that names `addr`, plus its leading-addr names, so a
+    // recycled allocation cannot resurrect stale state.
+    void invalidate(DevAddr addr);
+
+    // Stable counter name ("haze_mrp_in_N" / "haze_mrp_out_N") for the group
+    // led by `leading`; invalidate() drops it.
+    std::string group_name(bool output, DevAddr leading);
+
+    // True exactly once per name; the caller then emits the fhetch input tag.
+    bool mark_input_tagged(const std::string &name);
+
+    // Record `addrs`/`moduli` as the current MRP group `name` (latest-write-wins), returning
+    // true if it was already a tagged output so the caller re-tags its members.
+    std::expected<bool, HazeInternalError> record_mrp_group(std::span<const DevAddr> addrs,
+                                                            std::span<const uint64_t> moduli,
+                                                            std::string &&name);
+
+    // Mark `addr`'s MRP group as a tagged output and return its residue addrs, or nullopt if
+    // `addr` is in no group.
+    std::optional<std::vector<DevAddr>> mark_group_output(DevAddr addr);
+
+    // Pending-group view for flush-time export (resolved through the latest
+    // registration).
+    bool has_pending() const { return !pending_.empty(); }
+    std::vector<std::string> pending_names() const;
+    const Group *find(const std::string &name) const;
+
+    void clear();
+
+  private:
+    void evict_group(const std::string &name);
+
+    std::unordered_map<std::string, Group> known_;
+    std::unordered_set<std::string> pending_; // subset of known_ keys
+    // Reverse index addr -> group names (at most one after any registration).
+    std::unordered_map<DevAddr, std::unordered_set<std::string>> addr_to_groups_;
+    std::unordered_map<DevAddr, std::string> in_names_;
+    std::unordered_map<DevAddr, std::string> out_names_;
+    std::unordered_set<std::string> input_tagged_;
+    uint64_t in_counter_ = 0;
+    uint64_t out_counter_ = 0;
+};
+
+} // namespace haze

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -1510,8 +1510,8 @@ TEST_CASE("MRP output round-trip: hazeMulMrp result via fhetch::result(name, MRP
 }
 
 // ============================================================================
-// Regression: invalidate() must drop pending_mrp_groups_ entries for the freed
-// addr so the stale group can't surface (or get silently rebound on recycle).
+// Regression: invalidate() must drop pending MRP-group entries (MrpGroupRegistry::pending_) for the
+// freed addr so the stale group can't surface (or get silently rebound on recycle).
 // ============================================================================
 
 TEST_CASE("hazeFree mid-recording on MRP output addrs does not break replay", "[integration]") {
@@ -1533,7 +1533,7 @@ TEST_CASE("hazeFree mid-recording on MRP output addrs does not break replay", "[
     auto intt_dst = haze::test::allocate_dst_residues(MrpDriver::kNumResidues, kBytes);
     d.intt(intt_dst, haze::test::to_const(d_a));
 
-    // Pre-fix: leaks a stale pending_mrp_groups_ entry. At the flush below,
+    // Pre-fix: leaks a stale pending MRP-group entry. At the flush below,
     // replay_and_populate's group walk hits MissingPolyMapBinding ->
     // HAZE_ERROR_INTERNAL because poly_map_[intt_dst...] are gone.
     haze::test::free_all_residues(intt_dst);

--- a/test/test_d2d_copy.cpp
+++ b/test/test_d2d_copy.cpp
@@ -257,7 +257,7 @@ TEST_CASE("hazeMemcpyMrp(D2D) promotes H2D'd sources and registers the output gr
     }
 
     // No compute op ran, so the D2D fan-out is the only haze_mrp_out_* group;
-    // confirm register_mrp_output_group_locked made it readable as an MRP.
+    // confirm record_mrp_group_locked made it readable as an MRP.
     haze::test::check_mrp_against_per_residue(base, res);
 
     haze::test::free_all_residues(dst);

--- a/test/test_mrp_group_reuse.cpp
+++ b/test/test_mrp_group_reuse.cpp
@@ -2,7 +2,7 @@
 //
 // MRP output-group latest-write-wins tests.
 //
-// register_mrp_output_group_locked semantics exercised here:
+// record_mrp_group_locked semantics exercised here:
 //   1. Identical re-registration → no-op dedup; exactly one group exported.
 //   2. Same dst[0], different shape → group replaced; flushed probe reflects
 //      the latest residue count and moduli — whether the tag lands before or
@@ -156,7 +156,7 @@ TEST_CASE("MRP group reuse: identical in-place re-registration is a dedup no-op"
 // TC2 (core repro): same dst[0] re-registered with fewer residues exports
 // the latest shape, NOT the original 3-residue stale group.
 //
-// This test MUST FAIL when the fix in register_mrp_output_group_locked is
+// This test MUST FAIL when the fix in record_mrp_group_locked is
 // reverted: on the broken code the 3-residue group is still registered and
 // exported, so check_mrp_against_per_residue with base2 finds no matching
 // group.
@@ -258,7 +258,7 @@ TEST_CASE("MRP group reuse: same dst[0] re-registered with fewer residues export
 // TC2b: tag BEFORE the replacement — the pending promotion follows it.
 //
 // hazeTagOutput runs before the second op, while the group is still the
-// 3-residue shape. pending_mrp_groups_ stores names (not membership
+// 3-residue shape. the pending MRP-group set stores names (not membership
 // snapshots), so the flush exports the replacement 2-residue shape under the
 // same name. The dropped member a2 keeps the per-residue tag it got when the
 // 3-residue group was promoted, and exports its latest binding (op1's value)

--- a/test/test_mrp_registry.cpp
+++ b/test/test_mrp_registry.cpp
@@ -1,0 +1,149 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// Direct unit tests for MrpGroupRegistry — the invariants previously only
+// reachable through the full C-ABI + fhetch stack (test_mrp_group_reuse.cpp).
+
+#include "common/errors.hpp"
+#include "common/handle.hpp"
+#include "core/mrp_registry.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+#include <initializer_list>
+#include <string>
+#include <vector>
+
+namespace {
+
+using haze::DevAddr;
+using haze::MrpGroupRegistry;
+
+DevAddr addr(uint64_t n) {
+    return DevAddr{0x4000000000ULL + (n * 0x8000)};
+}
+
+std::vector<DevAddr> addrs(std::initializer_list<uint64_t> ns) {
+    std::vector<DevAddr> out;
+    for (auto n : ns)
+        out.push_back(addr(n));
+    return out;
+}
+
+const std::vector<uint64_t> kQ2 = {97, 193};
+const std::vector<uint64_t> kQ3 = {97, 193, 389};
+
+} // namespace
+
+TEST_CASE("registry: group names are stable per leading addr and side", "[unit]") {
+    MrpGroupRegistry reg;
+    const auto in0 = reg.group_name(false, addr(1));
+    const auto out0 = reg.group_name(true, addr(1));
+    REQUIRE(in0 == "haze_mrp_in_0");
+    REQUIRE(out0 == "haze_mrp_out_0");
+    REQUIRE(reg.group_name(false, addr(1)) == in0); // stable on re-ask
+    REQUIRE(reg.group_name(false, addr(2)) == "haze_mrp_in_1");
+    // invalidate() drops the name so a recycled addr gets a fresh one.
+    reg.invalidate(addr(1));
+    REQUIRE(reg.group_name(false, addr(1)) == "haze_mrp_in_2");
+}
+
+TEST_CASE("registry: input tag dedup fires exactly once per name", "[unit]") {
+    MrpGroupRegistry reg;
+    REQUIRE(reg.mark_input_tagged("g"));
+    REQUIRE_FALSE(reg.mark_input_tagged("g"));
+    reg.clear();
+    REQUIRE(reg.mark_input_tagged("g"));
+}
+
+TEST_CASE("registry: addr/moduli length mismatch is rejected", "[unit]") {
+    MrpGroupRegistry reg;
+    const auto a = addrs({1, 2});
+    const std::vector<uint64_t> one = {97};
+    auto r = reg.record_mrp_group(a, one, "g");
+    REQUIRE_FALSE(r.has_value());
+    REQUIRE(r.error() == haze::HazeInternalError::MrpGroupAddrModuliMismatch);
+    REQUIRE(reg.find("g") == nullptr);
+}
+
+TEST_CASE("registry: identical re-registration is a no-op", "[unit]") {
+    MrpGroupRegistry reg;
+    const auto a = addrs({1, 2});
+    REQUIRE(reg.record_mrp_group(a, kQ2, "g").has_value());
+    auto again = reg.record_mrp_group(a, kQ2, "g");
+    REQUIRE(again.has_value());
+    REQUIRE_FALSE(again.value_or(true)); // no re-tag needed
+    REQUIRE(reg.find("g") != nullptr);
+}
+
+TEST_CASE("registry: conflicting registration evicts the competing group", "[unit]") {
+    MrpGroupRegistry reg;
+    REQUIRE(reg.record_mrp_group(addrs({1, 2}), kQ2, "g1").has_value());
+    // g2 claims addr 2: g1 no longer describes what addr 2 holds.
+    REQUIRE(reg.record_mrp_group(addrs({2, 3}), kQ2, "g2").has_value());
+    REQUIRE(reg.find("g1") == nullptr);
+    REQUIRE(reg.find("g2") != nullptr);
+    // addr 1 now belongs to no group.
+    REQUIRE_FALSE(reg.mark_group_output(addr(1)).has_value());
+}
+
+TEST_CASE("registry: promote marks pending and expands the whole group", "[unit]") {
+    MrpGroupRegistry reg;
+    REQUIRE(reg.record_mrp_group(addrs({1, 2, 3}), kQ3, "g").has_value());
+    REQUIRE(reg.pending_names().empty());
+    auto members = reg.mark_group_output(addr(2));
+    REQUIRE(members.has_value());
+    REQUIRE(members.value_or(std::vector<DevAddr>{}) == addrs({1, 2, 3}));
+    REQUIRE(reg.pending_names() == std::vector<std::string>{"g"});
+    // Pending stays a subset of known: evicting the group clears it.
+    reg.invalidate(addr(1));
+    REQUIRE(reg.pending_names().empty());
+    REQUIRE(reg.find("g") == nullptr);
+}
+
+TEST_CASE("registry: replacing a pending group demands re-tagging its members", "[unit]") {
+    MrpGroupRegistry reg;
+    REQUIRE(reg.record_mrp_group(addrs({1, 2, 3}), kQ3, "g").has_value());
+    REQUIRE(reg.mark_group_output(addr(1)).has_value());
+    // In-place rescale reuses the leading addr with fewer residues.
+    auto replaced = reg.record_mrp_group(addrs({1, 2}), kQ2, "g");
+    REQUIRE(replaced.has_value());
+    REQUIRE(replaced.value_or(false)); // pending group: caller re-tags
+    const auto *g = reg.find("g");
+    REQUIRE(g != nullptr);
+    REQUIRE(g->addrs == addrs({1, 2}));
+    REQUIRE(g->moduli == kQ2);
+    // The dropped member no longer maps to the group.
+    REQUIRE_FALSE(reg.mark_group_output(addr(3)).has_value());
+}
+
+TEST_CASE("registry: replacement of a non-pending group needs no new tags", "[unit]") {
+    MrpGroupRegistry reg;
+    REQUIRE(reg.record_mrp_group(addrs({1, 2, 3}), kQ3, "g").has_value());
+    auto replaced = reg.record_mrp_group(addrs({1, 2}), kQ2, "g");
+    REQUIRE(replaced.has_value());
+    REQUIRE_FALSE(replaced.value_or(true));
+}
+
+TEST_CASE("registry: clear resets groups, pending, names, and counters", "[unit]") {
+    MrpGroupRegistry reg;
+    REQUIRE(reg.record_mrp_group(addrs({1, 2}), kQ2, "g").has_value());
+    REQUIRE(reg.mark_group_output(addr(1)).has_value());
+    REQUIRE(reg.group_name(false, addr(1)) == "haze_mrp_in_0");
+    REQUIRE(reg.group_name(true, addr(1)) == "haze_mrp_out_0");
+    reg.clear();
+    REQUIRE(reg.find("g") == nullptr);
+    REQUIRE_FALSE(reg.has_pending());
+    REQUIRE_FALSE(reg.mark_group_output(addr(1)).has_value());
+    REQUIRE(reg.group_name(false, addr(1)) == "haze_mrp_in_0"); // counters restart
+    REQUIRE(reg.group_name(true, addr(1)) == "haze_mrp_out_0");
+}
+
+TEST_CASE("registry: invalidate detaches only the touched addr's group", "[unit]") {
+    MrpGroupRegistry reg;
+    REQUIRE(reg.record_mrp_group(addrs({1, 2}), kQ2, "g1").has_value());
+    REQUIRE(reg.record_mrp_group(addrs({3, 4}), kQ2, "g2").has_value());
+    reg.invalidate(addr(1));
+    REQUIRE(reg.find("g1") == nullptr);
+    REQUIRE(reg.find("g2") != nullptr);
+    REQUIRE(reg.mark_group_output(addr(3)).has_value());
+}


### PR DESCRIPTION
The eight MRP-group fields and their intertwined invariants (at most one group per addr, latest-write-wins registration, pending ⊆ known, stable leading-addr names) move into a lock-free value type owned by EpochState under the same mutex — no locking or behavior change. The registry is directly unit-tested (test_mrp_registry.cpp) instead of only through the full C-ABI + fhetch stack, and the triplicated pending-output naming collapses into ensure_output_tag_locked.