### PR TITLE
refactor(core): collapse the four singletons into one DeviceState

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ add_library(haze_objs OBJECT
   src/core/basis_convert.cpp
   src/core/config.cpp
   src/core/device.cpp
+  src/core/device_state.cpp
   src/core/epoch.cpp
   src/core/materialize.cpp
   src/core/mrp_polymap.cpp

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -565,7 +565,7 @@ extern "C" void hazeReplayBridgeReset() noexcept {
 
     // Disk-only cleanup so stale template/probe names from prior tests don't
     // pollute MRP lookups; the hook lambda is freed by compiler().reset().
-    // program_dir is queried live — reset_all() runs us before compiler().reset().
+    // program_dir is queried live — DeviceState::reset() runs us before the vendor reset.
     fs::path program_dir;
     try {
         program_dir = niobium::compiler().get_program_directory();

--- a/src/api/lifecycle.cpp
+++ b/src/api/lifecycle.cpp
@@ -11,47 +11,19 @@
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
 //
-// Process-wide reset orchestration. Each subsystem owns its own reset();
-// reset_all() invokes them in dependency order (epoch first so any
-// pending compute is dropped before the backend / allocator state is
-// torn down).
+// hazeDeviceReset and the flush/tag entry points; the reset orchestration
+// itself lives in DeviceState::reset() (core/device_state.cpp).
 
 #include "common/errors.hpp"
 #include "common/handle.hpp"
-#include "core/allocator.hpp"
-#include "core/backend.hpp"
-#include "core/config.hpp"
-#include "core/device.hpp"
+#include "core/device_state.hpp"
 #include "core/epoch.hpp"
-#include "core/stream.hpp"
 
 #include <haze/haze.h>
 #include <haze/haze_types.h>
-#include <haze/replay_bridge.h>
-
-namespace haze {
-
-void reset_all() noexcept {
-    // Clear all internal state first, since we may depend on external object state when clearing
-    // otherwise. hazeReplayBridgeReset queries the compiler's live program
-    // directory, so the vendor-compiler reset must stay LAST.
-    epoch().reset();
-    backend().reset();
-    allocator().reset();
-    config().reset();
-    streams_reset();
-    events_reset();
-    device_reset();
-    hazeReplayBridgeReset();
-
-    // Clear any external state next
-    CompilerBackend::reset_compiler();
-}
-
-} // namespace haze
 
 extern "C" hazeError_t hazeDeviceReset(void) noexcept {
-    haze::reset_all();
+    haze::device_state().reset();
     // Match cudaDeviceReset: also clear the thread-local last-error so
     // callers can use this as a clean test-isolation point.
     g_last_error = HAZE_SUCCESS;

--- a/src/core/allocator.cpp
+++ b/src/core/allocator.cpp
@@ -27,11 +27,6 @@
 
 namespace haze {
 
-DeviceAllocator &DeviceAllocator::instance() noexcept {
-    static DeviceAllocator inst;
-    return inst;
-}
-
 void DeviceAllocator::clear_pool_locked() noexcept {
     for (DevAddr addr : pool_free_) {
         alloc_set_.erase(addr);

--- a/src/core/allocator.hpp
+++ b/src/core/allocator.hpp
@@ -27,6 +27,8 @@
 
 namespace haze {
 
+class DeviceState;
+
 namespace test {
 // Forward declaration for the test peer (Attorney pattern); definition
 // lives under test/ and is never linked into production.
@@ -80,12 +82,6 @@ class AllocatorTestAccess;
 // order and would deadlock.
 class DeviceAllocator {
   public:
-    // HAZE_API on this and `extract_polynomial_components` exports the
-    // symbols from libhaze's hidden-visibility .so so the test binary
-    // can resolve them; encapsulation rests on allocator.hpp living in
-    // src/ (private include path), not on the visibility attribute.
-    HAZE_API static DeviceAllocator &instance() noexcept;
-
     // Configure the pool's polynomial size. Calling with a size different
     // from the current configuration drains the pool. Calling with size 0
     // disables pooling entirely.
@@ -182,6 +178,7 @@ class DeviceAllocator {
     DeviceAllocator &operator=(const DeviceAllocator &) = delete;
 
   private:
+    friend class DeviceState;
     DeviceAllocator() = default;
 
     friend class test::AllocatorTestAccess;
@@ -219,8 +216,7 @@ class DeviceAllocator {
     uintptr_t next_addr_ HAZE_GUARDED_BY(mutex_) = kHbmBase;
 };
 
-inline DeviceAllocator &allocator() noexcept {
-    return DeviceAllocator::instance();
-}
+// Defined in device_state.cpp.
+DeviceAllocator &allocator() noexcept;
 
 } // namespace haze

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -29,11 +29,6 @@
 
 namespace haze {
 
-CompilerBackend &CompilerBackend::instance() noexcept {
-    static CompilerBackend inst;
-    return inst;
-}
-
 bool CompilerBackend::ensure_initialized() noexcept {
     // Lock-free fast path for the common case where init has already
     // completed. The acquire load pairs with the release store below so

--- a/src/core/backend.hpp
+++ b/src/core/backend.hpp
@@ -23,14 +23,14 @@ namespace haze {
 // those route to the linked fhetch "dummy" compiler implicitly. CompilerBackend wraps
 // only the *control* operations: init, recording lifecycle, replay.
 //
+class DeviceState;
+
 // Single concrete class, no virtual dispatch. Backend swap (e.g. to the
 // niobium-fhetch dummy compiler when stable) happens at link time:
 // backend.cpp calls into whichever library supplies the
 // niobium::compiler() symbol.
 class CompilerBackend {
   public:
-    static CompilerBackend &instance() noexcept;
-
     // Idempotent, concurrency-safe compiler init from Config metadata;
     // false on throw or unsupported config, and the compute preludes'
     // require_recording_locked gate then surfaces the failure at the ABI.
@@ -78,6 +78,7 @@ class CompilerBackend {
     CompilerBackend &operator=(const CompilerBackend &) = delete;
 
   private:
+    friend class DeviceState;
     CompilerBackend() = default;
 
     // Atomic flag enables a lock-free fast path on the hot
@@ -87,8 +88,7 @@ class CompilerBackend {
     HazeMutex init_mutex_;
 };
 
-inline CompilerBackend &backend() noexcept {
-    return CompilerBackend::instance();
-}
+// Defined in device_state.cpp (returns the DeviceState member).
+CompilerBackend &backend() noexcept;
 
 } // namespace haze

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -38,11 +38,6 @@ bool is_supported_ring_dim(uint64_t n) noexcept {
 
 } // namespace
 
-Config &Config::instance() noexcept {
-    static Config inst;
-    return inst;
-}
-
 std::expected<void, HazeInternalError> Config::set_ring_dimension(uint64_t n) noexcept {
     if (!is_supported_ring_dim(n))
         return std::unexpected(HazeInternalError::InvalidArgument);
@@ -58,13 +53,13 @@ std::expected<void, HazeInternalError> Config::set_ring_dimension(uint64_t n) no
     }
     // Live allocations bake in the polynomial size; changing it under them
     // left stale-sized shadows (formerly a heap overread on D2H).
-    if (ring_dim_ != n && DeviceAllocator::instance().has_live_allocations()) {
+    if (ring_dim_ != n && allocator().has_live_allocations()) {
         record_internal_error(HazeInternalError::ConfigLocked,
                               "set_ring_dimension: allocations live; free them or reset first");
         return std::unexpected(HazeInternalError::ConfigLocked);
     }
     ring_dim_ = n;
-    DeviceAllocator::instance().set_polynomial_size(n * sizeof(uint64_t));
+    allocator().set_polynomial_size(n * sizeof(uint64_t));
     return {};
 }
 

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -38,16 +38,14 @@ namespace haze {
 // through every comparison site in haze.
 constexpr std::string_view kLocalTarget = "local";
 
+class DeviceState;
+
 // Global FHE-context configuration: ring dimension, ciphertext moduli,
-// twiddle generators. Plus the program/target metadata fed to the
-// compiler at recording-init time.
-//
-// Singleton via instance(). Mutex protects mutating writes; reads are
-// taken under the same lock for consistency with vector resizes.
+// twiddle generators, plus the program/target metadata fed to the compiler
+// at recording-init time. A DeviceState member reached via config(); the
+// mutex covers writes and reads alike (vector resizes).
 class Config {
   public:
-    static Config &instance() noexcept;
-
     // FHE parameters (existing public API).
     std::expected<void, HazeInternalError> set_ring_dimension(uint64_t n) noexcept
         HAZE_EXCLUDES(mutex_);
@@ -100,6 +98,7 @@ class Config {
     Config &operator=(const Config &) = delete;
 
   private:
+    friend class DeviceState;
     Config() = default;
 
     mutable HazeMutex mutex_;
@@ -122,8 +121,7 @@ class Config {
     bool reduced_noise_ HAZE_GUARDED_BY(mutex_) = false;
 };
 
-inline Config &config() noexcept {
-    return Config::instance();
-}
+// Defined in device_state.cpp (returns the DeviceState member).
+Config &config() noexcept;
 
 } // namespace haze

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -13,6 +13,7 @@
 #include "core/device.hpp"
 
 #include "common/errors.hpp"
+#include "core/device_state.hpp"
 
 #include <atomic>
 #include <cstddef>
@@ -32,10 +33,6 @@ inline constexpr int kNumHbmBanks = 8;
 // Config::set_ring_dimension validates against the same range.
 inline constexpr int kNumSupportedRingDims = kMaxRingDimExponent - kMinRingDimExponent + 1;
 
-// Single-device runtime: only one piece of mutable state. Atomic so a
-// hazeGetDevice racing a hazeDeviceReset reads a coherent value without
-// needing a lock (relaxed: no ordering is implied with other state).
-std::atomic<int> g_active_device{0};
 } // namespace
 
 int device_count() noexcept {
@@ -43,14 +40,14 @@ int device_count() noexcept {
 }
 
 int device_active() noexcept {
-    return g_active_device.load(std::memory_order_relaxed);
+    return device_state().active_device.load(std::memory_order_relaxed);
 }
 
 std::expected<void, HazeInternalError> device_set_active(int device) noexcept {
     if (device != 0)
         return std::unexpected(HazeInternalError::InvalidArgument);
-    // g_active_device is initialised to 0, only reset to 0, and the
-    // guard above rejects every non-zero value — no assignment needed.
+    // active_device starts 0 and DeviceState::reset() only stores 0; the
+    // guard above rejects every non-zero value, so no assignment is needed.
     return {};
 }
 
@@ -73,10 +70,6 @@ std::expected<void, HazeInternalError> device_fill_properties(hazeDeviceProp *pr
     prop->maxCiphertextModuli = kMaxCiphertextModuli;
     prop->numHBMBanks = kNumHbmBanks;
     return {};
-}
-
-void device_reset() noexcept {
-    g_active_device.store(0, std::memory_order_relaxed);
 }
 
 } // namespace haze

--- a/src/core/device.hpp
+++ b/src/core/device.hpp
@@ -43,6 +43,5 @@ int device_active() noexcept;
 std::expected<void, HazeInternalError> device_set_active(int device) noexcept;
 std::expected<void, HazeInternalError> device_fill_properties(hazeDeviceProp *prop,
                                                               int device) noexcept;
-void device_reset() noexcept;
 
 } // namespace haze

--- a/src/core/device_state.cpp
+++ b/src/core/device_state.cpp
@@ -1,0 +1,58 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#include "core/device_state.hpp"
+
+#include <atomic>
+// Plain C-ABI header (only haze_types.h + stdint.h) — pulls no C++/OpenFHE, so
+// depending on it here does not leak the bridge's OpenFHE surface into core/.
+#include <haze/replay_bridge.h>
+
+namespace haze {
+
+DeviceState &DeviceState::instance() noexcept {
+    // Meyers singleton: thread-safe first-use init, destroyed at exit. A throw
+    // from the constructor terminates through this noexcept frame.
+    static DeviceState inst;
+    return inst;
+}
+
+void DeviceState::reset() noexcept {
+    epoch.reset();
+    backend.reset();
+    allocator.reset();
+    config.reset();
+    active_device.store(0, std::memory_order_relaxed);
+    next_stream_id.store(1, std::memory_order_relaxed);
+    next_event_id.store(1, std::memory_order_relaxed);
+    // Bridge reset queries the live compiler, so it must precede the vendor
+    // compiler teardown that follows.
+    hazeReplayBridgeReset();
+    CompilerBackend::reset_compiler();
+}
+
+// Single definition point for the subsystem accessors declared in each
+// class's header.
+Config &config() noexcept {
+    return device_state().config;
+}
+CompilerBackend &backend() noexcept {
+    return device_state().backend;
+}
+DeviceAllocator &allocator() noexcept {
+    return device_state().allocator;
+}
+EpochState &epoch() noexcept {
+    return device_state().epoch;
+}
+
+} // namespace haze

--- a/src/core/device_state.hpp
+++ b/src/core/device_state.hpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#pragma once
+
+#include "core/allocator.hpp"
+#include "core/backend.hpp"
+#include "core/config.hpp"
+#include "core/epoch.hpp"
+
+#include <atomic>
+#include <cstdint>
+
+namespace haze {
+
+// The single piece of mutable global state — the CUDA-primary-context analogue
+// the C ABI implies. A Meyers singleton: constructed on first use, destroyed at
+// exit in reverse member order; hazeDeviceReset via reset() is the mid-life teardown.
+class DeviceState {
+  public:
+    static DeviceState &instance() noexcept;
+
+    Config config;
+    CompilerBackend backend;
+    DeviceAllocator allocator;
+    EpochState epoch;
+    std::atomic<int> active_device{0};
+    std::atomic<uint64_t> next_stream_id{1};
+    std::atomic<uint64_t> next_event_id{1};
+
+    // Full teardown backing hazeDeviceReset; subsystem order matters (see the .cpp).
+    void reset() noexcept;
+
+    // Rule of five, all deleted: the sole instance is reached by reference,
+    // never copied or moved.
+    DeviceState(const DeviceState &) = delete;
+    DeviceState &operator=(const DeviceState &) = delete;
+    DeviceState(DeviceState &&) = delete;
+    DeviceState &operator=(DeviceState &&) = delete;
+    ~DeviceState() = default;
+
+  private:
+    DeviceState() = default;
+};
+
+inline DeviceState &device_state() noexcept {
+    return DeviceState::instance();
+}
+
+} // namespace haze

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -34,11 +34,6 @@ namespace haze {
 
 namespace fhetch = niobium::fhetch;
 
-EpochState &EpochState::instance() noexcept {
-    static EpochState inst;
-    return inst;
-}
-
 void EpochState::ensure_recording_locked() {
     // start_epoch() precedes start(); on any failure recording_ stays false so
     // require_recording_locked reports it. If start() fails after start_epoch()

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -34,17 +34,16 @@ namespace haze {
 // "modulus unknown" marker for the addr->modulus tracking below.
 inline constexpr uint64_t kCopyModulus = 0xFFFFFFFFFFFFFFFFULL;
 
+class DeviceState;
 class EpochState;
-EpochState &epoch() noexcept; // inline definition after the class
+EpochState &epoch() noexcept; // defined in device_state.cpp
 
-// Singleton tracking the polymap, pending outputs, and recording flag for
-// the active epoch; replay_and_populate() drains it at flush time. Public
-// methods take mutex_; _locked variants require it held via EpochSession
-// (enforced by clang -Wthread-safety).
+// Tracks the polymap, pending outputs, and recording flag for the active
+// epoch (a DeviceState member); replay_and_populate() drains it at flush
+// time. Public methods take mutex_; _locked variants require it held via
+// EpochSession (enforced by clang -Wthread-safety).
 class EpochState {
   public:
-    static EpochState &instance() noexcept;
-
     // The mutex itself; EpochSession is the canonical acquirer.
     HazeMutex &mutex() noexcept HAZE_RETURN_CAPABILITY(mutex_) { return mutex_; }
 
@@ -150,6 +149,7 @@ class EpochState {
     EpochState &operator=(const EpochState &) = delete;
 
   private:
+    friend class DeviceState;
     EpochState() = default;
 
     // Tag pending SRP + MRP outputs for fhetch. Shared by replay_and_populate
@@ -200,10 +200,6 @@ class EpochState {
     // Friend so EpochSession's ACQUIRE/RELEASE attributes can name mutex_.
     friend class EpochSession;
 };
-
-inline EpochState &epoch() noexcept {
-    return EpochState::instance();
-}
 
 // RAII guard for compute entry points: brings up the backend, takes the
 // epoch mutex, and enters recording mode for the session lifetime.

--- a/src/core/stream.cpp
+++ b/src/core/stream.cpp
@@ -12,34 +12,26 @@
 // from the Product.
 #include "core/stream.hpp"
 
+#include "core/device_state.hpp"
+
 #include <atomic>
-#include <cstdint>
 #include <haze/haze_types.h>
 #include <new>
 
 namespace haze {
 
-namespace {
-std::atomic<uint64_t> g_next_stream_id{1};
-std::atomic<uint64_t> g_next_event_id{1};
-} // namespace
-
 hazeStream_t stream_create() noexcept {
     return new (std::nothrow)
-        haze_stream_s{.id = g_next_stream_id.fetch_add(1, std::memory_order_relaxed)};
+        haze_stream_s{.id = device_state().next_stream_id.fetch_add(1, std::memory_order_relaxed)};
 }
 
 void stream_destroy(hazeStream_t s) noexcept {
     delete s; // delete nullptr is well-defined and a no-op
 }
 
-void streams_reset() noexcept {
-    g_next_stream_id.store(1, std::memory_order_relaxed);
-}
-
 hazeEvent_t event_create() noexcept {
     return new (std::nothrow)
-        haze_event_s{.id = g_next_event_id.fetch_add(1, std::memory_order_relaxed)};
+        haze_event_s{.id = device_state().next_event_id.fetch_add(1, std::memory_order_relaxed)};
 }
 
 void event_destroy(hazeEvent_t e) noexcept {
@@ -49,10 +41,6 @@ void event_destroy(hazeEvent_t e) noexcept {
 void event_record(hazeEvent_t /*e*/) noexcept {
     // Events do not model ordering in this runtime (CUDA-shape parity
     // only); recording is a no-op.
-}
-
-void events_reset() noexcept {
-    g_next_event_id.store(1, std::memory_order_relaxed);
 }
 
 } // namespace haze

--- a/src/core/stream.hpp
+++ b/src/core/stream.hpp
@@ -33,11 +33,9 @@ namespace haze {
 
 hazeStream_t stream_create() noexcept; // new haze_stream_s, caller owns
 void stream_destroy(hazeStream_t s) noexcept;
-void streams_reset() noexcept;
 
 hazeEvent_t event_create() noexcept;
 void event_destroy(hazeEvent_t e) noexcept;
 void event_record(hazeEvent_t e) noexcept;
-void events_reset() noexcept;
 
 } // namespace haze

--- a/test/test_invariant_regressions.cpp
+++ b/test/test_invariant_regressions.cpp
@@ -5,6 +5,7 @@
 // destinations, no-op flush semantics, CRT base validation, sticky
 // last-error, and the configuration freeze rules.
 
+#include "core/stream.hpp" // haze_stream_s/haze_event_s ids for the reset pin
 #include "integration_helpers.hpp"
 
 #include <catch2/catch_test_macros.hpp>
@@ -494,4 +495,29 @@ TEST_CASE("failed materialize clears the epoch: retag fails, next flush is a no-
     REQUIRE(hazeFree(b) == HAZE_SUCCESS);
     REQUIRE(hazeFree(c) == HAZE_SUCCESS);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeDeviceReset restarts stream/event ids and the active device", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    hazeStream_t s1 = nullptr;
+    hazeEvent_t e1 = nullptr;
+    REQUIRE(hazeStreamCreate(&s1) == HAZE_SUCCESS);
+    REQUIRE(hazeEventCreate(&e1) == HAZE_SUCCESS);
+    REQUIRE(s1->id == 1);
+    REQUIRE(e1->id == 1);
+    REQUIRE(hazeStreamDestroy(s1) == HAZE_SUCCESS);
+    REQUIRE(hazeEventDestroy(e1) == HAZE_SUCCESS);
+
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    hazeStream_t s2 = nullptr;
+    hazeEvent_t e2 = nullptr;
+    REQUIRE(hazeStreamCreate(&s2) == HAZE_SUCCESS);
+    REQUIRE(hazeEventCreate(&e2) == HAZE_SUCCESS);
+    REQUIRE(s2->id == 1); // counters restart, not continue
+    REQUIRE(e2->id == 1);
+    REQUIRE(hazeStreamDestroy(s2) == HAZE_SUCCESS);
+    REQUIRE(hazeEventDestroy(e2) == HAZE_SUCCESS);
+    int dev = -1;
+    REQUIRE(hazeGetDevice(&dev) == HAZE_SUCCESS);
+    REQUIRE(dev == 0);
 }

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -321,7 +321,7 @@ TEST_CASE("hazeMallocMrp with null ptrs is rejected", "[unit]") {
 TEST_CASE("hazeMallocMrp with wrong size is rejected and allocates nothing", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    const auto &alloc = haze::DeviceAllocator::instance();
+    const auto &alloc = haze::allocator();
     REQUIRE(haze::test::AllocatorTestAccess::alloc_set_size(alloc) == 0);
 
     void *ptrs[3] = {reinterpret_cast<void *>(0xA), reinterpret_cast<void *>(0xB),
@@ -337,7 +337,7 @@ TEST_CASE("hazeMallocMrp with wrong size is rejected and allocates nothing", "[u
 
 TEST_CASE("hazeMallocMrp rolls back reserved polys on a mid-batch failure", "[unit]") {
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
-    auto &alloc = haze::DeviceAllocator::instance();
+    auto &alloc = haze::allocator();
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
 
@@ -407,7 +407,7 @@ TEST_CASE("hazeFreeMrp skips null entries and frees the rest", "[unit]") {
 TEST_CASE("hazeMallocMrp rejects an out-of-range count without allocating", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    const auto &alloc = haze::DeviceAllocator::instance();
+    const auto &alloc = haze::allocator();
     void *ptrs[1] = {reinterpret_cast<void *>(0x1234)};
 
     // count = SIZE_MAX and count = cap+1 both reject before any reserve, so
@@ -482,7 +482,7 @@ TEST_CASE("hazeFreeMrp of an already-freed group is rejected and does not alias"
 
 TEST_CASE("hazeFreeMrp frees every entry and returns the first error", "[unit]") {
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
-    auto &alloc = haze::DeviceAllocator::instance();
+    auto &alloc = haze::allocator();
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
     void *a = nullptr;


### PR DESCRIPTION
Config, CompilerBackend, DeviceAllocator, and EpochState become members of a single DeviceState aggregate (the CUDA-primary-context analogue the C ABI implies), alongside the stream/event counters and active-device flag that used to be loose globals. Teardown completeness is now structural — DeviceState::reset() replaces lifecycle.cpp's remember-to-add-your-subsystem reset_all — and the subsystem accessors keep their call-site spelling, defined once in device_state.cpp.