### PR TITLE
refactor(core): extract materialization out of EpochState

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -451,9 +451,10 @@ control surface (`CompilerBackend`):
   `niobium::compiler()` route through these wrappers only (`backend.cpp` is
   the sole first-party TU that includes `niobium/compiler.h`, besides the
   replay bridge's own init path).
-- The recording-side IR (`fhetch::sr_*`, `tag_input`, `tag_output`,
-  `result`) is emitted directly from `epoch.cpp`, bypassing the backend
-  wrapper.
+- The recording-side IR (`fhetch::sr_*`, `tag_input`, `tag_output`) is
+  emitted directly from `epoch.cpp` / `compute.hpp`, and `fhetch::result`
+  readback lives in `core/materialize.cpp` — the data plane bypasses the
+  backend wrapper.
 
 Recordings land in a per-program directory under the test working
 directory (`build/runs/haze/...`). Each functional epoch produces its own

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ add_library(haze_objs OBJECT
   src/core/config.cpp
   src/core/device.cpp
   src/core/epoch.cpp
+  src/core/materialize.cpp
   src/core/mrp_polymap.cpp
   src/core/mrp_registry.cpp
   src/core/polynomial_io.cpp
@@ -225,7 +226,7 @@ target_link_libraries(haze_objs PRIVATE Niobium::fhetch)
 # ---------------------------------------------------------------------------
 # Replay bridge — OpenFHE-using helper that synthesizes CryptoContext +
 # ciphertext templates the compiler-side replay needs, and provides the
-# niobium::fhetch::result(...) overloads libhaze references from epoch.cpp.
+# niobium::fhetch::result(...) overloads libhaze references from core/materialize.cpp.
 # Built as an OBJECT library (see replay_bridge/CMakeLists.txt) so all its TUs
 # (incl. result()) are absorbed unconditionally; its OpenFHE includes stay out
 # of libhaze's own sources.

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -18,12 +18,10 @@
 #include "core/allocator.hpp"
 #include "core/backend.hpp"
 #include "core/config.hpp"
-#include "core/polynomial_io.hpp"
 
 #include <cstddef>
 #include <cstdint>
 #include <expected>
-#include <haze/replay_bridge.h>
 #include <ios>
 #include <niobium/fhetch_api.h>
 #include <span>
@@ -300,7 +298,11 @@ std::expected<void, HazeInternalError> EpochState::finalize_locked(bool run_repl
     if (auto tagged = tag_pending_outputs_locked(); !tagged)
         return std::unexpected(tagged.error());
 
-    return write_trace_and_replay_locked(run_replay);
+    // State always resets after materialization so the next epoch starts clean
+    // on success or failure.
+    auto materialized = materialize_epoch(run_replay);
+    clear_state_locked();
+    return materialized;
 }
 
 std::expected<void, HazeInternalError> EpochState::replay_and_populate() noexcept {
@@ -324,79 +326,6 @@ std::expected<void, HazeInternalError> EpochState::finalize_guarded_locked(bool 
                               "finalize threw; epoch state cleared");
         return std::unexpected(HazeInternalError::BackendReplayFailed);
     }
-}
-
-std::expected<void, HazeInternalError> EpochState::write_trace_and_replay_locked(bool run_replay) {
-    if (!recording_) {
-        return {};
-    }
-
-    // Step 1: write the trace. The replay_bridge post-recording hook
-    // runs inside the vendor stop(); we drain its failure flag right after.
-    const bool stop_ok = CompilerBackend::stop_recording();
-    if (!stop_ok) {
-        clear_state_locked();
-        record_internal_error(HazeInternalError::BackendReplayFailed,
-                              "EpochState::write_trace_and_replay_locked (stop_recording)");
-        return std::unexpected(HazeInternalError::BackendReplayFailed);
-    }
-    if (hazeReplayBridgeTakeHookHadError() != 0) {
-        clear_state_locked();
-        record_internal_error(
-            HazeInternalError::BridgeHookFailed,
-            "post_recording_hook reported per-input/output failures (see prior log entries)");
-        return std::unexpected(HazeInternalError::BridgeHookFailed);
-    }
-
-    // hazeWriteProgram() stops here: step 1 has written the full program dir
-    // (.fhetch + inputs + templates + cryptocontext), ready to ship for
-    // out-of-process replay (e.g. on the FPGA host). There is no in-process
-    // result to read back, so skip replay + shadow population.
-    if (!run_replay) {
-        clear_state_locked();
-        return {};
-    }
-
-    // Step 2: dispatch replay. kLocalTarget runs the in-process simulator;
-    // other targets spawn nbcc_fhetch_replay over HTTP — both produce
-    // serialized_probes/<name>.ct for step 3 to read.
-    const bool replay_ok = CompilerBackend::replay();
-    if (!replay_ok) {
-        clear_state_locked();
-        record_internal_error(HazeInternalError::BackendReplayFailed,
-                              "EpochState::write_trace_and_replay_locked (replay)");
-        return std::unexpected(HazeInternalError::BackendReplayFailed);
-    }
-
-    // Step 3: per-output shadow population. Any failure aborts the
-    // epoch so a stale shadow can't surface as a silent wrong-value D2H.
-    for (auto &[addr, name] : pending_outputs_) {
-        fhetch::Polynomial result_poly;
-        if (!fhetch::result(name, result_poly)) {
-            std::ostringstream body;
-            body << "result('" << name << "') unavailable for addr 0x" << std::hex
-                 << to_uintptr(addr) << std::dec;
-            clear_state_locked();
-            record_internal_error(HazeInternalError::BackendOutputMissing, body.str().c_str());
-            return std::unexpected(HazeInternalError::BackendOutputMissing);
-        }
-        std::vector<uint64_t> values;
-        if (!decode_result_values(result_poly, values)) {
-            std::ostringstream body;
-            body << "failed to extract values for output '" << name << "' at addr 0x" << std::hex
-                 << to_uintptr(addr) << std::dec;
-            clear_state_locked();
-            record_internal_error(HazeInternalError::BackendOutputDecodeFailed, body.str().c_str());
-            return std::unexpected(HazeInternalError::BackendOutputDecodeFailed);
-        }
-        if (auto r = allocator().update_shadow(addr, std::move(values)); !r) {
-            clear_state_locked();
-            return std::unexpected(r.error());
-        }
-    }
-
-    clear_state_locked();
-    return {};
 }
 
 void EpochState::clear_state_locked() noexcept {

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -34,6 +34,9 @@ namespace haze {
 // "modulus unknown" marker for the addr->modulus tracking below.
 inline constexpr uint64_t kCopyModulus = 0xFFFFFFFFFFFFFFFFULL;
 
+class EpochState;
+EpochState &epoch() noexcept; // inline definition after the class
+
 // Singleton tracking the polymap, pending outputs, and recording flag for
 // the active epoch; replay_and_populate() drains it at flush time. Public
 // methods take mutex_; _locked variants require it held via EpochSession
@@ -162,11 +165,11 @@ class EpochState {
     std::expected<void, HazeInternalError> finalize_guarded_locked(bool run_replay)
         HAZE_REQUIRES(mutex_);
 
-    // Write the trace (step 1) and, when run_replay, dispatch replay + populate
-    // shadows (steps 2-3). Always resets state at the end so the next epoch
-    // starts clean on success or failure.
-    std::expected<void, HazeInternalError> write_trace_and_replay_locked(bool run_replay)
-        HAZE_REQUIRES(mutex_);
+    // Backend/bridge orchestration for a finalized epoch (stop, replay,
+    // populate shadows); defined in core/materialize.cpp to keep OpenFHE /
+    // replay-bridge includes out of epoch.cpp. Never clears state — the
+    // caller does that after it returns.
+    std::expected<void, HazeInternalError> materialize_epoch(bool run_replay) HAZE_REQUIRES(mutex_);
 
     void clear_state_locked() noexcept HAZE_REQUIRES(mutex_);
 

--- a/src/core/materialize.cpp
+++ b/src/core/materialize.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#include "common/errors.hpp"
+#include "common/handle.hpp"
+#include "core/allocator.hpp"
+#include "core/backend.hpp"
+#include "core/epoch.hpp"
+#include "core/polynomial_io.hpp"
+
+#include <cstdint>
+#include <expected>
+#include <haze/replay_bridge.h>
+#include <ios>
+#include <niobium/fhetch_api.h>
+#include <sstream>
+#include <utility>
+#include <vector>
+
+namespace haze {
+
+namespace fhetch = niobium::fhetch;
+
+std::expected<void, HazeInternalError> EpochState::materialize_epoch(bool run_replay) {
+    // Never clears epoch state on any return path — finalize_locked is the sole
+    // clearer, once, after this returns.
+    // Step 1: write the trace; the replay-bridge post-recording hook runs
+    // inside the vendor stop(), so drain its failure flag right after.
+    if (!CompilerBackend::stop_recording()) {
+        record_internal_error(HazeInternalError::BackendReplayFailed,
+                              "materialize_epoch (stop_recording)");
+        return std::unexpected(HazeInternalError::BackendReplayFailed);
+    }
+    if (hazeReplayBridgeTakeHookHadError() != 0) {
+        record_internal_error(
+            HazeInternalError::BridgeHookFailed,
+            "post_recording_hook reported per-input/output failures (see prior log entries)");
+        return std::unexpected(HazeInternalError::BridgeHookFailed);
+    }
+
+    // hazeWriteProgram() stops here: the program dir is complete and there
+    // is no in-process result to read back.
+    if (!run_replay) {
+        return {};
+    }
+
+    // Step 2: dispatch replay per the configured target.
+    if (!CompilerBackend::replay()) {
+        record_internal_error(HazeInternalError::BackendReplayFailed, "materialize_epoch (replay)");
+        return std::unexpected(HazeInternalError::BackendReplayFailed);
+    }
+
+    // Step 3: per-output shadow population; any failure aborts so a stale
+    // shadow can't surface as a silent wrong-value D2H.
+    for (const auto &[addr, name] : pending_outputs_) {
+        fhetch::Polynomial result_poly;
+        if (!fhetch::result(name, result_poly)) {
+            std::ostringstream body;
+            body << "result('" << name << "') unavailable for addr 0x" << std::hex
+                 << to_uintptr(addr) << std::dec;
+            record_internal_error(HazeInternalError::BackendOutputMissing, body.str().c_str());
+            return std::unexpected(HazeInternalError::BackendOutputMissing);
+        }
+        std::vector<uint64_t> values;
+        if (!decode_result_values(result_poly, values)) {
+            std::ostringstream body;
+            body << "failed to extract values for output '" << name << "' at addr 0x" << std::hex
+                 << to_uintptr(addr) << std::dec;
+            record_internal_error(HazeInternalError::BackendOutputDecodeFailed, body.str().c_str());
+            return std::unexpected(HazeInternalError::BackendOutputDecodeFailed);
+        }
+        if (auto r = allocator().update_shadow(addr, std::move(values)); !r) {
+            return std::unexpected(r.error());
+        }
+    }
+
+    return {};
+}
+
+} // namespace haze

--- a/test/test_invariant_regressions.cpp
+++ b/test/test_invariant_regressions.cpp
@@ -455,3 +455,43 @@ TEST_CASE("bridge honors a custom program name for cryptocontext.dat", "[integra
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     fs::remove_all("haze_custom_prog_review");
 }
+
+TEST_CASE("failed materialize clears the epoch: retag fails, next flush is a no-op", "[unit]") {
+    // An unreachable transport target makes replay fail deterministically in
+    // every environment (spawn failure without a compiler; unknown-target
+    // error with one), exercising the materialize error path end to end.
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    REQUIRE(hazeSetTarget("HAZE_TEST_NO_SUCH_TARGET") == HAZE_SUCCESS);
+    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
+
+    void *a = nullptr;
+    void *b = nullptr;
+    void *c = nullptr;
+    REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&b, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&c, kBytes) == HAZE_SUCCESS);
+    std::vector<uint64_t> data(kRingDim, 3);
+    REQUIRE(hazeMemcpy(a, data.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(b, data.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeAdd(c, a, b, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(c) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_ERROR_INTERNAL);
+    hazeGetLastError();
+
+    // Always-clear pin: the failed flush must drop every binding — a re-tag
+    // has nothing to name, the output was never materialized, and a second
+    // flush is an idle no-op instead of replaying a half-torn epoch.
+    REQUIRE(hazeTagOutput(c) == HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+    std::vector<uint64_t> out(kRingDim, 0);
+    REQUIRE(hazeMemcpy(out.data(), c, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+            HAZE_ERROR_NOT_FLUSHED);
+    hazeGetLastError();
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    REQUIRE(hazeFree(a) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(b) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(c) == HAZE_SUCCESS);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}


### PR DESCRIPTION
The stop/replay/populate orchestration moves to core/materialize.cpp (materialize_epoch), separating "what this epoch recorded" from "how results come back"; epoch.cpp drops its replay-bridge and polynomial_io dependencies, and finalize_locked keeps the always-clear semantics.