### PR TITLE
refactor(core): make Config's hot-path scalars lock-free

### DIFF
--- a/.github/instructions/CODE_REVIEW_GUIDE.md
+++ b/.github/instructions/CODE_REVIEW_GUIDE.md
@@ -62,7 +62,7 @@ Label every issue: **Blocker / High / Medium / Low**.
 ### Medium Risk — targeted review
 - New compute API implementations in `src/api/compute.cpp`.
 - New or modified test cases under `test/`.
-- Changes to `hazeSetRingDimension`, `hazeMalloc`, `hazeFree` (single-size invariant enforcement).
+- Changes to `hazeConfigureDevice`, `hazeMalloc`, `hazeFree` (single-size invariant enforcement).
 - Changes to the `EpochSession` RAII guard lifecycle (constructor, destructor, `ensure_initialized`).
 
 ### Low Risk — light review
@@ -116,7 +116,7 @@ This is the most subtle correctness area in libhaze.
 
 ### 3.6 Single-Size Allocation Invariant
 - Every `hazeMalloc` allocation must equal `ring_dim * sizeof(uint64_t)`. Any path that accepts a different size or skips the size check is a Blocker.
-- `hazeSetRingDimension` must be called before the first `hazeMalloc`. New code that calls `hazeMalloc` without a prior ring-dimension set is a contract violation.
+- `hazeConfigureDevice` must be called before the first `hazeMalloc`. New code that calls `hazeMalloc` without a prior configure is a contract violation.
 - `hazeHostAlloc` is the correct path for non-polynomial scratch (pointer arrays, twiddle tables, kernel-arg packs) — these must never go through `hazeMalloc`.
 
 ### 3.7 hazeDeviceReset and Bridge Re-init

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ is unaffected.
 Symptom: a clean release build links with warnings like `object file ...
 was built for newer macOS version (26.0) than being linked (14.0)`, then
 segfaults non-deterministically inside calls that should be no-ops
-(`hazeSetRingDimension`, `hazeMalloc`). Two libc++ ABI versions are
+(`hazeConfigureDevice`, `hazeMalloc`). Two libc++ ABI versions are
 colliding in the same process.
 
 Fix: rebuild every dylib in the link graph in the same shell so each
@@ -146,7 +146,7 @@ end-to-end; any other target string (`FUNC_SIM`, `FHE_SIM`, `FPGA_TRI`,
 `fhetch_sim`) is forwarded verbatim to `nbcc_fhetch_replay` over HTTP
 transport and requires `NIOBIUM_COMPILER_ROOT` to point at a compiler
 checkout with `build/nbcc_fhetch_replay`. Resolution order for the value
-itself: explicit `hazeSetTarget()` call > `HAZE_TARGET` env var > `"local"`
+itself: explicit `hazeReplayConfig::target` > `HAZE_TARGET` env var > `"local"`
 default. `kLocalTarget` in `src/core/config.hpp` is the single source of
 truth for the local string literal — keep comparison sites going through
 that constant.
@@ -412,7 +412,7 @@ CUDA-shape parity but do not flush and do not model ordering.
   addr that was never written is a contract violation).
 
 Every `hazeMalloc` allocation must equal the configured polynomial size
-(`ring_dim * sizeof(uint64_t)`). `hazeSetRingDimension` is required before
+(`ring_dim * sizeof(uint64_t)`). `hazeConfigureDevice` is required before
 the first `hazeMalloc`. Non-polynomial scratch (pointer arrays, twiddle
 tables, kernel-arg packs) goes through `hazeHostAlloc` or ordinary host
 malloc, not `hazeMalloc`.
@@ -428,7 +428,10 @@ addresses above FHETCH's synthetic address range (< `0x1000000000`).
 ### Lock order
 
 The full DAG is documented canonically in `src/common/thread_safety.hpp`:
-epoch → {config, allocator}; config → allocator; backend-init → config.
+epoch → allocator. Config carries no lock: it is a write-only builder frozen to
+an immutable value by the explicit `hazeConfigureDevice()`, then read without
+lock or atomics (the config is mutated only by the single-threaded control
+plane, never by compute — see thread_safety.hpp for the contract).
 The allocator is a leaf — allocator-side code must never call back into
 `EpochState` (or any other component) while holding its lock or it will
 deadlock. The constraint is enforced architecturally (no back-call exists

--- a/README.md
+++ b/README.md
@@ -63,10 +63,11 @@ simulator internals, see the companion repository:
    against `libhaze`. No probes, no instrumented OpenFHE. Haze pulls
    `libnbfhetch` in transitively for the recording back-end.
 
-2. **Configure** — `hazeSetRingDimension(N)`, `hazeSetCiphertextModulus(idx, q)`
-   for each residue, and `hazeConfigureDevice()` lock in the FHE parameter set.
-   Optional: `hazeSetTarget("FUNC_SIM")` (or set `HAZE_TARGET` in the
-   environment) to pick a non-default replay target.
+2. **Configure** — fill a `hazeFheParams` (ring dimension + the ciphertext
+   moduli array) and pass it to `hazeConfigureDevice(&fhe, &replay)` in one call
+   to lock in the FHE parameter set. The optional `hazeReplayConfig` picks a
+   non-default replay target (`.target = "FUNC_SIM"`, or set `HAZE_TARGET` in the
+   environment) and other hardware/replay options; pass `NULL` for all defaults.
 
 3. **Allocate & Record** — `hazeMalloc` returns one FHETCH-addressable
    polynomial. Compute calls (`hazeAdd`, `hazeMul`, `hazeNTT`, `hazeAutomorph`,
@@ -133,14 +134,13 @@ int main(void) {
         576460752364240897ULL,
     };
 
-    /* ---- Configure the FHE parameter set. ---- */
-    hazeSetRingDimension(ring_dim);
-    /* Seed the CryptoContext the local simulator uses to reconstruct values. */
+    /* ---- Configure the FHE parameter set (ring dim + the modulus tower). ---- */
+    hazeFheParams fhe = {.ring_dim = ring_dim, .moduli = q, .moduli_count = kNumLimbs};
+    hazeConfigureDevice(&fhe, NULL);
+    /* Seed the CryptoContext the local simulator uses to reconstruct values;
+       requires the configure above to have run first. */
     uint64_t picked = 0;
     hazeReplayBridgeInitCryptoContext(ring_dim, q[0], &picked);
-    for (int i = 0; i < kNumLimbs; ++i)
-        hazeSetCiphertextModulus(i, q[i]);
-    hazeConfigureDevice();
 
     /* ---- Allocate the MRP groups; stage host inputs (a = 1, b = 2). ---- */
     void *d_a[kNumLimbs], *d_b[kNumLimbs], *d_dst[kNumLimbs];
@@ -275,12 +275,10 @@ int main() {
 
     // ---- Configure haze for the same chain (moduli read off the context). ----
     hazeDeviceReset();
-    hazeSetRingDimension(N);
+    hazeFheParams fhe = {.ring_dim = N, .moduli = q_base.data(), .moduli_count = towers};
+    hazeConfigureDevice(&fhe, nullptr);
     uint64_t picked = 0;
     hazeReplayBridgeInitCryptoContext(N, q_base[0], &picked);
-    for (std::size_t i = 0; i < towers; ++i)
-        hazeSetCiphertextModulus(static_cast<int>(i), q_base[i]);
-    hazeConfigureDevice();
 
     // ---- Stage each ciphertext's (c0, c1) limbs to the device as one MRP group. ----
     auto h2d = [&](const std::vector<std::vector<uint64_t>> &chain) {
@@ -698,8 +696,9 @@ niobium-haze/
   recorded `.fhetch` trace through the in-process simulator inside `libnbfhetch`
   (no external binary, no transport). The compiler-side targets (`FUNC_SIM`,
   `FHE_SIM`, `FPGA_TRI`, `fhetch_sim`) ship the same trace over HTTP to
-  `nbcc_fhetch_replay`. Switching between them is a single `hazeSetTarget`
-  call (or `HAZE_TARGET` env var); the application code does not change.
+  `nbcc_fhetch_replay`. Switching between them is a single `hazeReplayConfig`
+  field (`.target`, or the `HAZE_TARGET` env var); the application code does not
+  change.
 
 ## License
 

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -22,14 +22,13 @@ extern "C" {
 
 // Device management.
 //
-// hazeDeviceSynchronize is a no-op returning HAZE_SUCCESS. CUDA blocks until
-// async device work drains; HAZE records synchronously and has nothing running
-// in the background, so there is nothing to wait for. It does NOT execute the
-// recording — run it explicitly with hazeFlush() before reading results back.
+// hazeDeviceSynchronize is a no-op returning HAZE_SUCCESS (HAZE records synchronously, so there
+// is no background work to wait for); it does NOT execute the recording — call hazeFlush()
+// before reading results back.
 //
-// hazeDeviceReset clears all process-global HAZE state (allocator pool,
-// epoch, compiler backend, configuration, streams, events, active
-// device) AND the thread-local last-error flag. Mirrors cudaDeviceReset.
+// hazeDeviceReset mirrors cudaDeviceReset: it clears all process-global HAZE state (allocator
+// pool, epoch, compiler backend, configuration, streams, events, active device) and the
+// thread-local last-error flag.
 
 HAZE_API hazeError_t hazeGetDeviceCount(int *count) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeSetDevice(int device) HAZE_NOEXCEPT;
@@ -42,27 +41,19 @@ HAZE_API hazeError_t hazeDeviceCanAccessPeer(int *can_access, int device, int pe
 
 // Device memory: allocation, free, host-pinned buffers, pointer attributes.
 //
-// hazeMalloc returns one FHETCH-addressable polynomial. `size` must equal
-// the configured polynomial size (= ring_dim * sizeof(uint64_t)). Calls
-// before hazeSetRingDimension return HAZE_ERROR_CONFIGERR; calls with a
-// size that does not match the configured polynomial size return
-// HAZE_ERROR_SIZE_MISMATCH. Non-polynomial host-side scratch should use
-// hazeHostAlloc (or ordinary host allocation).
+// hazeMalloc returns one FHETCH-addressable polynomial: `size` must equal the configured
+// polynomial size (= ring_dim * sizeof(uint64_t)) or HAZE_ERROR_SIZE_MISMATCH is returned, and
+// calls before hazeConfigureDevice return HAZE_ERROR_CONFIGERR; non-polynomial host-side
+// scratch should use hazeHostAlloc (or ordinary host allocation).
 //
-// Async variants (hazeMallocAsync, hazeFreeAsync, hazeMemcpyAsync,
-// hazeMemsetAsync, hazeMemcpyPeerAsync). The `stream` parameter is
-// accepted for CUDA-shape parity but is intentionally not honoured for
-// ordering: HAZE is a recording layer that emits FHETCH IR, not an
-// execution engine. Stream-relative ordering is meaningless until
-// hazeFlush() materializes the recorded program. The async entries
-// behave identically to their sync counterparts.
+// The async variants behave identically to their sync counterparts: `stream` is accepted for
+// CUDA-shape parity but intentionally not honoured for ordering, because HAZE records FHETCH IR
+// and stream-relative ordering is meaningless until hazeFlush() materializes the program.
 //
-// hazePointerGetAttributes returns HAZE_SUCCESS for any non-null
-// `attrs` argument. Pointers obtained from hazeMalloc / hazeMallocAsync
-// report HAZE_MEMORY_TYPE_DEVICE; pointers from hazeHostAlloc report
-// HAZE_MEMORY_TYPE_HOST; any other pointer (stack, heap from a foreign
-// allocator, etc.) reports HAZE_MEMORY_TYPE_UNREGISTERED — matches
-// cudaPointerGetAttributes' behaviour from CUDA 11 onward.
+// hazePointerGetAttributes returns HAZE_SUCCESS for any non-null `attrs`: hazeMalloc /
+// hazeMallocAsync pointers report HAZE_MEMORY_TYPE_DEVICE, hazeHostAlloc pointers report
+// HAZE_MEMORY_TYPE_HOST, and any other pointer reports HAZE_MEMORY_TYPE_UNREGISTERED, matching
+// cudaPointerGetAttributes from CUDA 11 onward.
 
 HAZE_API hazeError_t hazeMalloc(void **ptr, size_t size) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeFree(void *ptr) HAZE_NOEXCEPT;
@@ -75,19 +66,18 @@ HAZE_API hazeError_t hazePointerGetAttributes(hazePointerAttributes *attrs,
 
 // Data transfer: H2D, D2H, D2D, memset, peer copies.
 //
-// Output model (explicit): HAZE records compute lazily and does not infer
-// which results you want back. The canonical pattern is
-// compute -> hazeTagOutput(ptr) -> hazeFlush() -> hazeMemcpy(D2H). A D2H of an
-// address that was not tagged-and-flushed returns HAZE_ERROR_NOT_FLUSHED. A
-// plain H2D-then-D2H round-trip needs no tag/flush — the uploaded bytes are
-// returned as-is. A compute result or D2D copy landing on an address drops
-// any previously uploaded bytes there — D2H then errors with
-// HAZE_ERROR_NOT_FLUSHED until tag+flush, never returning stale data.
+// Outputs are explicit — HAZE records compute lazily and does not infer which results you want
+// back: the canonical pattern is compute -> hazeTagOutput(ptr) -> hazeFlush() ->
+// hazeMemcpy(D2H), and a D2H of an address that was not tagged-and-flushed returns
+// HAZE_ERROR_NOT_FLUSHED. A plain H2D-then-D2H round-trip needs no tag/flush — the uploaded
+// bytes are returned as-is. A compute result or D2D copy landing on an address drops any
+// previously uploaded bytes there, so D2H errors with HAZE_ERROR_NOT_FLUSHED until tag+flush
+// rather than returning stale data.
 //
-// D2D copies whole polynomials: `count` must equal the polynomial size
-// (partial copies are unexpressible in the IR — HAZE_ERROR_INVALID_VALUE;
-// oversized is HAZE_ERROR_SIZE_MISMATCH). H2D/D2H accept count <= polynomial
-// size, and a zero `count` (memcpy or memset) is a success no-op, per CUDA.
+// D2D copies whole polynomials: `count` must equal the polynomial size (partial copies are
+// unexpressible in the IR — HAZE_ERROR_INVALID_VALUE; oversized is HAZE_ERROR_SIZE_MISMATCH).
+// H2D/D2H accept count <= polynomial size, and a zero `count` (memcpy or memset) is a success
+// no-op, per CUDA.
 
 HAZE_API hazeError_t hazeMemcpy(void *dst, const void *src, size_t count,
                                 hazeMemcpyKind kind) HAZE_NOEXCEPT;
@@ -99,55 +89,44 @@ HAZE_API hazeError_t hazeMemsetAsync(void *dev_ptr, int value, size_t count,
 HAZE_API hazeError_t hazeMemcpyPeerAsync(void *dst, int dst_device, const void *src, int src_device,
                                          size_t count, hazeStream_t stream) HAZE_NOEXCEPT;
 
-// Per-residue (MRP) variant of hazeMemcpy: `dst`/`src` are arrays of
-// `base_len` poly pointers and `count` is bytes-per-residue, applied to every
-// residue under `kind`. `base` (the per-residue primes, see the MRP block
-// below) is consulted only by D2D, which records a per-residue pass-through
-// copy under base[i] and registers the dst as an MRP output group.
+// Per-residue (MRP) variant of hazeMemcpy: `dst`/`src` are arrays of `base_len` poly pointers
+// and `count` is bytes-per-residue, applied to every residue under `kind`. `base` (the
+// per-residue primes, see the MRP block below) is consulted only by D2D, which records a
+// per-residue pass-through copy under base[i] and registers the dst as an MRP output group.
 HAZE_API hazeError_t hazeMemcpyMrp(void *const *dst, const void *const *src, size_t count,
                                    hazeMemcpyKind kind, const uint64_t *base,
                                    size_t base_len) HAZE_NOEXCEPT;
 
-// Per-residue (MRP) allocation. hazeMallocMrp reserves `num_residues` device
-// polynomials for one MRP group and writes their addresses into
-// `ptrs[0..num_residues)`. `num_residues` is the group's residue count (the
-// `base_len` passed to the MRP compute ops); `size` is the bytes per residue
-// and must equal the configured polynomial size (ring_dim * sizeof(uint64_t))
-// — same rule and same error (HAZE_ERROR_SIZE_MISMATCH) as hazeMalloc, and
-// hazeSetRingDimension must precede the first allocation (else
-// HAZE_ERROR_CONFIGERR). The group is reserved under a single allocator lock
-// rather than `num_residues` separate hazeMalloc calls. Like
-// hazeMalloc/hazeFree, these are pure allocator operations and are not
-// recorded into the trace.
-//
-// Partial-failure rollback: if the i-th reservation fails, the 0..i-1 already
-// reserved are freed and the error returned, so nothing leaks and `ptrs` is
-// left unwritten. On success every ptrs[j] is non-null. `num_residues == 0`
-// is a success no-op (empty group), but `ptrs == NULL` is checked first, so
-// (NULL, 0) returns HAZE_ERROR_INVALID_VALUE; a `num_residues` above the
-// device modulus envelope (hazeDeviceProp::maxCiphertextModuli) is rejected
-// the same way rather than attempting an unbounded reservation.
+// hazeMallocMrp reserves `num_residues` device polynomials for one MRP group under a single
+// allocator lock and writes their addresses into `ptrs[0..num_residues)` (all non-null on
+// success); `num_residues` is the group's residue count (the `base_len` passed to the MRP
+// compute ops). `size` is bytes per residue and follows hazeMalloc's rules: it must equal the
+// configured polynomial size (ring_dim * sizeof(uint64_t)) or HAZE_ERROR_SIZE_MISMATCH is
+// returned, and hazeConfigureDevice must precede the first allocation (else
+// HAZE_ERROR_CONFIGERR). Like hazeMalloc/hazeFree these are pure allocator operations, never
+// recorded into the trace. If the i-th reservation fails, the 0..i-1 already reserved are
+// freed and the error returned, leaving `ptrs` unwritten. `num_residues == 0` is a success
+// no-op (empty group), but `ptrs == NULL` is checked first, so (NULL, 0) returns
+// HAZE_ERROR_INVALID_VALUE; a `num_residues` above the device modulus envelope
+// (hazeDeviceProp::maxCiphertextModuli) is rejected the same way.
 HAZE_API hazeError_t hazeMallocMrp(void **ptrs, size_t num_residues, size_t size) HAZE_NOEXCEPT;
 
-// Free the `num_residues`-residue MRP group in `ptrs[0..num_residues)`
-// (addresses from hazeMallocMrp or any `num_residues` hazeMalloc results)
-// under a single allocator lock. Every address is freed even if one fails;
-// the first error is returned. NULL entries are skipped, matching
-// hazeFree(NULL). Freeing an address that is not currently allocated (e.g. a
-// double free) returns HAZE_ERROR_UNKNOWN_ADDRESS. `num_residues == 0` is a
-// no-op, but `ptrs == NULL` is checked first so (NULL, 0) returns
-// HAZE_ERROR_INVALID_VALUE; a `num_residues` above the device modulus
-// envelope is rejected the same way.
+// hazeFreeMrp frees the MRP group in `ptrs[0..num_residues)` (addresses from hazeMallocMrp or
+// any `num_residues` hazeMalloc results) under a single allocator lock: every address is freed
+// even if one fails, with the first error returned; NULL entries are skipped, matching
+// hazeFree(NULL); freeing a not-currently-allocated address (e.g. a double free) returns
+// HAZE_ERROR_UNKNOWN_ADDRESS. `num_residues == 0` is a no-op, but `ptrs == NULL` is checked
+// first so (NULL, 0) returns HAZE_ERROR_INVALID_VALUE; a `num_residues` above the device
+// modulus envelope is rejected the same way.
 HAZE_API hazeError_t hazeFreeMrp(void *const *ptrs, size_t num_residues) HAZE_NOEXCEPT;
 
-// Declare `ptr` an output of the in-flight recording (tagging any one residue
-// of an MRP value tags the whole value). HAZE_ERROR_SOURCE_UNAVAILABLE if `ptr`
-// names no recorded value; a later H2D to a tagged address drops the tag. A
-// tag exports the value's final binding and shape at flush time — if a later op
-// re-registers the tagged addrs as a different-shaped multi-residue value, the
-// readback reflects that latest registration, and if a later op claims a tagged
-// residue into a different value entirely, the original group's multi-residue
-// view is dropped (its residues still materialize individually).
+// Declare `ptr` an output of the in-flight recording (tagging any one residue of an MRP value
+// tags the whole value); HAZE_ERROR_SOURCE_UNAVAILABLE if `ptr` names no recorded value, and a
+// later H2D to a tagged address drops the tag. A tag exports the value's final binding and
+// shape at flush time: if a later op re-registers the tagged addrs as a different-shaped
+// multi-residue value the readback reflects that latest registration, and if a later op claims
+// a tagged residue into a different value entirely the original group's multi-residue view is
+// dropped (its residues still materialize individually).
 HAZE_API hazeError_t hazeTagOutput(void *ptr) HAZE_NOEXCEPT;
 
 // Run the recorded program and populate the tagged outputs' shadow buffers.
@@ -155,103 +134,51 @@ HAZE_API hazeError_t hazeTagOutput(void *ptr) HAZE_NOEXCEPT;
 // intact (it is not an epoch reset — use hazeDeviceReset to discard).
 HAZE_API hazeError_t hazeFlush(void) HAZE_NOEXCEPT;
 
-// Device configuration: ring dimension, ciphertext moduli, twiddle factors,
-// program metadata, target selection, lifecycle reset.
+/* One-shot device configuration. Fill a hazeFheParams (required) with the ring
+ * dimension, ciphertext moduli, and optional twiddle generators, and optionally
+ * a hazeReplayConfig with the target, program metadata, and data-format toggles
+ * (pass NULL to accept all defaults, including target "local"). Then call this
+ * once — the caller owns both structs; haze copies what it needs and retains no
+ * pointer, so no configuration state is held before this call.
+ *
+ * Must run before any compute, hazeMemcpy(H2D), hazeMalloc, or
+ * hazeReplayBridgeInitCryptoContext. Validates the whole config (ring dimension
+ * in the device envelope; ciphertext moduli non-zero, contiguous, and unique)
+ * and returns HAZE_ERROR_CONFIGERR on a bad config or HAZE_ERROR_INVALID_VALUE
+ * on a malformed struct (NULL fhe, or a NULL array with a non-zero count);
+ * nothing is installed on failure, so a corrected struct may be retried.
+ * Re-calling reinstalls the configuration; changing the ring dimension while
+ * allocations are live returns HAZE_ERROR_CONFIGERR (free them or reset first).
+ *
+ * hazeReplayConfig::target selects the niobium-compiler replay target:
+ *   1. "local" (the default): libnbfhetch loads the .fhetch trace into its
+ *      in-process instruction-set simulator, executes it, and writes ciphertext
+ *      probes under <program_dir>/serialized_probes/, so hazeMemcpy(D2H) returns
+ *      simulator-computed values with no compiler binary or HTTP transport.
+ *   2. "FHE_SIM"/"FUNC_SIM"/"FPGA_TRI"/"fhetch_sim": dispatched over the HTTP
+ *      transport (see niobium-client/scripts/fhetch_server.sh), requiring a
+ *      built nbcc_fhetch_replay binary on PATH plus a running FHETCH server.
+ * Target dispatch happens inside hazeFlush(). The montgomery/bit_reversal
+ * toggles record alternate trace representations (Montgomery-form residues,
+ * bit-reversed coefficient order); replay decodes outputs back to ordinary form
+ * so D2H results are byte-identical. The in-process "local" simulator runs
+ * ordinary-form traces only — either toggle on "local" is reported at the first
+ * compute as HAZE_ERROR_NOT_SUPPORTED; use a transport target. reduced_noise
+ * selects centered FBC matching OpenFHE WITH_REDUCED_NOISE. */
+HAZE_API hazeError_t hazeConfigureDevice(const hazeFheParams *fhe,
+                                         const hazeReplayConfig *replay) HAZE_NOEXCEPT;
 
-HAZE_API hazeError_t hazeSetRingDimension(uint64_t n) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeSetCiphertextModulus(int index, uint64_t modulus) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeSetTwiddleFactors(int index, uint64_t generator) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeConfigureDevice(void) HAZE_NOEXCEPT;
-
-/* Set program metadata recorded in the FHETCH trace produced by HAZE.
- * Defaults: name="haze", version="0.1", description="HAZE runtime".
- * Must be called before the first H2D or compute call to take effect (the
- * first of either brings up the compiler backend). */
-HAZE_API hazeError_t hazeSetProgramInfo(const char *name, const char *version,
-                                        const char *description) HAZE_NOEXCEPT;
-
-/* Override where the recorded project is written (default <cwd>/<program_name>/);
- * `dir` is used verbatim. Must be called before the first H2D or compute call
- * (which brings up the compiler backend). */
-HAZE_API hazeError_t hazeSetProgramDirectory(const char *dir) HAZE_NOEXCEPT;
-
-/* Select the niobium-compiler target for replay.
- *
- * Targets fall into two tiers by where they execute:
- *
- *   1. In-process FHETCH simulator (DEFAULT):
- *        "local"        libnbfhetch loads the .fhetch trace into its
- *                       in-process instruction-set simulator,
- *                       executes it, and writes ciphertext probes
- *                       under <program_dir>/serialized_probes/.
- *                       hazeMemcpy(D2H) returns simulator-computed
- *                       values. No compiler-side binary or HTTP
- *                       transport required.
- *
- *   2. Compiler-side simulators via HTTP transport:
- *        "FHE_SIM"      OpenFHE simulator via nbcc_fhetch_replay.
- *        "FUNC_SIM"     Functional simulator.
- *        "FPGA_TRI"     FPGA target.
- *        "fhetch_sim"   FHETCH instruction-set simulator on the
- *                       compiler side.
- *                       These dispatch the recorded project over the
- *                       HTTP transport (see niobium-client/scripts/
- *                       fhetch_server.sh) and require a built
- *                       nbcc_fhetch_replay binary on PATH plus a
- *                       running FHETCH server.
- *
- * Defaults to "local" if hazeSetTarget is not called.
- *
- * The target is baked in when the first H2D/compute brings the backend up;
- * later calls return HAZE_ERROR_CONFIGERR (hazeDeviceReset re-opens it).
- *
- * Behaviour-by-target dispatch happens inside hazeFlush(), which finalises the
- * recording, runs the replay, and populates the tagged outputs' shadow buffers;
- * a subsequent hazeMemcpy(D2H) then reads them. */
-HAZE_API hazeError_t hazeSetTarget(const char *target) HAZE_NOEXCEPT;
-
-/* Data-representation toggles for recorded traces: Montgomery-form RNS
- * residues and bit-reversed coefficient order. Independent opt-ins.
- *
- * When enabled, traces are recorded in the chosen representation (input
- * residues Montgomery-encoded and/or bit-reversed, immediates Montgomery-
- * encoded, basis-convert lowered to its 4-op mod-switch form). Replay decodes
- * outputs back to the ordinary representation, so D2H results are byte-
- * identical to a run with the toggles off — only the recorded form changes.
- *
- * Constraints:
- *   - The in-process "local" simulator runs ordinary-form traces only; the
- *     first compute/flush returns HAZE_ERROR_NOT_SUPPORTED. Use a transport
- *     target.
- *   - Replay supports the ordinary form or both toggles together; enabling
- *     exactly one is recordable (for trace inspection via hazeWriteProgram)
- *     but rejected at replay.
- *
- * Off by default; set before the first H2D or compute. Unlike hazeSetTarget,
- * post-init toggles stay accepted: an unrunnable format is reported at the
- * next compute/flush, and toggling back off keeps the recording intact. */
-HAZE_API hazeError_t hazeSetMontgomery(int enable) HAZE_NOEXCEPT;
-HAZE_API hazeError_t hazeSetBitReversal(int enable) HAZE_NOEXCEPT;
-
-/* Centered (reduced-noise) FBC matching OpenFHE WITH_REDUCED_NOISE (off by
- * default, enabled for bit-exact parity); set before the first H2D or compute. */
-HAZE_API hazeError_t hazeSetReducedNoise(int enable) HAZE_NOEXCEPT;
-
-/* Finalize the recording and write the project directory (.fhetch trace,
- * inputs, ciphertext templates, cryptocontext) WITHOUT running replay; only
- * hazeTagOutput()-declared outputs are emitted, so tag them first. Use it to
- * record where replay isn't available locally and replay elsewhere (e.g.
- * `nbcc_fhetch_replay --project=<dir> --target=<device>` on a remote host).
- * No-op when not recording; nothing is materialized in-process, so a later
- * in-process D2H of an output returns HAZE_ERROR_NOT_FLUSHED. */
+/* Finalize the recording and write the project directory (.fhetch trace, inputs, ciphertext
+ * templates, cryptocontext) WITHOUT running replay; only hazeTagOutput()-declared outputs are
+ * emitted, so tag them first. Use it to record where replay isn't available locally and replay
+ * elsewhere (e.g. `nbcc_fhetch_replay --project=<dir> --target=<device>` on a remote host).
+ * No-op when not recording; nothing is materialized in-process, so a later in-process D2H of
+ * an output returns HAZE_ERROR_NOT_FLUSHED. */
 HAZE_API hazeError_t hazeWriteProgram(void) HAZE_NOEXCEPT;
 
-// Streams: lifecycle and ordering primitives. HAZE is a recording layer
-// that emits FHETCH IR; nothing executes until hazeFlush() dispatches
-// the recording. Stream-relative ordering is therefore not modelled,
-// and hazeStreamSynchronize / hazeStreamWaitEvent are no-ops returning
-// HAZE_SUCCESS. The handle and signature surface is preserved for
-// CUDA-shape porting parity.
+// Streams: nothing executes until hazeFlush() dispatches the recording, so stream-relative
+// ordering is not modelled — hazeStreamSynchronize / hazeStreamWaitEvent are no-ops returning
+// HAZE_SUCCESS, and the handle/signature surface exists for CUDA-shape porting parity.
 
 HAZE_API hazeError_t hazeStreamCreate(hazeStream_t *stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeStreamCreateWithPriority(hazeStream_t *stream, unsigned int flags,
@@ -295,42 +222,27 @@ HAZE_API hazeError_t hazeNTT(void *dst, const void *src, int mod_idx,
 HAZE_API hazeError_t hazeINTT(void *dst, const void *src, int mod_idx,
                               hazeStream_t stream) HAZE_NOEXCEPT;
 
-// Automorphism / rotation. hazeAutomorph(_, k) records the eval-form
-// Galois action f(X) → f(X^k): in slot terms, output slot i reads from
-// input slot j where 2j+1 ≡ k·(2i+1) (mod 2N). Specific values of k give
-// CKKS-style slot rotations; in general the action is the permutation
-// determined by k.
-//
-// `index` (= k) must be odd in [1, 2N-1]; the action is then invertible.
-// Applying automorph(k) then automorph(k') with k·k' ≡ 1 (mod 2N) yields
-// the identity, so to invert the action — i.e. permute in the opposite
-// direction — pass the multiplicative inverse of k modulo 2N as `index`.
+// hazeAutomorph(_, k) records the eval-form Galois action f(X) → f(X^k): output slot i reads
+// from input slot j where 2j+1 ≡ k·(2i+1) (mod 2N), and specific values of k give CKKS-style
+// slot rotations. `index` (= k) must be odd in [1, 2N-1], which makes the action invertible —
+// to permute in the opposite direction, pass the multiplicative inverse of k modulo 2N.
 
 HAZE_API hazeError_t hazeAutomorph(void *dst, const void *src, uint64_t index,
                                    hazeStream_t stream) HAZE_NOEXCEPT;
 
-// Multi-residue polynomial (MRP) variants of the pointwise / scalar / NTT /
-// automorph ops above. Each MRP allocation lives across `base_len` separate
-// haze allocations (one per residue / prime in `base`). The `dst` and
-// `src*` arguments are non-null arrays of `base_len` poly pointers; `base`
-// is a non-null array of `base_len` ciphertext-modulus primes (same primes
-// passed to hazeSetCiphertextModulus). Scalar variants take a parallel
-// `scalars` array of length `base_len` — `scalars[i]` is reduced
-// (semantically) modulo `base[i]`.
-//
-// hazeAutomorphMrp is the same eval-form Galois action as hazeAutomorph
-// applied to every residue — see the hazeAutomorph comment above for the
-// `index` convention and the inversion rule (pass the multiplicative
-// inverse of k modulo 2N to permute the other way).
-//
-// hazeRotAutomorphCoeffMrp is the negacyclic LEFT shift in coefficient
-// form (offset in [0, N-1]; output[i] reads input at (i+offset) mod N,
-// with a sign flip on wraparound since X^N = -1). Equivalently,
-// multiplication by X^{-offset} in R_q. Distinct semantics, distinct IR
-// op (mr_rot_automorph_coeff).
-//
-// Each call records a single `mr_*` IR op that fans out to per-residue
+// Multi-residue polynomial (MRP) variants of the pointwise / scalar / NTT / automorph ops
+// above: each MRP value spans `base_len` separate haze allocations (one per residue), `dst` /
+// `src*` are non-null arrays of `base_len` poly pointers, `base` is a non-null array of
+// `base_len` ciphertext-modulus primes (the same primes passed in hazeFheParams::moduli),
+// and scalar variants take a parallel `scalars` array with `scalars[i]` reduced (semantically)
+// modulo `base[i]`. Each call records a single `mr_*` IR op that fans out to per-residue
 // `sr_*` instructions inside niobium-fhetch.
+//
+// hazeAutomorphMrp applies hazeAutomorph's eval-form Galois action to every residue (see its
+// comment above for the `index` convention and inversion rule). hazeRotAutomorphCoeffMrp is a
+// distinct IR op (mr_rot_automorph_coeff) with distinct semantics: the negacyclic LEFT shift
+// in coefficient form — `offset` in [0, N-1], output[i] reads input at (i+offset) mod N with a
+// sign flip on wraparound since X^N = -1, equivalently multiplication by X^{-offset} in R_q.
 
 HAZE_API hazeError_t hazeAddMrp(void *const *dst, const void *const *src1, const void *const *src2,
                                 const uint64_t *base, size_t base_len,
@@ -361,16 +273,12 @@ HAZE_API hazeError_t hazeRotAutomorphCoeffMrp(void *const *dst, const void *cons
                                               uint64_t offset, const uint64_t *base,
                                               size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
 
-// CRT basis conversion (composite operations: ModUp, ModDown,
-// generalised basis convert).
-//
-// Each operates on multi-residue polynomials whose component
-// single-residue polynomials live in separate HAZE allocations. `src`
-// is a non-null array of input poly pointers (length defined by the
-// matching params field — `src_base_len`); `dst` is a non-null array
-// of output poly pointers (length per the params, see each struct's
-// doc). `params` carries the moduli bases and other scalar metadata
-// only — never polynomial pointers.
+// CRT basis conversion (composite operations: ModUp, ModDown, generalised basis convert).
+// Each operates on multi-residue polynomials whose component single-residue polynomials live
+// in separate HAZE allocations: `src` is a non-null array of `src_base_len` input poly
+// pointers, `dst` a non-null array of output poly pointers (length per the matching params
+// struct's doc), and `params` carries the moduli bases and other scalar metadata only — never
+// polynomial pointers.
 
 HAZE_API hazeError_t hazeBasisConvert(void *const *dst, const void *const *src, const void *params,
                                       hazeStream_t stream) HAZE_NOEXCEPT;
@@ -379,9 +287,8 @@ HAZE_API hazeError_t hazeModDown(void *const *dst, const void *const *src, const
 HAZE_API hazeError_t hazeModUp(void *const *dst, const void *const *src, const void *params,
                                hazeStream_t stream) HAZE_NOEXCEPT;
 
-// Graph recording and execution. Names mirror CUDA's graph API. All
-// entries currently return HAZE_ERROR_NOT_SUPPORTED — graph capture is
-// a future task.
+// Graph recording and execution mirror CUDA's graph API; every entry currently returns
+// HAZE_ERROR_NOT_SUPPORTED.
 
 HAZE_API hazeError_t hazeStreamBeginCapture(hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeStreamEndCapture(hazeStream_t stream, hazeGraph_t *graph) HAZE_NOEXCEPT;

--- a/include/haze/haze_types.h
+++ b/include/haze/haze_types.h
@@ -20,10 +20,7 @@
 // NOLINTNEXTLINE(modernize-deprecated-headers)
 #include <stdint.h>
 
-// ---------------------------------------------------------------------------
-// Symbol visibility
-// ---------------------------------------------------------------------------
-
+// Symbol visibility.
 #ifdef _WIN32
 #ifdef HAZE_BUILDING_LIBRARY
 #define HAZE_API __declspec(dllexport)
@@ -52,31 +49,20 @@
 #define HAZE_NOEXCEPT
 #endif
 
-// ---------------------------------------------------------------------------
-// Opaque handle types (distinct pointer types, not void*)
-// ---------------------------------------------------------------------------
-
+// Opaque handle types (distinct pointer types, not void*).
 typedef struct haze_stream_s *hazeStream_t;
 typedef struct haze_event_s *hazeEvent_t;
 typedef struct haze_graph_s *hazeGraph_t;
 typedef struct haze_exec_s *hazeGraphExec_t;
 
-// ---------------------------------------------------------------------------
-// Error codes
-// ---------------------------------------------------------------------------
-
-// The four typedef-enum types below are the public C ABI. C does not
-// have `enum class`, and adding a `: uint8_t` underlying type is C23-
-// only and not portable, so the C++ Core Guidelines / performance
-// recommendations that flag unscoped enums and oversized base types
-// are silenced for the entire ABI block.
+// The four typedef-enum types below are the public C ABI: C has no `enum class` and a
+// `: uint8_t` underlying type is C23-only, so the checks flagging unscoped enums and oversized
+// base types are silenced for the entire ABI block.
 // NOLINTBEGIN(cppcoreguidelines-use-enum-class,performance-enum-size)
 
-// Only user-actionable conditions get their own code. Anything that
-// signals "haze itself is broken" maps to HAZE_ERROR_INTERNAL — callers
-// can log it but can't recover; the rich classification lives in
-// haze's internal `HazeInternalError` enum and surfaces via the
-// HAZE_DEBUG=1 stderr log.
+// Only user-actionable conditions get their own code; anything signalling "haze itself is
+// broken" maps to HAZE_ERROR_INTERNAL (loggable, not recoverable), whose rich classification
+// lives in the internal `HazeInternalError` enum and surfaces via the HAZE_DEBUG=1 stderr log.
 typedef enum {
     // Values are explicit: the catch-all is a single high bit, which is not
     // sequential, so readability-enum-initial-value requires all-or-none.
@@ -91,28 +77,18 @@ typedef enum {
     HAZE_ERROR_SOURCE_UNAVAILABLE = 8, // compute / D2D read from an address that was never
                                        // written (H2D) and holds no recorded result
     HAZE_ERROR_NOT_FLUSHED = 9, // D2H of an untagged / unflushed address: tag output + hazeFlush
-    // Catch-all sits last as a single high bit (2^10). User-actionable codes are
-    // added sequentially above and must stay below it, so `err & HAZE_ERROR_INTERNAL`
-    // detects an internal error without enumerating every code.
+    // User-actionable codes stay sequential below this single high bit (2^10), so
+    // `err & HAZE_ERROR_INTERNAL` detects an internal error without enumerating every code.
     HAZE_ERROR_INTERNAL = 1024, // haze invariant broke or backend failed; see HAZE_DEBUG log
 } hazeError_t;
 
-// ---------------------------------------------------------------------------
-// DMA direction
-// Numbering matches CUDA's cudaMemcpyKind value-for-value so callers
-// porting from CUDA can cast cudaMemcpyKind to hazeMemcpyKind without
-// silently swapping directions.
-// ---------------------------------------------------------------------------
-
+// DMA direction: numbering matches CUDA's cudaMemcpyKind value-for-value, so CUDA ports can
+// cast cudaMemcpyKind to hazeMemcpyKind without silently swapping directions.
 typedef enum {
     HAZE_MEMCPY_HOST_TO_DEVICE = 1,
     HAZE_MEMCPY_DEVICE_TO_HOST = 2,
     HAZE_MEMCPY_DEVICE_TO_DEVICE = 3,
 } hazeMemcpyKind;
-
-// ---------------------------------------------------------------------------
-// Device properties.
-// ---------------------------------------------------------------------------
 
 typedef struct {
     char name[256];
@@ -124,12 +100,8 @@ typedef struct {
     int numHBMBanks;                   /* HAZE-specific */
 } hazeDeviceProp;
 
-// ---------------------------------------------------------------------------
-// Pointer attribute query result
-// ---------------------------------------------------------------------------
-
-// Memory-type values stored in hazePointerAttributes::type. Numbering
-// matches CUDA's cudaMemoryType for portability of CUDA-to-HAZE ports.
+// Memory-type values stored in hazePointerAttributes::type; numbering matches CUDA's
+// cudaMemoryType for portability of CUDA-to-HAZE ports.
 typedef enum {
     HAZE_MEMORY_TYPE_UNREGISTERED = 0,
     HAZE_MEMORY_TYPE_HOST = 1,
@@ -144,15 +116,40 @@ typedef struct {
     void *hostPointer;
 } hazePointerAttributes;
 
-// CRT basis-conversion parameter structs.
-//
-// Each struct describes a multi-residue polynomial (MRP) operation by
-// listing its prime moduli (the CRT base) and any auxiliary metadata.
-// All `*_base` arrays are arrays of `uint64_t` prime values that match
-// the primes passed to hazeSetCiphertextModulus.
-//
-// Polynomial pointers are passed via the matching public function's
-// `dst` / `src` arguments — never inside the params struct.
+// One-shot device configuration, filled by the caller and passed to
+// hazeConfigureDevice(); haze copies what it needs and retains no pointer.
+
+// FHE-scheme parameters. ring_dim is required (a power of two in the device
+// envelope). moduli lists moduli_count ciphertext-modulus primes (contiguous,
+// non-zero, unique); twiddle_generators is optional NTT metadata. A *_count of
+// 0 permits the matching pointer to be NULL.
+typedef struct {
+    uint64_t ring_dim;
+    const uint64_t *moduli;
+    size_t moduli_count;
+    const uint64_t *twiddle_generators;
+    size_t twiddle_count;
+} hazeFheParams;
+
+// Hardware/replay configuration. Every field is optional: a NULL string takes
+// its default (target "local"; program "haze" / "0.1" / "HAZE runtime";
+// program directory <cwd>/<program_name>) and the int flags default off. Pass
+// a NULL hazeReplayConfig* to hazeConfigureDevice to accept all defaults.
+typedef struct {
+    const char *target;
+    const char *program_name;
+    const char *program_version;
+    const char *program_description;
+    const char *program_directory;
+    int montgomery;
+    int bit_reversal;
+    int reduced_noise;
+} hazeReplayConfig;
+
+// CRT basis-conversion parameter structs: each describes a multi-residue polynomial (MRP)
+// operation by listing its prime moduli plus auxiliary metadata, where every `*_base` array
+// holds `uint64_t` primes matching those passed in hazeFheParams::moduli; polynomial
+// pointers travel via the matching function's `dst` / `src` arguments, never inside the struct.
 
 // hazeBasisConvert: convert an MRP from src_base to dst_base.
 //   src: array of src_base_len input poly pointers.

--- a/replay_bridge/include/haze/replay_bridge.h
+++ b/replay_bridge/include/haze/replay_bridge.h
@@ -24,10 +24,13 @@ extern "C" {
 #endif
 
 /// Build a CKKS CryptoContext for (ring_dim, desired_modulus), write
-/// cryptocontext.dat, and return the OpenFHE-picked modulus via
-/// `picked_modulus` (non-null) so callers can align via hazeSetCiphertextModulus.
-/// Must be re-called after every hazeDeviceReset (setup_integration_compute_config
-/// enforces this; the post-recording hook is cleared by reset).
+/// cryptocontext.dat, and return the OpenFHE-picked scaffold modulus via
+/// `picked_modulus` (non-null). The scaffold prime is overwritten from the
+/// trace at synthesis and never consulted for results, so callers set the
+/// authoritative primes in hazeFheParams::moduli and only read picked_modulus
+/// for reference. Requires hazeConfigureDevice() first, and must be re-called
+/// after every hazeDeviceReset (setup_integration_compute_config enforces this;
+/// the post-recording hook is cleared by reset).
 HAZE_API hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim, uint64_t desired_modulus,
                                                        uint64_t *picked_modulus) HAZE_NOEXCEPT;
 

--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -12,7 +12,7 @@
 #include "ciphertext-ser.h"
 #include "common/errors.hpp" // set_error — bridge entries feed hazeGetLastError too
 #include "common/log.hpp"
-#include "core/config.hpp" // haze::config() — honor caller-pinned program name/directory
+#include "core/config.hpp" // haze::replay_config() — honor caller-pinned program name/directory
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
 #include "openfhe.h"
@@ -495,6 +495,12 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
     if (picked_modulus == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
 
+    // Configuration must be finalized (hazeConfigureDevice) first; this pre-init
+    // reads the frozen replay config, never the write-only builder.
+    if (!haze::config_finalized())
+        return set_error(HAZE_ERROR_CONFIGERR);
+    const haze::ReplayConfig &rc = haze::replay_config();
+
     try {
         // The record-time capture builds a local OpenFHE context regardless of the
         // replay target, so disable the compiler's hardware ring-dim/prime checks
@@ -504,9 +510,9 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         // default target instead of the configured one (init() re-applies, so the
         // backend's first-compute bring-up stays authoritative when it does run).
         {
-            const std::string target_arg = "--target=" + haze::config().target();
+            const std::string target_arg = "--target=" + rc.target();
             // argv[0] mirrors backend.cpp's bring-up.
-            std::string prog_storage = haze::config().program_name();
+            std::string prog_storage = rc.program_name();
             std::string target_storage = target_arg;
             std::string no_ring_check_storage = "--no-ring-dim-check";
             std::string no_prime_check_storage = "--no-prime-check";
@@ -525,12 +531,11 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         // Use the CONFIGURED program name so cryptocontext.dat lands in the
         // same directory the trace will (a hard-coded "haze" orphaned it
         // whenever the app set a custom name).
-        niobium::compiler().set_program_info(haze::config().program_name(),
-                                             haze::config().program_version(),
-                                             haze::config().program_description());
+        niobium::compiler().set_program_info(rc.program_name(), rc.program_version(),
+                                             rc.program_description());
 
         // Honor a caller-pinned program directory. hazeSetProgramDirectory()
-        // stores the directory in haze::config(); the backend only forwards it to
+        // stores the directory in the replay config; the backend only forwards it to
         // the compiler at first-compute bring-up (core/backend.cpp), which happens
         // AFTER this init writes cryptocontext.dat. Without re-applying it here,
         // set_program_info()'s cwd/<name> reset orphans cryptocontext.dat under
@@ -540,8 +545,8 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         // never pin a directory (cwd/<name> default), so the divergence stayed
         // hidden until a library integrator (FIDESlib's HazeEngine) pinned a custom
         // run directory.
-        if (haze::config().has_program_directory())
-            niobium::compiler().set_program_directory(haze::config().program_directory());
+        if (rc.has_program_directory())
+            niobium::compiler().set_program_directory(rc.program_directory());
 
         niobium::compiler().capture_crypto_context(built->cc);
 

--- a/src/api/config.cpp
+++ b/src/api/config.cpp
@@ -13,62 +13,17 @@
 #include "core/config.hpp"
 
 #include "common/errors.hpp"
-#include "core/backend.hpp"
 
-#include <cstdint>
 #include <haze/haze.h>
 #include <haze/haze_types.h>
 
-extern "C" hazeError_t hazeSetRingDimension(uint64_t n) noexcept {
-    return set_internal_result(haze::config().set_ring_dimension(n));
-}
-
-extern "C" hazeError_t hazeSetCiphertextModulus(int index, uint64_t modulus) noexcept {
-    return set_internal_result(haze::config().set_modulus(index, modulus));
-}
-
-extern "C" hazeError_t hazeSetTwiddleFactors(int index, uint64_t generator) noexcept {
-    return set_internal_result(haze::config().set_twiddle_generator(index, generator));
-}
-
-extern "C" hazeError_t hazeConfigureDevice() noexcept {
-    return set_internal_result(haze::config().configure_device());
-}
-
-extern "C" hazeError_t hazeSetProgramInfo(const char *name, const char *version,
-                                          const char *description) noexcept {
-    return set_internal_result(haze::config().set_program_info(name, version, description));
-}
-
-extern "C" hazeError_t hazeSetTarget(const char *target) noexcept {
-    if (target == nullptr)
+extern "C" hazeError_t hazeConfigureDevice(const hazeFheParams *fhe,
+                                           const hazeReplayConfig *replay) noexcept {
+    // One-shot configuration: the caller owns both structs. `fhe` is required;
+    // `replay` may be null (all defaults). configure_device builds the immutable
+    // configs through transient local builders and installs them — no config
+    // state is held before this call, and nothing is installed on failure.
+    if (fhe == nullptr)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    // The target is baked into compiler().init() at bring-up and never
-    // re-read; fail fast instead of silently ignoring the change. The gate is
-    // serialized against init so a set racing bring-up cannot slip through.
-    if (!haze::backend().try_set_target(target)) {
-        haze::record_internal_error(haze::HazeInternalError::ConfigLocked,
-                                    "hazeSetTarget: backend already initialized");
-        return set_error(HAZE_ERROR_CONFIGERR);
-    }
-    return HAZE_SUCCESS;
-}
-
-extern "C" hazeError_t hazeSetProgramDirectory(const char *dir) noexcept {
-    return set_internal_result(haze::config().set_program_directory(dir));
-}
-
-extern "C" hazeError_t hazeSetMontgomery(int enable) noexcept {
-    haze::config().set_montgomery(enable != 0);
-    return HAZE_SUCCESS;
-}
-
-extern "C" hazeError_t hazeSetBitReversal(int enable) noexcept {
-    haze::config().set_bit_reversal(enable != 0);
-    return HAZE_SUCCESS;
-}
-
-extern "C" hazeError_t hazeSetReducedNoise(int enable) noexcept {
-    haze::config().set_reduced_noise(enable != 0);
-    return HAZE_SUCCESS;
+    return set_internal_result(haze::configure_device(*fhe, replay));
 }

--- a/src/common/errors.cpp
+++ b/src/common/errors.cpp
@@ -26,6 +26,7 @@ hazeError_t to_public_error(HazeInternalError err) noexcept {
         return HAZE_ERROR_INVALID_VALUE;
     case HazeInternalError::NotConfigured:
     case HazeInternalError::ConfigLocked:
+    case HazeInternalError::DuplicateModulus:
         return HAZE_ERROR_CONFIGERR;
     case HazeInternalError::UnknownAddress:
         return HAZE_ERROR_UNKNOWN_ADDRESS;
@@ -69,6 +70,8 @@ const char *internal_error_name(HazeInternalError err) noexcept {
         return "not configured";
     case HazeInternalError::ConfigLocked:
         return "configuration locked (already configured / in use); conflicting re-set rejected";
+    case HazeInternalError::DuplicateModulus:
+        return "duplicate ciphertext modulus; each configured modulus must be distinct";
     case HazeInternalError::UnknownAddress:
         return "unknown address";
     case HazeInternalError::NoData:

--- a/src/common/errors.hpp
+++ b/src/common/errors.hpp
@@ -34,6 +34,7 @@ enum class HazeInternalError : std::uint8_t {
     InvalidArgument,            // params struct field violates the API contract
     NotConfigured,              // ring_dim / modulus not set when required
     ConfigLocked,               // configuration frozen; conflicting re-set rejected
+    DuplicateModulus,           // FheParams::build(): two ciphertext moduli are equal
     UnknownAddress,             // DevAddr not in the allocator's table
     NoData,                     // address allocated but no H2D / compute output present
     PolySizeMismatch,           // size != configured polynomial size (ring_dim * 8)

--- a/src/common/thread_safety.hpp
+++ b/src/common/thread_safety.hpp
@@ -12,37 +12,37 @@
 // from the Product.
 #pragma once
 
-// Clang thread-safety analysis annotations. Compile-time, zero runtime cost.
-// Enabled by passing -Wthread-safety to clang; expand to nothing on other
-// compilers. Documented at:
-// https://clang.llvm.org/docs/ThreadSafetyAnalysis.html
+// Clang thread-safety analysis annotations: compile-time, zero runtime cost,
+// enabled by -Wthread-safety and expanding to nothing on other compilers
+// (https://clang.llvm.org/docs/ThreadSafetyAnalysis.html).
 //
-// Usage in HAZE:
-//   - Mark mutex members with HAZE_CAPABILITY("mutex").
-//   - Mark fields the mutex protects with HAZE_GUARDED_BY(mutex_).
-//   - Mark methods that require the caller to hold the lock with
-//     HAZE_REQUIRES(mutex_) — typically the *_locked variants.
-//   - Mark methods that take the lock themselves (and so must not be
-//     called with the lock already held) with HAZE_EXCLUDES(mutex_).
-//   - Mark RAII lock-holders with HAZE_SCOPED_CAPABILITY on the class,
-//     HAZE_ACQUIRE(mutex) on the constructor, HAZE_RELEASE() on the
-//     destructor.
-//   - Mark accessor methods that hand out a reference to the underlying
-//     capability with HAZE_RETURN_CAPABILITY(field).
+// Usage: HAZE_CAPABILITY marks a mutex, HAZE_GUARDED_BY the fields it protects,
+// HAZE_REQUIRES(mutex_) methods the caller must hold the lock for (the *_locked
+// variants), HAZE_EXCLUDES(mutex_) methods that take it themselves (so must not be
+// called holding it); HAZE_SCOPED_CAPABILITY + HAZE_ACQUIRE/HAZE_RELEASE annotate
+// RAII lock-holders and HAZE_RETURN_CAPABILITY accessors returning the capability.
 //
-// Lock order (canonical statement — other files reference this one).
-// HAZE's mutexes form a DAG; acquire only along its edges:
+// Lock order (canonical statement — other files reference this one); HAZE's
+// mutexes form a DAG, acquire only along its edges:
 //
-//   EpochState::mutex_           -> { Config::mutex_, DeviceAllocator::mutex_ }
-//   Config::mutex_               -> DeviceAllocator::mutex_
-//   CompilerBackend::init_mutex_ -> Config::mutex_
+//   EpochState::mutex_ -> DeviceAllocator::mutex_
 //
-// The allocator is a leaf: allocator code must not call into any other
-// component while holding its lock; TSAN is the runtime backstop.
+// Config carries no lock. The FHE params and replay config are immutable values
+// built by the single explicit hazeConfigureDevice() (from caller-owned structs,
+// via transient local builders) and installed into DeviceState; only the control
+// plane (hazeConfigureDevice, hazeDeviceReset) writes them. The contract, like
+// CUDA's device setup, is that the control plane runs single-threaded and is not
+// concurrent with compute: configure happens before the first compute, and
+// hazeDeviceReset is not called while compute is in flight. Under that contract
+// the compute path only ever READS the frozen config — never finalizes, never
+// mutates — so it needs no lock or atomics (CompilerBackend::init_mutex_'s
+// acquire/release at bring-up orders the freeze before every compute read).
+// init_mutex_ serializes bring-up but acquires no other lock. The allocator is a
+// leaf: allocator code must not call into any other component while holding its
+// lock; TSAN is the runtime backstop.
 
-// Clang's thread-safety attributes are exposed as GNU-style
-// __attribute__((...)), not C++11 [[clang::...]]. The macro names
-// here mirror the spellings shown in the clang TSA documentation.
+// Clang's thread-safety attributes are GNU-style __attribute__((...)), not C++11
+// [[clang::...]]; the macro names mirror the clang TSA documentation spellings.
 #ifdef __clang__
 #define HAZE_CAPABILITY(s) __attribute__((capability(s)))
 #define HAZE_SCOPED_CAPABILITY __attribute__((scoped_lockable))
@@ -67,11 +67,9 @@
 
 namespace haze {
 
-// Thin wrapper around std::mutex annotated as a clang TSA capability.
-// libstdc++'s std::mutex carries no annotations, so without this
-// wrapper the TSA attributes cannot identify the underlying mutex as
-// the capability they protect. Used by EpochState::mutex_ and
-// DeviceAllocator::mutex_.
+// Thin std::mutex wrapper annotated as a clang TSA capability, because libstdc++'s
+// std::mutex carries no annotations for TSA to identify; used by EpochState::mutex_
+// and DeviceAllocator::mutex_.
 class HAZE_CAPABILITY("mutex") HazeMutex {
   public:
     HazeMutex() = default;
@@ -85,11 +83,9 @@ class HAZE_CAPABILITY("mutex") HazeMutex {
     std::mutex impl_;
 };
 
-// RAII scoped lock guard for HazeMutex, equivalent to std::lock_guard
-// but with TSA annotations propagated through HazeMutex's lock/unlock.
-// libstdc++'s std::lock_guard does not carry capability annotations;
-// without this wrapper TSA cannot tell that `std::lock_guard lock(m)`
-// holds the capability for the rest of the scope.
+// RAII scoped lock guard for HazeMutex, like std::lock_guard but propagating TSA
+// annotations through HazeMutex's lock/unlock, which libstdc++'s std::lock_guard
+// lacks so TSA cannot tell it holds the capability for the scope.
 class HAZE_SCOPED_CAPABILITY HazeLockGuard {
   public:
     explicit HazeLockGuard(HazeMutex &m) HAZE_ACQUIRE(m) : mutex_(m) { mutex_.lock(); }

--- a/src/core/allocator.cpp
+++ b/src/core/allocator.cpp
@@ -50,7 +50,7 @@ size_t DeviceAllocator::polynomial_size() const noexcept {
 
 std::expected<void, HazeInternalError>
 DeviceAllocator::validate_poly_size_locked(size_t bytes) const noexcept {
-    // Polynomial size must be configured (via Config::set_ring_dimension)
+    // Polynomial size must be configured (via hazeConfigureDevice)
     // before any allocation. HAZE's device space is FHETCH-addressable
     // storage — without a known polynomial size we cannot serve it.
     if (poly_bytes_ == 0) {
@@ -59,11 +59,8 @@ DeviceAllocator::validate_poly_size_locked(size_t bytes) const noexcept {
         return std::unexpected(HazeInternalError::NotConfigured);
     }
 
-    // Strict single-size contract: every allocation is one polynomial.
-    // Non-polynomial scratch is not a HAZE concern (use host memory or
-    // a future off-device allocator). Mismatches surface here so the
-    // consumer is forced to either use the right size or a different
-    // allocator.
+    // Strict single-size contract: every allocation is one polynomial (non-poly
+    // scratch uses host memory), so a size mismatch is rejected here.
     if (bytes != poly_bytes_) {
         record_internal_error(HazeInternalError::PolySizeMismatch,
                               "DeviceAllocator::allocate: size != polynomial bytes");
@@ -94,10 +91,9 @@ void DeviceAllocator::evict_shadow(DevAddr addr) noexcept {
 }
 
 std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate_one_locked() noexcept {
-    // Recycle from the free list when available. Both the shadow_data_ entry
-    // and alloc_set_ membership were dropped at hazeFree time, so a pooled
-    // DevAddr must NOT currently be live; if it is, pool_free_ and alloc_set_
-    // have desynced (a double-push or a live addr wrongly pooled).
+    // Recycle from the free list; a pooled DevAddr must not be live (its shadow and
+    // alloc_set_ membership were dropped at hazeFree), so a live one means
+    // pool_free_/alloc_set_ desynced.
     if (!pool_free_.empty()) {
         DevAddr addr = pool_free_.back();
         pool_free_.pop_back();
@@ -106,14 +102,12 @@ std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate_one_locked()
                                   "DeviceAllocator::allocate (recycled addr already live)");
             return std::unexpected(HazeInternalError::PoolMapDesync);
         }
-        // Re-establish liveness for the recycled addr.
         alloc_set_.insert(addr);
         return addr;
     }
 
-    // Fresh allocation: bump the address counter by exactly poly_bytes_.
-    // No shadow bytes are allocated. shadow_data_ stays empty for this
-    // DevAddr until the first H2D / memset / D2D / update_shadow.
+    // Fresh allocation: bump next_addr_ by poly_bytes_; no shadow bytes until the
+    // first H2D/memset/D2D/update_shadow.
     DevAddr addr{next_addr_};
     next_addr_ += poly_bytes_;
     alloc_set_.insert(addr);
@@ -122,14 +116,12 @@ std::expected<DevAddr, HazeInternalError> DeviceAllocator::allocate_one_locked()
 
 std::expected<void, HazeInternalError> DeviceAllocator::free_one_locked(DevAddr addr) noexcept {
     if (!alloc_set_.contains(addr)) {
-        // Not live: an unknown address or a double free. Reject rather than
-        // re-pool it — re-pooling would later hand the same DevAddr out to two
-        // live allocations (aliasing).
+        // Not live (unknown addr or double free): reject rather than re-pool, which
+        // would later alias the same DevAddr across two live allocations.
         record_internal_error(HazeInternalError::UnknownAddress, "DeviceAllocator::free");
         return std::unexpected(HazeInternalError::UnknownAddress);
     }
-    // Lifetime ends here: drop liveness and the shadow bytes, and pool the
-    // DevAddr for the next allocate() to recycle.
+    // Lifetime ends: drop liveness and shadow bytes, pool the DevAddr for recycling.
     alloc_set_.erase(addr);
     shadow_data_.erase(addr);
     pool_free_.push_back(addr);
@@ -160,9 +152,8 @@ DeviceAllocator::allocate_many(size_t count, size_t bytes) noexcept {
     for (size_t i = 0; i < count; ++i) {
         auto addr = allocate_one_locked();
         if (!addr) {
-            // Roll back everything reserved in THIS call so nothing leaks and
-            // no partially-populated result escapes. Each `done` was just
-            // reserved, so free_one_locked cannot fail on it.
+            // Roll back everything reserved in this call so nothing leaks; each was
+            // just reserved, so free_one_locked cannot fail.
             for (DevAddr done : out) {
                 [[maybe_unused]] const auto rolled_back = free_one_locked(done);
             }
@@ -203,11 +194,8 @@ DeviceAllocator::free_many(std::span<const DevAddr> addrs) noexcept {
 
 std::expected<std::vector<uint64_t>, HazeInternalError>
 DeviceAllocator::extract_polynomial_components(DevAddr addr, uint64_t ring_dim) noexcept {
-    if (ring_dim == 0) {
-        record_internal_error(HazeInternalError::NotConfigured,
-                              "DeviceAllocator::extract_polynomial_components: ring_dim == 0");
-        return std::unexpected(HazeInternalError::NotConfigured);
-    }
+    // ring_dim is validated non-zero at FheParams::build(); callers only reach
+    // here post-finalize, so no ring_dim==0 guard is needed.
     HazeLockGuard lock(mutex_);
     if (!alloc_set_.contains(addr)) {
         record_internal_error(HazeInternalError::UnknownAddress,
@@ -222,9 +210,8 @@ DeviceAllocator::extract_polynomial_components(DevAddr addr, uint64_t ring_dim) 
     }
     auto data_it = shadow_data_.find(addr);
     if (data_it == shadow_data_.end()) {
-        // Address allocated but never written. epoch::lookup_or_create_locked
-        // translates this to SourceUnavailable — compute / D2D on an
-        // uninitialized buffer is a contract violation.
+        // Allocated but never written; lookup_or_create_locked surfaces this as
+        // SourceUnavailable (compute/D2D on an uninitialized buffer is a violation).
         record_internal_error(HazeInternalError::NoData,
                               "DeviceAllocator::extract_polynomial_components");
         return std::unexpected(HazeInternalError::NoData);
@@ -236,20 +223,15 @@ DeviceAllocator::extract_polynomial_components(DevAddr addr, uint64_t ring_dim) 
                               "DeviceAllocator::extract_polynomial_components");
         return std::unexpected(HazeInternalError::ShadowSizeMismatch);
     }
-    // Detach the shadow's storage so the caller's from_data() can move
-    // it straight into a Polynomial; frees the HAZE-side entry
-    // mid-program, before hazeFree.
+    // Detach the storage so the caller can move it into a Polynomial, freeing the
+    // HAZE-side entry mid-program.
     auto node = shadow_data_.extract(data_it);
     return std::move(node.mapped());
 }
 
 std::expected<std::vector<uint64_t>, HazeInternalError>
 DeviceAllocator::read_polynomial_components(DevAddr addr, uint64_t ring_dim) const noexcept {
-    if (ring_dim == 0) {
-        record_internal_error(HazeInternalError::NotConfigured,
-                              "DeviceAllocator::read_polynomial_components: ring_dim == 0");
-        return std::unexpected(HazeInternalError::NotConfigured);
-    }
+    // ring_dim is validated non-zero at FheParams::build() (see extract).
     HazeLockGuard lock(mutex_);
     if (!alloc_set_.contains(addr)) {
         record_internal_error(HazeInternalError::UnknownAddress,
@@ -288,9 +270,8 @@ std::expected<void, HazeInternalError> DeviceAllocator::copy_h2d(DevAddr dst, co
     // Zero-byte copy: success no-op, no fabricated shadow entry.
     if (count == 0)
         return {};
-    // Lazy-create or overwrite the shadow entry. Sized to the full
-    // allocation so partial writes leave the tail at zero (matches
-    // prior eager-zero semantics for the unwritten tail).
+    // Lazy-create or overwrite the shadow entry, sized to the full allocation so a
+    // partial write leaves the tail zeroed.
     auto &shadow = shadow_data_[dst];
     const size_t want_elems = poly_bytes_ / sizeof(uint64_t);
     if (shadow.size() != want_elems) {
@@ -332,8 +313,8 @@ std::expected<void, HazeInternalError> DeviceAllocator::copy_to_host(void *dst, 
         return {}; // zero-byte read: success no-op, no shadow required
     auto data_it = shadow_data_.find(src);
     if (data_it == shadow_data_.end()) {
-        // No materialized bytes (never written, or a computed result not tagged
-        // + flushed): an error rather than the old silent zero read.
+        // No materialized bytes (never written, or a computed result not tagged +
+        // flushed): an error rather than a silent zero read.
         record_internal_error(
             HazeInternalError::OutputNotFlushed,
             "DeviceAllocator::copy_to_host: no shadow bytes (tag output + flush?)");
@@ -370,10 +351,8 @@ DeviceAllocator::pointer_attributes(hazePointerAttributes *attrs, const void *pt
     if (attrs == nullptr)
         return std::unexpected(HazeInternalError::InvalidArgument);
     *attrs = {};
-    // Resolve classification under one locked snapshot, then fill the
-    // attribute fields outside the lock. Snapshotting closes the window
-    // where a concurrent free() / unregister between membership check
-    // and attribute write could flip the answer.
+    // Resolve classification under one locked snapshot, then fill fields outside the
+    // lock, closing the window where a concurrent free()/unregister could flip it.
     enum class Classification : uint8_t { Unknown, Device, Host };
     auto classification = Classification::Unknown;
     if (ptr != nullptr) {
@@ -387,10 +366,9 @@ DeviceAllocator::pointer_attributes(hazePointerAttributes *attrs, const void *pt
     switch (classification) {
     case Classification::Device:
         attrs->type = HAZE_MEMORY_TYPE_DEVICE;
-        // hazePointerAttributes mirrors cudaPointerAttributes: the
-        // devicePointer / hostPointer fields are non-const void*, but
-        // the input here is const void*. The cast is contained to the
-        // two assignments at the C-ABI boundary.
+        // hazePointerAttributes mirrors cudaPointerAttributes: its devicePointer/
+        // hostPointer are non-const void*, so const_cast the const input at this
+        // C-ABI boundary.
         attrs->devicePointer =
             const_cast<void *>(ptr); // NOLINT(cppcoreguidelines-pro-type-const-cast)
         break;

--- a/src/core/allocator.hpp
+++ b/src/core/allocator.hpp
@@ -30,46 +30,32 @@ namespace haze {
 class DeviceState;
 
 namespace test {
-// Forward declaration for the test peer (Attorney pattern); definition
-// lives under test/ and is never linked into production.
+// Test peer (Attorney pattern); defined under test/, never linked into production.
 class AllocatorTestAccess;
 } // namespace test
 
-// Per-DevAddr metadata. Pure liveness + pool-recycling info — no
-// payload. Component storage lives in DeviceAllocator::shadow_data_,
-// which is sparse (an entry exists only for addresses that currently
-// hold user-written or materialized uint64_t components). Most
-// addresses in a typical FHE program are intermediate compute results
-// that flow entirely inside fhetch::Polynomial storage and never need
-// a HAZE shadow.
-// Single-size device allocator with sparse-map shadow storage.
+// Single-size device allocator with sparse-map shadow storage: every allocation
+// is one single-residue polynomial of poly_bytes_ (N × uint64_t); non-polynomial
+// scratch (pointer arrays, twiddle tables, kernel-arg packs) belongs in host
+// memory or hazeHostAlloc, not here.
 //
-// HAZE's device address space is FHETCH-addressable storage — every
-// allocation represents one single-residue polynomial of N × uint64_t
-// bytes. Non-polynomial scratch (pointer arrays, twiddle tables, kernel
-// arg packs, etc.) is not a HAZE concern; consumers should use ordinary
-// host allocations (or `hazeHostAlloc` when page-aligned host memory
-// is needed).
+// Storage model: alloc_set_ tracks live DevAddrs (size implicit, == poly_bytes_);
+// shadow_data_ is a sparse DevAddr -> vector<uint64_t> map holding components only
+// for addresses currently carrying user-written or materialized data (most
+// intermediates live entirely in fhetch::Polynomial storage and need no shadow).
+// An entry-less read returns OutputNotFlushed (D2H) or NoData (compute extract);
+// H2D/memset/update_shadow create it; compute extract, a compute-result/D2D re-bind
+// (via evict_shadow), and hazeFree evict it. Byte-granular C-ABI access
+// reinterpret_casts the over-aligned vector<uint64_t> storage to uint8_t*.
 //
-// Storage model. Live DevAddrs are tracked as set membership in
-// `alloc_set_` — allocation size is implicit (always `poly_bytes_`).
-// Component payloads live in a separate sparse map `shadow_data_`
-// keyed by DevAddr, with each entry a `vector<uint64_t>` sized to the
-// allocation. An entry exists only when the address currently carries
-// user-written or materialized components; addresses without an entry
-// hold zero shadow memory. Reads of an entry-less address return
-// OutputNotFlushed (D2H) or NoData (compute extract). Writes (H2D /
-// memset / update_shadow) create or overwrite the entry; consumption by
-// compute (extract_polynomial_components), a compute-result / D2D
-// re-bind (EpochState::store_compute_result_locked via evict_shadow),
-// and hazeFree evict it. Byte-granular
-// reads/writes from the C ABI go through `reinterpret_cast<uint8_t*>`
-// over the vector's storage — well-defined; `vector<uint64_t>::data()`
-// is over-aligned for `uint8_t*`.
+// Contract: Config::set_ring_dimension before the first allocate (poly size =
+// N × 8 bytes); every allocation must equal that size exactly (else
+// PolySizeMismatch); hazeMalloc reserves a DevAddr without zero-init or byte
+// storage, and the first write creates the shadow entry.
 //
 // Contract:
-//  - `Config::set_ring_dimension` must be called before the first
-//    `allocate`. The polynomial size is derived from N (= N × 8 bytes).
+//  - `hazeConfigureDevice` must be called before the first `allocate`.
+//    The polynomial size is derived from N (= N × 8 bytes).
 //  - Every allocation must equal that polynomial size exactly. Any
 //    other size returns PolySizeMismatch.
 //  - `hazeMalloc` reserves a DevAddr but does *not* zero-init or
@@ -82,9 +68,8 @@ class AllocatorTestAccess;
 // order and would deadlock.
 class DeviceAllocator {
   public:
-    // Configure the pool's polynomial size. Calling with a size different
-    // from the current configuration drains the pool. Calling with size 0
-    // disables pooling entirely.
+    // Set the pool's polynomial size; a size change drains the pool, size 0
+    // disables pooling.
     void set_polynomial_size(size_t bytes) noexcept HAZE_EXCLUDES(mutex_);
     size_t polynomial_size() const noexcept HAZE_EXCLUDES(mutex_);
 
@@ -102,52 +87,38 @@ class DeviceAllocator {
     // a pre-flush D2H after a compute/D2D re-bind.
     void evict_shadow(DevAddr addr) noexcept HAZE_EXCLUDES(mutex_);
 
-    // Batched allocate/free for an MRP group: the mutex is taken ONCE for
-    // all `count` residues (not once per residue). Both reuse the single-poly
-    // logic under the lock.
-    //
-    // allocate_many reserves `count` polynomials of `bytes` each (each must
-    // equal the configured polynomial size, same contract as allocate). On
-    // any per-residue failure the polys already reserved in this call are
-    // freed and the error returned, so nothing leaks; on success the result
-    // holds exactly `count` addresses. count == 0 yields an empty result.
+    // Batched allocate for an MRP group under a single lock acquisition (not once
+    // per residue); each poly must equal the configured size, a partial failure
+    // rolls back everything reserved here, and count == 0 yields an empty result.
     std::expected<std::vector<DevAddr>, HazeInternalError> allocate_many(size_t count,
                                                                          size_t bytes) noexcept
         HAZE_EXCLUDES(mutex_);
 
-    // free_many attempts every address; zero-valued (null) entries are
-    // skipped (hazeFree(nullptr) semantics). It frees all of them and returns
-    // the first error encountered, if any.
+    // Frees every address (null entries skipped per hazeFree(nullptr)) and returns
+    // the first error encountered.
     std::expected<void, HazeInternalError> free_many(std::span<const DevAddr> addrs) noexcept
         HAZE_EXCLUDES(mutex_);
 
-    // Bulk operations on a single allocation. Each path validates count
-    // against the allocation size.
+    // Bulk operations on one allocation; each validates count against the size.
     std::expected<void, HazeInternalError> copy_h2d(DevAddr dst, const void *src,
                                                     size_t count) noexcept HAZE_EXCLUDES(mutex_);
     std::expected<void, HazeInternalError> memset(DevAddr addr, int value, size_t count) noexcept
         HAZE_EXCLUDES(mutex_);
 
-    // Snapshot the shadow buffer as a vector of `ring_dim` 64-bit
-    // coefficients (uint64_t words).
-    // Used by EpochState::lookup_or_create_locked when promoting fresh
-    // shadow data to a FHETCH input polynomial. Returns NoData if the
-    // address has no shadow entry; the caller surfaces this as
-    // SourceUnavailable. **Evicts the shadow entry on success** — the
-    // caller now owns the bytes via fhetch's Polynomial storage; the
-    // HAZE-side shadow is freed mid-program. Non-const for that reason.
+    // Snapshot the shadow buffer as ring_dim uint64_t coefficients for promotion to
+    // a FHETCH input; returns NoData (surfaced as SourceUnavailable) when the address
+    // has no shadow, and evicts the entry on success (hence non-const).
     HAZE_API std::expected<std::vector<uint64_t>, HazeInternalError>
     extract_polynomial_components(DevAddr addr, uint64_t ring_dim) noexcept HAZE_EXCLUDES(mutex_);
 
-    // Non-evicting copy of the shadow components. Used by the H2D eager-tag
-    // path that must leave shadow_data_ intact (a subsequent compute-free
-    // D2H still reads the original H2D bytes).
+    // Non-evicting copy of the shadow components, for the H2D eager-tag path that
+    // must leave shadow_data_ intact for a later compute-free D2H.
     HAZE_API std::expected<std::vector<uint64_t>, HazeInternalError>
     read_polynomial_components(DevAddr addr, uint64_t ring_dim) const noexcept
         HAZE_EXCLUDES(mutex_);
 
-    // Read shadow bytes into a host buffer. Caller is responsible for
-    // any compute materialization; this only touches the shadow buffer.
+    // Read shadow bytes into a host buffer (shadow only; caller handles any
+    // compute materialization).
     std::expected<void, HazeInternalError> copy_to_host(void *dst, DevAddr src,
                                                         size_t count) const noexcept
         HAZE_EXCLUDES(mutex_);
@@ -158,10 +129,9 @@ class DeviceAllocator {
                                                          std::vector<uint64_t> &&values) noexcept
         HAZE_EXCLUDES(mutex_);
 
-    // Pointer-attribute query. Reports DEVICE for hazeMalloc-allocated
-    // pointers, HOST for hazeHostAlloc-allocated pointers, UNREGISTERED
-    // for any other pointer (matches cudaPointerGetAttributes from
-    // CUDA 11 onward).
+    // Pointer-attribute query: DEVICE for hazeMalloc pointers, HOST for
+    // hazeHostAlloc pointers, UNREGISTERED otherwise (matches
+    // cudaPointerGetAttributes from CUDA 11 onward).
     std::expected<void, HazeInternalError> pointer_attributes(hazePointerAttributes *attrs,
                                                               const void *ptr) const noexcept
         HAZE_EXCLUDES(mutex_);
@@ -183,10 +153,9 @@ class DeviceAllocator {
 
     friend class test::AllocatorTestAccess;
 
-    // Helpers (caller holds mutex_). validate_poly_size_locked enforces the
-    // ring-dim-set + single-size contract; allocate_one_locked and
-    // free_one_locked are the single-poly bodies shared by the scalar and
-    // batched entry points so the logic lives in one place.
+    // Helpers (caller holds mutex_): validate_poly_size_locked enforces the
+    // ring-dim-set + single-size contract; allocate_one_locked / free_one_locked
+    // are the single-poly bodies shared by the scalar and batched entry points.
     void clear_pool_locked() noexcept HAZE_REQUIRES(mutex_);
     std::expected<void, HazeInternalError> validate_poly_size_locked(size_t bytes) const noexcept
         HAZE_REQUIRES(mutex_);
@@ -196,17 +165,15 @@ class DeviceAllocator {
 
     // mutex_ protects all state below. Lock order across HAZE (full DAG
     // in common/thread_safety.hpp): this mutex is a LEAF — callers
-    // already holding EpochState::mutex_ or Config::mutex_ may re-enter
-    // here, and allocator-side code must NOT call into any other
-    // component while holding this lock.
+    // already holding EpochState::mutex_ may re-enter here (config sets the
+    // polynomial size during single-threaded setup), and allocator-side code
+    // must NOT call into any other component while holding this lock.
     mutable HazeMutex mutex_;
-    // Live DevAddrs. Set membership covers the lifetime of the
-    // hazeMalloc/hazeFree contract; allocation size is implicit
-    // (== poly_bytes_) under the single-size invariant.
+    // Live DevAddrs; size is implicit (== poly_bytes_) under the single-size invariant.
     std::unordered_set<DevAddr> alloc_set_ HAZE_GUARDED_BY(mutex_);
-    // Sparse uint64_t component storage, vector sized to
-    // `poly_bytes_ / sizeof(uint64_t)`. Created by H2D/memset/update_shadow,
-    // evicted by extract / evict_shadow / hazeFree / set_polynomial_size / reset.
+    // Sparse uint64_t component storage (vector sized poly_bytes_/sizeof(uint64_t));
+    // created by H2D/memset/update_shadow, evicted by
+    // extract/evict_shadow/hazeFree/set_polynomial_size/reset.
     std::unordered_map<DevAddr, std::vector<uint64_t>> shadow_data_ HAZE_GUARDED_BY(mutex_);
     std::vector<DevAddr>
         pool_free_ HAZE_GUARDED_BY(mutex_); // free list for poly_bytes_-sized allocations

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -41,11 +41,22 @@ bool CompilerBackend::ensure_initialized() noexcept {
     if (initialized_.load(std::memory_order_relaxed))
         return true;
 
+    // Configuration must be finalized by an explicit hazeConfigureDevice()
+    // first; bring-up only READS the frozen config — it never finalizes, so the
+    // compute path never mutates config state (hence needs no lock for it).
+    if (!config_finalized()) {
+        record_internal_error(HazeInternalError::NotConfigured,
+                              "CompilerBackend::ensure_initialized: hazeConfigureDevice() "
+                              "not called before first compute");
+        return false;
+    }
+    const ReplayConfig &rc = replay_config();
+
     // The local simulator runs ordinary-form traces only; reject the
     // Montgomery / bit-reversal toggles here so the error names the real cause.
-    const bool montgomery = config().montgomery();
-    const bool bit_reversal = config().bit_reversal();
-    if ((montgomery || bit_reversal) && config().target() == kLocalTarget) {
+    const bool montgomery = rc.montgomery();
+    const bool bit_reversal = rc.bit_reversal();
+    if ((montgomery || bit_reversal) && rc.target_is_local()) {
         record_internal_error(HazeInternalError::UnsupportedDataFormat,
                               "CompilerBackend::ensure_initialized (montgomery/bit_reversal "
                               "require a transport target such as FUNC_SIM)");
@@ -55,16 +66,15 @@ bool CompilerBackend::ensure_initialized() noexcept {
     // niobium::compiler() can throw (bad_alloc, config errors); catch here
     // so a thrown init becomes BackendInitFailed, not a process termination.
     try {
-        const std::string program_name = config().program_name();
-        const std::string program_version = config().program_version();
-        const std::string program_description = config().program_description();
-        const std::string target = config().target();
+        const std::string &program_name = rc.program_name();
+        const std::string &program_version = rc.program_version();
+        const std::string &program_description = rc.program_description();
 
         // Synthesize a minimal argv to pass --target= (and the Montgomery /
         // bit-reversal flags) to compiler().init() — no setters are exposed.
         // init copies argv during the call, so function-local storage is safe.
         std::string prog_storage = program_name;
-        std::string target_arg_storage = "--target=" + target;
+        std::string target_arg_storage = "--target=" + rc.target();
         std::string montgomery_arg_storage = "--montgomery";
         std::string bitrev_arg_storage = "--bit_reversal";
         std::string no_ring_check_storage = "--no-ring-dim-check";
@@ -92,8 +102,8 @@ bool CompilerBackend::ensure_initialized() noexcept {
         // the project (.fhetch + inputs + templates + cryptocontext) lands
         // here instead of cwd/<program_name>. Must precede the first compute
         // op so it's in effect when stop_recording() writes the trace.
-        if (config().has_program_directory())
-            niobium::compiler().set_program_directory(config().program_directory());
+        if (rc.has_program_directory())
+            niobium::compiler().set_program_directory(rc.program_directory());
         // haze emits IR via fhetch::sr_* directly, so the OpenFHE-side CPROBE
         // capture path is dead weight; mute it globally. Distinct from
         // openfhe_cprobe_pause_recording, which would also silence sr_*.
@@ -133,15 +143,6 @@ bool CompilerBackend::start_recording() noexcept {
                               "CompilerBackend::start_recording");
         return false;
     }
-}
-
-bool CompilerBackend::try_set_target(const char *target) noexcept {
-    // init_mutex_ serializes against ensure_initialized, closing the window
-    // where a set racing first-compute bring-up would be baked over.
-    HazeLockGuard lock(init_mutex_);
-    if (initialized_.load(std::memory_order_relaxed))
-        return false;
-    return config().set_target(target).has_value();
 }
 
 bool CompilerBackend::stop_recording() noexcept {

--- a/src/core/backend.hpp
+++ b/src/core/backend.hpp
@@ -18,20 +18,16 @@
 
 namespace haze {
 
-// Control surface for the niobium::compiler() singleton. HAZE records
-// FHETCH IR via fhetch::sr_*, fhetch::tag_input, and fhetch::result;
-// those route to the linked fhetch "dummy" compiler implicitly. CompilerBackend wraps
-// only the *control* operations: init, recording lifecycle, replay.
-//
+// CompilerBackend wraps only the *control* operations (init, recording
+// lifecycle, replay) of the niobium::compiler() singleton; IR (fhetch::sr_*,
+// tag_input, result) routes to the linked compiler directly.
 class DeviceState;
 
-// Single concrete class, no virtual dispatch. Backend swap (e.g. to the
-// niobium-fhetch dummy compiler when stable) happens at link time:
-// backend.cpp calls into whichever library supplies the
-// niobium::compiler() symbol.
+// Single concrete class, no virtual dispatch; the backend swaps at link time
+// via whichever library supplies the niobium::compiler() symbol.
 class CompilerBackend {
   public:
-    // Idempotent, concurrency-safe compiler init from Config metadata;
+    // Idempotent, concurrency-safe compiler init from the replay config;
     // false on throw or unsupported config, and the compute preludes'
     // require_recording_locked gate then surfaces the failure at the ABI.
     [[nodiscard]] bool ensure_initialized() noexcept;
@@ -46,11 +42,6 @@ class CompilerBackend {
     // Begin a new recording (after init or after stop_recording).
     [[nodiscard]] static bool start_recording() noexcept;
 
-    // Reject a target change once init has baked the target in; otherwise
-    // store it. Serialized against ensure_initialized via init_mutex_ so a
-    // set racing first-compute bring-up cannot be silently ignored.
-    [[nodiscard]] bool try_set_target(const char *target) noexcept;
-
     // Finalize the recording via upstream stop() — writes the .fhetch
     // trace AND fhetch_replay.json (upstream stop_epoch() writes only the
     // trace); replay() must be invoked separately.
@@ -64,14 +55,13 @@ class CompilerBackend {
     // so live queries (bridge program-dir lookup) see pre-reset state.
     static void reset_compiler() noexcept;
 
-    // Trigger replay of the most recently recorded epoch. Behaviour
-    // depends on the configured target — see haze.h's hazeSetTarget
-    // doc for the two-tier table (local in-process simulator vs HTTP
-    // transport). Returns true on success.
+    // Replay the most recently recorded epoch, dispatched per the configured
+    // target (see haze.h's hazeConfigureDevice / hazeReplayConfig::target doc);
+    // true on success.
     static bool replay() noexcept;
 
-    // Drop cached state so the next call to ensure_initialized() starts
-    // fresh. Mainly for tests via hazeDeviceReset().
+    // Drop cached state so the next ensure_initialized() starts fresh; mainly for
+    // tests via hazeDeviceReset().
     void reset() noexcept;
 
     CompilerBackend(const CompilerBackend &) = delete;
@@ -81,12 +71,18 @@ class CompilerBackend {
     friend class DeviceState;
     CompilerBackend() = default;
 
-    // Atomic flag enables a lock-free fast path on the hot
-    // ensure_initialized check. init_mutex_ serializes the first-call
-    // path so concurrent first callers don't all run init.
+    // Atomic flag drives the lock-free fast path; init_mutex_ serializes the
+    // first-call path so concurrent first callers don't all run init.
     std::atomic<bool> initialized_{false};
     HazeMutex init_mutex_;
 };
+
+// One-shot vendor-compiler bootstrap (argv from Config, program info, pinned
+// program dir) shared by first-compute bring-up and the replay bridge's pre-init.
+// Format flags are explicit parameters because vendor init LATCHES them (set-only
+// until reset), so callers pass a guard-approved snapshot; not idempotence-guarded
+// and may throw, so callers contain both.
+void bootstrap_compiler(bool montgomery, bool bit_reversal);
 
 // Defined in device_state.cpp (returns the DeviceState member).
 CompilerBackend &backend() noexcept;

--- a/src/core/basis_convert.cpp
+++ b/src/core/basis_convert.cpp
@@ -36,12 +36,13 @@ namespace {
 // FBC mode from engine config: reduced_noise selects the centered variant,
 // montgomery selects the 4-op (hardware SwitchModulus) center shape.
 fhetch::FbcVariant fbc_variant() noexcept {
-    return config().reduced_noise() ? fhetch::FbcVariant::ReducedNoise
-                                    : fhetch::FbcVariant::Standard;
+    return replay_config().reduced_noise() ? fhetch::FbcVariant::ReducedNoise
+                                           : fhetch::FbcVariant::Standard;
 }
 
 fhetch::FbcCenterShape fbc_center_shape() noexcept {
-    return config().montgomery() ? fhetch::FbcCenterShape::FourOp : fhetch::FbcCenterShape::ThreeOp;
+    return replay_config().montgomery() ? fhetch::FbcCenterShape::FourOp
+                                        : fhetch::FbcCenterShape::ThreeOp;
 }
 
 // Validation helpers; each returns InvalidArgument with a debug-log
@@ -230,10 +231,10 @@ std::expected<void, HazeInternalError> mod_up(void *const *dst, const void *cons
 
     // Open-code fhetch::dig_decomp so the per-digit lift follows the configured FBC
     // variant. dig_decomp hardcodes FbcVariant::ReducedNoise (centered), but mod_down and
-    // basis_convert thread config()'s fbc_variant(); mod_up must too, otherwise reduced_noise
-    // cannot toggle the keyswitch mod-up and a non-reduced-noise context gets a mismatched
-    // (always-centered) digit decomposition. The per-digit target is src_base ∪ p_base (Q∥P),
-    // exactly as dig_decomp builds it, and each lifted digit's base equals that target.
+    // basis_convert thread the replay config's fbc_variant(); mod_up must too, otherwise
+    // reduced_noise cannot toggle the keyswitch mod-up and a non-reduced-noise context gets a
+    // mismatched (always-centered) digit decomposition. The per-digit target is src_base ∪ p_base
+    // (Q∥P), exactly as dig_decomp builds it, and each lifted digit's base equals that target.
     const fhetch::MRP &x = *src_mrp;
     fhetch::ModuliBase target_base = x.base();
     target_base.insert(target_base.end(), p_base.begin(), p_base.end());

--- a/src/core/compute.hpp
+++ b/src/core/compute.hpp
@@ -41,7 +41,7 @@ std::expected<void, HazeInternalError> binary_pp_op(DevAddr dst, DevAddr src1, D
     EpochSession session;
     if (auto rec = epoch().require_recording_locked(); !rec)
         return rec;
-    const uint64_t q = config().modulus(mod_idx);
+    const uint64_t q = fhe_params().modulus(mod_idx);
     if (q == 0)
         return std::unexpected(HazeInternalError::InvalidArgument);
     auto p1 = epoch().lookup_or_create_locked(src1);
@@ -63,7 +63,7 @@ std::expected<void, HazeInternalError> binary_ps_op(DevAddr dst, DevAddr src, ui
     EpochSession session;
     if (auto rec = epoch().require_recording_locked(); !rec)
         return rec;
-    const uint64_t q = config().modulus(mod_idx);
+    const uint64_t q = fhe_params().modulus(mod_idx);
     if (q == 0)
         return std::unexpected(HazeInternalError::InvalidArgument);
     auto p = epoch().lookup_or_create_locked(src);
@@ -82,7 +82,7 @@ std::expected<void, HazeInternalError> unary_pq_op(DevAddr dst, DevAddr src, int
     EpochSession session;
     if (auto rec = epoch().require_recording_locked(); !rec)
         return rec;
-    const uint64_t q = config().modulus(mod_idx);
+    const uint64_t q = fhe_params().modulus(mod_idx);
     if (q == 0)
         return std::unexpected(HazeInternalError::InvalidArgument);
     auto p = epoch().lookup_or_create_locked(src);

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -13,16 +13,12 @@
 #include "core/config.hpp"
 
 #include "common/errors.hpp"
-#include "common/thread_safety.hpp"
-#include "core/allocator.hpp"
 #include "core/device.hpp"
 
+#include <cstddef>
 #include <cstdint>
-#include <cstdlib>
 #include <expected>
-#include <string>
-#include <utility>
-#include <vector>
+#include <haze/haze_types.h>
 
 namespace haze {
 
@@ -38,204 +34,58 @@ bool is_supported_ring_dim(uint64_t n) noexcept {
 
 } // namespace
 
-std::expected<void, HazeInternalError> Config::set_ring_dimension(uint64_t n) noexcept {
-    if (!is_supported_ring_dim(n))
+std::expected<FheParams, HazeInternalError> FheParams::create(const hazeFheParams &raw) noexcept {
+    // Struct well-formedness: a non-zero count with a null array would be
+    // dereferenced below.
+    if ((raw.moduli_count > 0 && raw.moduli == nullptr) ||
+        (raw.twiddle_count > 0 && raw.twiddle_generators == nullptr))
         return std::unexpected(HazeInternalError::InvalidArgument);
-    // Hold the Config lock across the allocator update so no observer
-    // ever sees (new ring_dim, old pool poly_bytes) or vice versa. Lock
-    // order is Config -> Allocator; the allocator never calls back into
-    // Config, so this direction cannot deadlock.
-    HazeLockGuard lock(mutex_);
-    if (configured_ && ring_dim_ != n) {
-        record_internal_error(HazeInternalError::ConfigLocked,
-                              "set_ring_dimension: configured; hazeDeviceReset to change");
-        return std::unexpected(HazeInternalError::ConfigLocked);
+    // Per-argument: ring_dim in the device envelope; modulus count within it.
+    if (!is_supported_ring_dim(raw.ring_dim))
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    if (raw.moduli_count > static_cast<size_t>(kMaxCiphertextModuli))
+        return std::unexpected(HazeInternalError::InvalidArgument);
+
+    FheParams p;
+    p.ring_dim_ = raw.ring_dim;
+    for (size_t i = 0; i < raw.moduli_count; ++i) {
+        const uint64_t qi = raw.moduli[i];
+        if (qi == 0) // per-argument: moduli non-zero
+            return std::unexpected(HazeInternalError::InvalidArgument);
+        for (size_t j = 0; j < i; ++j) // whole-config: moduli unique
+            if (raw.moduli[j] == qi) {
+                record_internal_error(HazeInternalError::DuplicateModulus,
+                                      "FheParams::create: duplicate modulus");
+                return std::unexpected(HazeInternalError::DuplicateModulus);
+            }
+        p.moduli_[i] = qi;
     }
-    // Live allocations bake in the polynomial size; changing it under them
-    // left stale-sized shadows (formerly a heap overread on D2H).
-    if (ring_dim_ != n && allocator().has_live_allocations()) {
-        record_internal_error(HazeInternalError::ConfigLocked,
-                              "set_ring_dimension: allocations live; free them or reset first");
-        return std::unexpected(HazeInternalError::ConfigLocked);
+    p.moduli_count_ = static_cast<int>(raw.moduli_count);
+    p.twiddle_generators_.assign(raw.twiddle_generators,
+                                 raw.twiddle_generators + raw.twiddle_count);
+    return p;
+}
+
+ReplayConfig ReplayConfig::create(const hazeReplayConfig *raw) noexcept {
+    ReplayConfig rc; // defaults; a NULL struct or NULL field keeps them
+    if (raw == nullptr)
+        return rc;
+    if (raw->target != nullptr)
+        rc.target_ = raw->target;
+    if (raw->program_name != nullptr)
+        rc.program_name_ = raw->program_name;
+    if (raw->program_version != nullptr)
+        rc.program_version_ = raw->program_version;
+    if (raw->program_description != nullptr)
+        rc.program_description_ = raw->program_description;
+    if (raw->program_directory != nullptr) {
+        rc.program_dir_ = raw->program_directory;
+        rc.program_dir_set_ = true;
     }
-    ring_dim_ = n;
-    allocator().set_polynomial_size(n * sizeof(uint64_t));
-    return {};
-}
-
-std::expected<void, HazeInternalError> Config::set_modulus(int idx, uint64_t modulus) noexcept {
-    if (idx < 0)
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    if (modulus == 0)
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    HazeLockGuard lock(mutex_);
-    if (configured_) {
-        const auto i = static_cast<size_t>(idx);
-        if (i >= moduli_.size() || moduli_[i] != modulus)
-            return std::unexpected(HazeInternalError::ConfigLocked);
-        return {};
-    }
-    // Reject sparse writes — every index from 0 to idx-1 must already
-    // have been set with a non-zero modulus. Without this constraint,
-    // skipping an index leaves a 0 in the table which Config::modulus()
-    // returns indistinguishably from "out of range," and the compute
-    // templates would conflate the two failure modes.
-    if (std::cmp_less(moduli_.size(), idx))
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    if (std::cmp_equal(moduli_.size(), idx)) {
-        moduli_.push_back(modulus);
-    } else {
-        moduli_[static_cast<size_t>(idx)] = modulus;
-    }
-    return {};
-}
-
-std::expected<void, HazeInternalError> Config::set_twiddle_generator(int idx,
-                                                                     uint64_t generator) noexcept {
-    if (idx < 0)
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    HazeLockGuard lock(mutex_);
-    if (configured_) {
-        const auto i = static_cast<size_t>(idx);
-        if (i >= twiddle_generators_.size() || twiddle_generators_[i] != generator)
-            return std::unexpected(HazeInternalError::ConfigLocked);
-        return {};
-    }
-    if (std::cmp_less_equal(twiddle_generators_.size(), idx)) {
-        twiddle_generators_.resize(static_cast<size_t>(idx) + 1, 0);
-    }
-    twiddle_generators_[static_cast<size_t>(idx)] = generator;
-    return {};
-}
-
-std::expected<void, HazeInternalError> Config::configure_device() noexcept {
-    HazeLockGuard lock(mutex_);
-    if (ring_dim_ == 0)
-        return std::unexpected(HazeInternalError::NotConfigured);
-    configured_ = true;
-    return {};
-}
-
-uint64_t Config::ring_dim() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return ring_dim_;
-}
-
-uint64_t Config::modulus(int idx) const noexcept {
-    HazeLockGuard lock(mutex_);
-    if (idx < 0 || static_cast<size_t>(idx) >= moduli_.size())
-        return 0;
-    return moduli_[static_cast<size_t>(idx)];
-}
-
-std::expected<void, HazeInternalError>
-Config::set_program_info(const char *name, const char *version, const char *description) noexcept {
-    if (name == nullptr || version == nullptr || description == nullptr)
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    HazeLockGuard lock(mutex_);
-    program_name_ = name;
-    program_version_ = version;
-    program_description_ = description;
-    program_info_set_ = true;
-    return {};
-}
-
-std::expected<void, HazeInternalError> Config::set_target(const char *target) noexcept {
-    if (target == nullptr)
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    HazeLockGuard lock(mutex_);
-    target_ = target;
-    target_set_ = true;
-    return {};
-}
-
-std::expected<void, HazeInternalError> Config::set_program_directory(const char *dir) noexcept {
-    if (dir == nullptr)
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    HazeLockGuard lock(mutex_);
-    program_dir_ = dir;
-    program_dir_set_ = true;
-    return {};
-}
-
-bool Config::has_program_directory() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return program_dir_set_;
-}
-
-std::string Config::program_directory() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return program_dir_;
-}
-
-std::string Config::program_name() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return program_info_set_ ? program_name_ : std::string{"haze"};
-}
-
-std::string Config::program_version() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return program_info_set_ ? program_version_ : std::string{"0.1"};
-}
-
-std::string Config::program_description() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return program_info_set_ ? program_description_ : std::string{"HAZE runtime"};
-}
-
-std::string Config::target() const noexcept {
-    // Default kLocalTarget runs the in-process FHETCH simulator.
-    HazeLockGuard lock(mutex_);
-    return target_set_ ? target_ : std::string{kLocalTarget};
-}
-
-void Config::set_montgomery(bool enable) noexcept {
-    HazeLockGuard lock(mutex_);
-    montgomery_ = enable;
-}
-
-void Config::set_bit_reversal(bool enable) noexcept {
-    HazeLockGuard lock(mutex_);
-    bit_reversal_ = enable;
-}
-
-bool Config::montgomery() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return montgomery_;
-}
-
-bool Config::bit_reversal() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return bit_reversal_;
-}
-
-void Config::set_reduced_noise(bool enable) noexcept {
-    HazeLockGuard lock(mutex_);
-    reduced_noise_ = enable;
-}
-
-bool Config::reduced_noise() const noexcept {
-    HazeLockGuard lock(mutex_);
-    return reduced_noise_;
-}
-
-void Config::reset() noexcept {
-    HazeLockGuard lock(mutex_);
-    ring_dim_ = 0;
-    moduli_.clear();
-    twiddle_generators_.clear();
-    configured_ = false;
-    program_name_.clear();
-    program_version_.clear();
-    program_description_.clear();
-    target_.clear();
-    program_dir_.clear();
-    program_info_set_ = false;
-    target_set_ = false;
-    program_dir_set_ = false;
-    montgomery_ = false;
-    bit_reversal_ = false;
-    reduced_noise_ = false;
+    rc.montgomery_ = raw->montgomery != 0;
+    rc.bit_reversal_ = raw->bit_reversal != 0;
+    rc.reduced_noise_ = raw->reduced_noise != 0;
+    return rc;
 }
 
 } // namespace haze

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -13,8 +13,10 @@
 #pragma once
 
 #include "common/errors.hpp"
-#include "common/thread_safety.hpp"
+#include "core/device.hpp"
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <expected>
 #include <haze/haze_types.h>
@@ -24,104 +26,95 @@
 
 namespace haze {
 
-// Canonical target string dispatched through libnbfhetch's compiler.
-// kLocalTarget runs the in-process FHETCH instruction-set simulator:
-// libnbfhetch loads the .fhetch trace into fhetch_sim::Simulator,
-// executes it, and writes <program_dir>/serialized_probes/<name>.ct
-// so epoch.cpp's result-population loop fills shadow buffers with
-// computed values. No compiler-side binary or HTTP transport needed.
-//
-// Anything else (e.g. "FUNC_SIM", "FHE_SIM", "FPGA_TRI", "fhetch_sim")
-// is forwarded verbatim to nbcc_fhetch_replay over the HTTP transport
-// — those strings select a backend on the compiler side. Keep
-// kLocalTarget symbolic so a future rename in libnbfhetch flows
-// through every comparison site in haze.
+// Canonical target string dispatched through libnbfhetch's compiler:
+// kLocalTarget runs the in-process FHETCH simulator; anything else is
+// forwarded verbatim to nbcc_fhetch_replay.
 constexpr std::string_view kLocalTarget = "local";
 
-class DeviceState;
-
-// Global FHE-context configuration: ring dimension, ciphertext moduli,
-// twiddle generators, plus the program/target metadata fed to the compiler
-// at recording-init time. A DeviceState member reached via config(); the
-// mutex covers writes and reads alike (vector resizes).
-class Config {
+// Immutable FHE-scheme parameters: a thin owning wrapper over the caller's
+// hazeFheParams, deep-copied and validated by create() (the sole non-empty
+// construction path — no separate builder). Read lock-free during compute: it
+// never changes after configure, and the backend/epoch acquire fence orders the
+// copy before every read, so no lock or atomics are needed.
+class FheParams {
   public:
-    // FHE parameters (existing public API).
-    std::expected<void, HazeInternalError> set_ring_dimension(uint64_t n) noexcept
-        HAZE_EXCLUDES(mutex_);
-    std::expected<void, HazeInternalError> set_modulus(int idx, uint64_t modulus) noexcept
-        HAZE_EXCLUDES(mutex_);
-    std::expected<void, HazeInternalError> set_twiddle_generator(int idx,
-                                                                 uint64_t generator) noexcept
-        HAZE_EXCLUDES(mutex_);
-    std::expected<void, HazeInternalError> configure_device() noexcept HAZE_EXCLUDES(mutex_);
+    // Validate the caller's struct and deep-copy it into an immutable FheParams.
+    // Enforces per-argument invariants (ring_dim in the device envelope; moduli
+    // non-zero and within the modulus envelope), the whole-config invariant
+    // (moduli unique), and struct well-formedness (a NULL array with a non-zero
+    // count is InvalidArgument). Nothing partial escapes — on any failure it
+    // returns the error and no object.
+    static std::expected<FheParams, HazeInternalError> create(const hazeFheParams &raw) noexcept;
 
-    uint64_t ring_dim() const noexcept HAZE_EXCLUDES(mutex_);
-    uint64_t modulus(int idx) const noexcept HAZE_EXCLUDES(mutex_);
+    FheParams() = default; // empty pre-configure placeholder (ring_dim 0 = unconfigured)
 
-    // Program / target metadata fed to the compiler during init. Defaults:
-    // name="haze", version="0.1", description="HAZE runtime", target=kLocalTarget.
-    std::expected<void, HazeInternalError> set_program_info(const char *name, const char *version,
-                                                            const char *description) noexcept
-        HAZE_EXCLUDES(mutex_);
-    std::expected<void, HazeInternalError> set_target(const char *target) noexcept
-        HAZE_EXCLUDES(mutex_);
-    std::string program_name() const noexcept HAZE_EXCLUDES(mutex_);
-    std::string program_version() const noexcept HAZE_EXCLUDES(mutex_);
-    std::string program_description() const noexcept HAZE_EXCLUDES(mutex_);
-    std::string target() const noexcept HAZE_EXCLUDES(mutex_);
-
-    // Data-representation toggles (Montgomery form, bit-reversed order), off by
-    // default; the local simulator rejects non-ordinary traces at init.
-    void set_montgomery(bool enable) noexcept HAZE_EXCLUDES(mutex_);
-    void set_bit_reversal(bool enable) noexcept HAZE_EXCLUDES(mutex_);
-    bool montgomery() const noexcept HAZE_EXCLUDES(mutex_);
-    bool bit_reversal() const noexcept HAZE_EXCLUDES(mutex_);
-
-    // Centered (reduced-noise) FBC variant matching OpenFHE WITH_REDUCED_NOISE,
-    // off by default; the HazeEngine constructor enables it for bit-exact parity.
-    void set_reduced_noise(bool enable) noexcept HAZE_EXCLUDES(mutex_);
-    bool reduced_noise() const noexcept HAZE_EXCLUDES(mutex_);
-
-    // Optional output-directory override. When set, the backend forwards it to
-    // niobium::compiler().set_program_directory() at init, so the program dir
-    // (.fhetch + inputs + templates + cryptocontext) lands at this exact path
-    // instead of the cwd/<program_name> default. Unset by default.
-    std::expected<void, HazeInternalError> set_program_directory(const char *dir) noexcept
-        HAZE_EXCLUDES(mutex_);
-    bool has_program_directory() const noexcept HAZE_EXCLUDES(mutex_);
-    std::string program_directory() const noexcept HAZE_EXCLUDES(mutex_);
-
-    void reset() noexcept HAZE_EXCLUDES(mutex_);
-
-    Config(const Config &) = delete;
-    Config &operator=(const Config &) = delete;
+    uint64_t ring_dim() const noexcept { return ring_dim_; }
+    // 0 means "no such configured slot" (outside the contiguous [0, count) range).
+    uint64_t modulus(int idx) const noexcept {
+        if (idx < 0 || idx >= moduli_count_)
+            return 0;
+        return moduli_[static_cast<size_t>(idx)];
+    }
 
   private:
-    friend class DeviceState;
-    Config() = default;
-
-    mutable HazeMutex mutex_;
-    uint64_t ring_dim_ HAZE_GUARDED_BY(mutex_) = 0;
-    std::vector<uint64_t> moduli_ HAZE_GUARDED_BY(mutex_);
-    std::vector<uint64_t> twiddle_generators_ HAZE_GUARDED_BY(mutex_);
-    bool configured_ HAZE_GUARDED_BY(mutex_) = false;
-
-    // Defaults applied lazily on first read.
-    std::string program_name_ HAZE_GUARDED_BY(mutex_);
-    std::string program_version_ HAZE_GUARDED_BY(mutex_);
-    std::string program_description_ HAZE_GUARDED_BY(mutex_);
-    std::string target_ HAZE_GUARDED_BY(mutex_);
-    std::string program_dir_ HAZE_GUARDED_BY(mutex_);
-    bool program_info_set_ HAZE_GUARDED_BY(mutex_) = false;
-    bool target_set_ HAZE_GUARDED_BY(mutex_) = false;
-    bool program_dir_set_ HAZE_GUARDED_BY(mutex_) = false;
-    bool montgomery_ HAZE_GUARDED_BY(mutex_) = false;
-    bool bit_reversal_ HAZE_GUARDED_BY(mutex_) = false;
-    bool reduced_noise_ HAZE_GUARDED_BY(mutex_) = false;
+    uint64_t ring_dim_ = 0;
+    std::array<uint64_t, static_cast<size_t>(kMaxCiphertextModuli)> moduli_{};
+    int moduli_count_ = 0;
+    std::vector<uint64_t> twiddle_generators_; // stored for the trace; no reader yet
 };
 
-// Defined in device_state.cpp (returns the DeviceState member).
-Config &config() noexcept;
+// Immutable hardware/replay configuration (target + program metadata + the
+// data-format toggles): a thin owning wrapper over the caller's hazeReplayConfig,
+// copied by create(). Read at backend bring-up, replay dispatch, and compute.
+class ReplayConfig {
+  public:
+    // Copy the caller's struct into an immutable config; a NULL field keeps its
+    // default and a NULL struct yields all defaults. Infallible — montgomery/
+    // bit-reversal on a local target is an execution-compatibility concern checked
+    // at bring-up against the built config, not a config invariant.
+    static ReplayConfig create(const hazeReplayConfig *raw) noexcept;
+
+    ReplayConfig() = default; // defaults (target "local", program "haze"/"0.1"/...)
+
+    const std::string &target() const noexcept { return target_; }
+    bool target_is_local() const noexcept { return target_ == kLocalTarget; }
+    const std::string &program_name() const noexcept { return program_name_; }
+    const std::string &program_version() const noexcept { return program_version_; }
+    const std::string &program_description() const noexcept { return program_description_; }
+    bool has_program_directory() const noexcept { return program_dir_set_; }
+    const std::string &program_directory() const noexcept { return program_dir_; }
+    bool montgomery() const noexcept { return montgomery_; }
+    bool bit_reversal() const noexcept { return bit_reversal_; }
+    bool reduced_noise() const noexcept { return reduced_noise_; }
+
+  private:
+    std::string target_ = std::string(kLocalTarget);
+    std::string program_name_ = "haze";
+    std::string program_version_ = "0.1";
+    std::string program_description_ = "HAZE runtime";
+    std::string program_dir_;
+    bool program_dir_set_ = false;
+    bool montgomery_ = false;
+    bool bit_reversal_ = false;
+    bool reduced_noise_ = false;
+};
+
+// One-shot configuration entry point (impl in config.cpp): validate + deep-copy
+// the caller's structs into the two immutable configs (FheParams::create /
+// ReplayConfig::create) and install them into DeviceState. `replay` may be null
+// (accept all defaults). Only the frozen configs are stored, and nothing is
+// installed on failure. Called solely by hazeConfigureDevice.
+std::expected<void, HazeInternalError> configure_device(const hazeFheParams &fhe,
+                                                        const hazeReplayConfig *replay) noexcept;
+
+// Read side (defined in device_state.cpp): the frozen configs — plain
+// always-valid members (default until configured), so reads never fault.
+// Meaningful once config_finalized() is true; callers gate on it.
+const FheParams &fhe_params() noexcept;
+const ReplayConfig &replay_config() noexcept;
+// True once hazeConfigureDevice has installed the configs. Compute/bring-up/
+// bridge paths REQUIRE this; they only read the frozen config and never
+// configure themselves, so the read path never mutates config state.
+bool config_finalized() noexcept;
 
 } // namespace haze

--- a/src/core/device.cpp
+++ b/src/core/device.cpp
@@ -30,7 +30,7 @@ inline constexpr int kNumRegisters = 64;
 inline constexpr int kNumHbmBanks = 8;
 // Ring dimension exponents kMinRingDimExponent..kMaxRingDimExponent
 // (N = 1024..65536); the envelope constants live in device.hpp so
-// Config::set_ring_dimension validates against the same range.
+// FheParams::create validates the ring dimension against the same range.
 inline constexpr int kNumSupportedRingDims = kMaxRingDimExponent - kMinRingDimExponent + 1;
 
 } // namespace

--- a/src/core/device.hpp
+++ b/src/core/device.hpp
@@ -19,24 +19,20 @@
 
 namespace haze {
 
-// Device ciphertext-modulus envelope (reported as
-// hazeDeviceProp::maxCiphertextModuli). Also the upper bound on an MRP
-// group's residue count: a valid group cannot span more residues than the
-// device supports moduli, so the C-ABI batch entry points reject a larger
-// `count` rather than attempting an unbounded reservation.
+// Device ciphertext-modulus envelope (reported as hazeDeviceProp::maxCiphertextModuli)
+// and the upper bound on an MRP group's residue count, so the C-ABI batch entry
+// points reject a larger `count` rather than attempting an unbounded reservation.
 inline constexpr int kMaxCiphertextModuli = 64;
 
 // Supported ring-dimension envelope (reported as
-// hazeDeviceProp::supportedRingDimExponents: N = 2^10 .. 2^16). Config
-// validates hazeSetRingDimension against the same range so a dimension
-// the device can't run — or one whose byte size would overflow
-// n * sizeof(uint64_t) — is rejected at the setter.
+// hazeDeviceProp::supportedRingDimExponents: N = 2^10 .. 2^16); hazeConfigureDevice
+// validates the ring dimension against the same range, rejecting a dimension the
+// device can't run or one whose n * sizeof(uint64_t) would overflow.
 inline constexpr int kMinRingDimExponent = 10;
 inline constexpr int kMaxRingDimExponent = 16;
 
-// Single-device runtime state. Only one device exists; the only valid
-// device index is 0. Free functions instead of a class — a class adds
-// nothing over a one-int counter and a couple of getters.
+// Single-device runtime state (only device index 0 is valid); free functions
+// instead of a class, which adds nothing over a counter and a few getters.
 
 int device_count() noexcept;
 int device_active() noexcept;

--- a/src/core/device_state.cpp
+++ b/src/core/device_state.cpp
@@ -12,7 +12,14 @@
 // from the Product.
 #include "core/device_state.hpp"
 
+#include "common/errors.hpp"
+#include "core/config.hpp"
+
 #include <atomic>
+#include <cstdint>
+#include <expected>
+#include <haze/haze_types.h>
+#include <utility>
 // Plain C-ABI header (only haze_types.h + stdint.h) — pulls no C++/OpenFHE, so
 // depending on it here does not leak the bridge's OpenFHE surface into core/.
 #include <haze/replay_bridge.h>
@@ -30,7 +37,9 @@ void DeviceState::reset() noexcept {
     epoch.reset();
     backend.reset();
     allocator.reset();
-    config.reset();
+    fhe_params = {}; // back to unconfigured; hazeConfigureDevice must run again
+    replay_config = {};
+    configured = false;
     active_device.store(0, std::memory_order_relaxed);
     next_stream_id.store(1, std::memory_order_relaxed);
     next_event_id.store(1, std::memory_order_relaxed);
@@ -40,11 +49,7 @@ void DeviceState::reset() noexcept {
     CompilerBackend::reset_compiler();
 }
 
-// Single definition point for the subsystem accessors declared in each
-// class's header.
-Config &config() noexcept {
-    return device_state().config;
-}
+// Single definition point for the subsystem accessors declared in each header.
 CompilerBackend &backend() noexcept {
     return device_state().backend;
 }
@@ -53,6 +58,58 @@ DeviceAllocator &allocator() noexcept {
 }
 EpochState &epoch() noexcept {
     return device_state().epoch;
+}
+
+// Read side: the frozen configs — plain always-valid members (default until
+// configured), so these never fault; callers gate on config_finalized().
+const FheParams &fhe_params() noexcept {
+    return device_state().fhe_params;
+}
+const ReplayConfig &replay_config() noexcept {
+    return device_state().replay_config;
+}
+
+bool config_finalized() noexcept {
+    return device_state().configured;
+}
+
+std::expected<void, HazeInternalError> configure_device(const hazeFheParams &fhe,
+                                                        const hazeReplayConfig *replay) noexcept {
+    // Once the backend is brought up (first compute) it has latched the config,
+    // so a later reconfigure could not take effect — reject it rather than
+    // silently diverge. Reconfiguring before bring-up is fine (latest wins);
+    // hazeDeviceReset re-opens configuration.
+    if (backend().is_initialized()) {
+        record_internal_error(
+            HazeInternalError::ConfigLocked,
+            "hazeConfigureDevice: device already brought up; reset to reconfigure");
+        return std::unexpected(HazeInternalError::ConfigLocked);
+    }
+
+    // Validate + deep-copy the caller's structs into the immutable configs; the
+    // config types own all validation (no builder). Nothing is installed unless
+    // FheParams::create succeeds (ReplayConfig::create is infallible).
+    auto built_fhe = FheParams::create(fhe);
+    if (!built_fhe)
+        return std::unexpected(built_fhe.error());
+    ReplayConfig built_replay = ReplayConfig::create(replay);
+
+    // Apply the allocator's polynomial size only now the whole config is valid;
+    // changing the ring dimension under live allocations would leave their
+    // shadows mis-sized (a former D2H overread), so refuse that.
+    const uint64_t ring_dim = built_fhe->ring_dim();
+    if (allocator().has_live_allocations() && ring_dim != device_state().fhe_params.ring_dim()) {
+        record_internal_error(HazeInternalError::ConfigLocked,
+                              "hazeConfigureDevice: allocations live; free them or reset first");
+        return std::unexpected(HazeInternalError::ConfigLocked);
+    }
+    allocator().set_polynomial_size(ring_dim * sizeof(uint64_t));
+
+    // Commit the frozen configs — the only stored config state.
+    device_state().fhe_params = std::move(*built_fhe);
+    device_state().replay_config = std::move(built_replay);
+    device_state().configured = true;
+    return {};
 }
 
 } // namespace haze

--- a/src/core/device_state.hpp
+++ b/src/core/device_state.hpp
@@ -29,7 +29,13 @@ class DeviceState {
   public:
     static DeviceState &instance() noexcept;
 
-    Config config;
+    // The frozen immutable configs, installed by hazeConfigureDevice through
+    // configure_device(). No builder is ever stored here: the caller owns the
+    // config structs and the transient build runs inside configure_device. The
+    // configs default (empty) until then; `configured` gates every read of them.
+    FheParams fhe_params;
+    ReplayConfig replay_config;
+    bool configured = false;
     CompilerBackend backend;
     DeviceAllocator allocator;
     EpochState epoch;

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -52,9 +52,17 @@ void EpochState::ensure_recording_locked() {
 std::expected<void, HazeInternalError> EpochState::require_recording_locked() const noexcept {
     if (recording_)
         return {};
-    // Name the user-actionable refusal (montgomery/bit-reversal on local)
-    // distinctly from a backend-init failure.
-    if ((config().montgomery() || config().bit_reversal()) && config().target() == kLocalTarget) {
+    // No explicit hazeConfigureDevice(): the frozen config isn't built, so report
+    // that distinctly and before touching replay_config().
+    if (!config_finalized()) {
+        record_internal_error(HazeInternalError::NotConfigured,
+                              "require_recording_locked: hazeConfigureDevice() not called");
+        return std::unexpected(HazeInternalError::NotConfigured);
+    }
+    // Configured but recording refused: name the montgomery/bit-reversal-on-local
+    // case distinctly from a backend-init failure.
+    const ReplayConfig &rc = replay_config();
+    if ((rc.montgomery() || rc.bit_reversal()) && rc.target_is_local()) {
         record_internal_error(HazeInternalError::UnsupportedDataFormat,
                               "require_recording_locked (montgomery/bit_reversal require a "
                               "transport target such as FUNC_SIM)");
@@ -84,7 +92,7 @@ EpochState::lookup_or_create_locked(DevAddr addr) {
         return it->second;
     }
 
-    const uint64_t ring_dim = config().ring_dim();
+    const uint64_t ring_dim = fhe_params().ring_dim();
     auto components = allocator().extract_polynomial_components(addr, ring_dim);
     if (!components) {
         // Compute / D2D on an addr with neither shadow data nor a
@@ -182,17 +190,10 @@ std::expected<void, HazeInternalError> EpochState::tag_h2d_input_locked(DevAddr 
     if (!recording_) {
         return {};
     }
-    // Both guards below cover invariants that the H2D entry point has
-    // already enforced (copy_h2d requires alloc_set_ membership and a
-    // configured poly_bytes_, so by the time this runs ring_dim is set
-    // and shadow bytes exist). Treat hits as broken-haze internal
-    // errors so we don't silently drop the input tag.
-    const uint64_t ring_dim = config().ring_dim();
-    if (ring_dim == 0) {
-        record_internal_error(HazeInternalError::NotConfigured,
-                              "tag_h2d_input_locked: ring_dim == 0 after copy_h2d");
-        return std::unexpected(HazeInternalError::NotConfigured);
-    }
+    // recording_ implies a finalized FheParams (ring_dim set and validated at
+    // build), so ring_dim is non-zero here; the read-back guard below covers the
+    // remaining shadow-size invariant.
+    const uint64_t ring_dim = fhe_params().ring_dim();
     auto components = allocator().read_polynomial_components(addr, ring_dim);
     if (!components)
         return std::unexpected(components.error());
@@ -376,18 +377,9 @@ std::expected<void, HazeInternalError> tag_output(DevAddr addr) noexcept {
 }
 
 std::expected<void, HazeInternalError> flush() noexcept {
-    // Montgomery / bit-reversed traces can't execute on the in-process
-    // simulator. ensure_initialized() already refuses first-time init for this
-    // combination (so nothing was recorded); checking again here makes the
-    // failure visible at the flush call instead of a silent no-op followed
-    // by OutputNotFlushed on the next D2H, and also covers the
-    // flags-set-after-init ordering the init-time check can't see.
-    if ((config().montgomery() || config().bit_reversal()) && config().target() == kLocalTarget) {
-        record_internal_error(HazeInternalError::UnsupportedDataFormat,
-                              "haze::flush (montgomery/bit_reversal require a transport "
-                              "target such as FUNC_SIM)");
-        return std::unexpected(HazeInternalError::UnsupportedDataFormat);
-    }
+    // The montgomery/bit-reversal-on-local refusal is enforced at bring-up
+    // against the frozen replay config; the format can't change afterwards, so
+    // no flush-time re-check is needed.
     return epoch().replay_and_populate();
 }
 

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -177,8 +177,7 @@ class EpochState {
     void ensure_output_tag_locked(DevAddr addr) HAZE_REQUIRES(mutex_);
 
     // Lock order: see the canonical DAG in common/thread_safety.hpp
-    // (epoch → {config, allocator}). Allocator-side code must never
-    // call back into EpochState while holding its own lock.
+    // (epoch → allocator only; config scalars are read lock-free).
     HazeMutex mutex_;
     // Every poly in flight this epoch (inputs and outputs land here).
     // pending_outputs_ is the addr-keyed subset that names the outputs.

--- a/style.md
+++ b/style.md
@@ -44,7 +44,7 @@ Concise house style for libhaze: a Rust programmer's path to Rust-grade safety i
 
 - Annotate every guarded field `HAZE_GUARDED_BY(mutex_)`; `-Wthread-safety` rejects unguarded access at compile time.
 - Mark lock-taking public methods `HAZE_EXCLUDES(mutex_)`; mark `_locked`-suffixed helpers `HAZE_REQUIRES(mutex_)` and call them only inside a guarded scope.
-- Hold the lock DAG documented in `src/common/thread_safety.hpp` (epoch → {config, allocator}; config → allocator; backend-init → config): code under `EpochState::mutex_` may re-enter `DeviceAllocator`; keep allocator code self-contained (a leaf) so it resolves device state entirely within the allocator.
+- Hold the lock DAG documented in `src/common/thread_safety.hpp` (epoch → allocator): code under `EpochState::mutex_` may re-enter `DeviceAllocator`; keep allocator code self-contained (a leaf) so it resolves device state entirely within the allocator. Config carries no lock — it is a write-only builder frozen to an immutable value at bring-up, then read without synchronization.
 - Expose a mutex reference through an accessor annotated `HAZE_RETURN_CAPABILITY(mutex_)`.
 
 ## Prefer (modern C++20/23)

--- a/test/e2e/ops.cpp
+++ b/test/e2e/ops.cpp
@@ -367,12 +367,13 @@ void Allocs::free_all() noexcept {
 OpCtx make_ctx(const CtxParams &params) {
     using namespace lbcrypto;
 
-    // The library reads no env: bridge the HAZE_TARGET test parameter to the
-    // explicit setter, and enable the reduced-noise FBC so haze matches the
-    // WITH_REDUCED_NOISE OpenFHE oracle. The caller resets the device just before.
+    // The library reads no env: capture the HAZE_TARGET test parameter here and
+    // fold it (plus the reduced-noise FBC, so haze matches the WITH_REDUCED_NOISE
+    // OpenFHE oracle) into the one-shot config below. The caller resets the device
+    // just before.
+    const char *target = nullptr;
     if (const char *t = std::getenv("HAZE_TARGET"); t != nullptr && t[0] != '\0')
-        REQUIRE(hazeSetTarget(t) == HAZE_SUCCESS);
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
+        target = t;
 
     OpCtx ctx;
     ctx.mode = params.mode;
@@ -420,24 +421,22 @@ OpCtx make_ctx(const CtxParams &params) {
             ctx.p_base.push_back(p->GetModulus().ConvertToInt());
     }
 
-    REQUIRE(hazeSetRingDimension(ctx.ring_dim) == HAZE_SUCCESS);
     // Pure-C bridge: build haze's CryptoContext from (ring_dim, first Q prime).
-    // The full Q∥P chain is conveyed below via hazeSetCiphertextModulus; per-op
-    // shapes are rebuilt from the trace moduli, so the exact picked prime here
-    // only seeds the fallback primary context.
+    // The full Q∥P chain is conveyed via hazeFheParams::moduli in Q-then-P order;
+    // per-op shapes are rebuilt from the trace moduli, so the exact picked prime
+    // here only seeds the fallback primary context.
+    std::vector<uint64_t> moduli(ctx.q_base.begin(), ctx.q_base.end());
+    moduli.insert(moduli.end(), ctx.p_base.begin(), ctx.p_base.end());
+    const hazeFheParams fhe = {
+        .ring_dim = ctx.ring_dim, .moduli = moduli.data(), .moduli_count = moduli.size()};
+    const hazeReplayConfig replay = {.target = target, .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+
+    // Bridge pre-init after the explicit finalize, so it reads the frozen config.
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(ctx.ring_dim, ctx.q_base.front(), &picked) ==
             HAZE_SUCCESS);
     REQUIRE(picked != 0);
-
-    int mod_idx = 0;
-    for (uint64_t q : ctx.q_base) {
-        REQUIRE(hazeSetCiphertextModulus(mod_idx++, q) == HAZE_SUCCESS);
-    }
-    for (uint64_t pmod : ctx.p_base) {
-        REQUIRE(hazeSetCiphertextModulus(mod_idx++, pmod) == HAZE_SUCCESS);
-    }
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     if (ctx.with_relin_key) {
         REQUIRE(extract_evalmult_key_limbs(ctx.cc, ctx.keys.secretKey, ctx.relin_key) ==

--- a/test/e2e/test_openfhe_mul_no_relin_e2e.cpp
+++ b/test/e2e/test_openfhe_mul_no_relin_e2e.cpp
@@ -109,8 +109,6 @@ TEMPLATE_TEST_CASE("openfhe mul-no-relin e2e", "[integration][e2e]", FixedManual
     INFO("policy: " << P::kName);
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    // Match the ReducedNoise reference oracle (WITH_REDUCED_NOISE OpenFHE).
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
 
     CCParams<CryptoContextCKKSRNS> params;
     params.SetMultiplicativeDepth(2);
@@ -126,7 +124,6 @@ TEMPLATE_TEST_CASE("openfhe mul-no-relin e2e", "[integration][e2e]", FixedManual
     auto keys = cc->KeyGen();
 
     const uint64_t ring_dim = cc->GetRingDimension();
-    REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
 
     const auto &eparams = cc->GetCryptoParameters()->GetElementParams()->GetParams();
     std::vector<uint64_t> base;
@@ -137,14 +134,15 @@ TEMPLATE_TEST_CASE("openfhe mul-no-relin e2e", "[integration][e2e]", FixedManual
     REQUIRE(!base.empty());
 
     // Pure-C bridge: seed haze's context from the first Q prime, then convey the
-    // full chain via hazeSetCiphertextModulus.
+    // full chain via hazeFheParams::moduli.
+    const hazeFheParams fhe = {
+        .ring_dim = ring_dim, .moduli = base.data(), .moduli_count = base.size()};
+    // Match the ReducedNoise reference oracle (WITH_REDUCED_NOISE OpenFHE).
+    const hazeReplayConfig replay = {.reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, base.front(), &picked) == HAZE_SUCCESS);
     REQUIRE(picked != 0);
-    for (std::size_t i = 0; i < base.size(); ++i) {
-        REQUIRE(hazeSetCiphertextModulus(static_cast<int>(i), base[i]) == HAZE_SUCCESS);
-    }
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     INFO("ring_dim=" << ring_dim << " towers=" << base.size());
     REQUIRE(base.size() >= 2);

--- a/test/integration_helpers.hpp
+++ b/test/integration_helpers.hpp
@@ -18,59 +18,57 @@
 
 namespace haze::test {
 
-// The library no longer reads HAZE_TARGET; the suite still uses it as the
-// parameter selecting the replay target (set by make test-transport). Bridge it
-// to the explicit setter after a device reset, before the first configure/record.
-inline void apply_target_from_env() {
-    if (const char *t = std::getenv("HAZE_TARGET"); t != nullptr && t[0] != '\0')
-        REQUIRE(hazeSetTarget(t) == HAZE_SUCCESS);
+// The library doesn't read HAZE_TARGET; the suite uses it to select the replay
+// target (set by make test-transport). NULL (unset/empty) means the "local"
+// default; pass the result straight into hazeReplayConfig::target.
+inline const char *target_from_env() {
+    const char *t = std::getenv("HAZE_TARGET");
+    return (t != nullptr && t[0] != '\0') ? t : nullptr;
 }
 
-// MODULUS CONTRACT (single source of truth): the values passed to
-// hazeSetCiphertextModulus ARE the .fhetch trace moduli, and both replay paths
-// reconstruct under them; hazeReplayBridgeInitCryptoContext's scaffold prime is
-// overwritten with the trace primes at synthesis (bridge switch_tower_modulus)
-// and never consulted for results. So tests set the
-// slot to the intended prime and oracle against it (verified by "trace modulus
-// is authoritative ..." in test_hardware_format.cpp). Modulus-less SRP ops are
-// trace-authoritative too — haze recovers and binds the source modulus — except
-// a copy of a never-modulus-bound (raw H2D) address, which has none.
+// MODULUS CONTRACT (single source of truth): the primes in hazeFheParams::moduli
+// ARE the .fhetch trace moduli, and both replay paths reconstruct under them;
+// hazeReplayBridgeInitCryptoContext's scaffold prime is overwritten with the
+// trace primes at synthesis (bridge switch_tower_modulus) and never consulted
+// for results, so tests set the slot to the intended prime and oracle against it
+// (verified by "trace modulus is authoritative ..." in test_hardware_format.cpp).
+// Modulus-less SRP ops are trace-authoritative too (haze recovers and binds the
+// source modulus) except a copy of a never-modulus-bound (raw H2D) address,
+// which has none.
 
-// Combined integration setup: reset, ring dim, bridge CC init, set the
-// ciphertext modulus, configure device. Returns the modulus it set so callers
-// generate inputs and oracles against the same (authoritative) value.
+// Combined integration setup: reset, one-shot configure (ring dim + single
+// modulus, reduced-noise on, target from env), then bridge CC init. Returns the
+// configured modulus so callers generate inputs and oracles against the same
+// (authoritative) value. `mod_idx` must be 0 (single-prime helper; multi-prime
+// cases use setup_integration_mrp3_config).
 inline uint64_t setup_integration_compute_config(uint64_t ring_dim = 4096,
                                                  uint64_t modulus = 576460752303415297ULL,
                                                  int mod_idx = 0) {
+    REQUIRE(mod_idx == 0);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    apply_target_from_env();
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {modulus};
+    const hazeFheParams fhe = {.ring_dim = ring_dim, .moduli = moduli, .moduli_count = 1};
+    const hazeReplayConfig replay = {.target = target_from_env(), .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t scaffold = 0; // built then overwritten from the trace; not used for results
     REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, modulus, &scaffold) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(mod_idx, modulus) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
     return modulus;
 }
 
-// Three-prime variant for MRP cases: all three slots set before the single
-// hazeConfigureDevice, each to its intended (trace-authoritative) prime: slot
-// 0 the requested modulus, slots 1 and 2 the suite's NTT-friendly companion
-// primes. Returns the configured base, index-aligned with the modulus slots.
+// Three-prime variant for MRP cases: slot 0 the requested modulus, slots 1 and 2
+// the suite's NTT-friendly companion primes, all in one hazeConfigureDevice.
+// Returns the configured base, index-aligned with the modulus slots.
 inline std::vector<uint64_t>
 setup_integration_mrp3_config(uint64_t ring_dim = 4096, uint64_t modulus = 576460752303415297ULL) {
     constexpr uint64_t kQ1 = 576460752303439873ULL;
     constexpr uint64_t kQ2 = 576460752303702017ULL;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    apply_target_from_env();
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {modulus, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = ring_dim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = target_from_env(), .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t scaffold = 0; // built then overwritten from the trace; not used for results
     REQUIRE(hazeReplayBridgeInitCryptoContext(ring_dim, modulus, &scaffold) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, modulus) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
     return {modulus, kQ1, kQ2};
 }
 
@@ -81,9 +79,8 @@ inline uint64_t add_mod(uint64_t a, uint64_t b, uint64_t q) {
     return (s >= q) ? s - q : s;
 }
 
-// Deterministic non-trivial residue. Avoids zeros and all-equal
-// coefficients across primes so per-residue bugs cannot hide behind a
-// trivial input.
+// Deterministic non-trivial residue: avoids zeros and all-equal coefficients
+// across primes so per-residue bugs cannot hide behind a trivial input.
 inline std::vector<uint64_t> make_residue(uint64_t prime, uint64_t seed, std::size_t n) {
     std::vector<uint64_t> r(n);
     for (std::size_t k = 0; k < n; ++k) {

--- a/test/test_basis_convert.cpp
+++ b/test/test_basis_convert.cpp
@@ -20,7 +20,6 @@
 #include <haze/haze_types.h>
 #include <haze/replay_bridge.h>
 #include <math/math-hal.h>
-#include <utility>
 #include <vector>
 
 static constexpr uint64_t kRingDim = 4096;
@@ -45,14 +44,12 @@ static constexpr uint64_t kQ2 = 576460752303702017ULL;
 static void configure_three_moduli() {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Match the ReducedNoise reference oracle (WITH_REDUCED_NOISE OpenFHE).
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 }
 
 // Parameter validation.
@@ -545,14 +542,12 @@ constexpr uint64_t kBigBase[kSrcLimbs + kPLimbs] = {
 void configure_sixteen_moduli() {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Match the ReducedNoise reference oracle (WITH_REDUCED_NOISE OpenFHE).
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const hazeFheParams fhe = {
+        .ring_dim = kRingDim, .moduli = kBigBase, .moduli_count = kSrcLimbs + kPLimbs};
+    const hazeReplayConfig replay = {.reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kBigBase[0], &picked) == HAZE_SUCCESS);
-    for (int i = 0; std::cmp_less(i, kSrcLimbs + kPLimbs); ++i) {
-        REQUIRE(hazeSetCiphertextModulus(i, kBigBase[static_cast<size_t>(i)]) == HAZE_SUCCESS);
-    }
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 }
 
 // Deterministic non-trivial residues. Avoids zeros (which trigger

--- a/test/test_build.cpp
+++ b/test/test_build.cpp
@@ -76,7 +76,8 @@ TEST_CASE("multi-device stubs return HAZE_ERROR_NOT_SUPPORTED", "[unit]") {
 TEST_CASE("successful stubs do not pollute error state", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Ensure a sequence of successful calls leaves hazeGetLastError as HAZE_SUCCESS.
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    const hazeFheParams fhe = {.ring_dim = 4096};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
     void *ptr = nullptr;
     REQUIRE(hazeMalloc(&ptr, 32768) == HAZE_SUCCESS);
     REQUIRE(hazeFree(ptr) == HAZE_SUCCESS);

--- a/test/test_compute.cpp
+++ b/test/test_compute.cpp
@@ -18,6 +18,7 @@
 #include <haze/haze_types.h>
 #include <haze/replay_bridge.h>
 #include <niobium/compiler.h>
+#include <string>
 #include <system_error>
 #include <utility>
 #include <vector>
@@ -106,14 +107,12 @@ struct MrpDriver {
 
     uint64_t setup() {
         REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-        REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+        const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+        const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+        REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
         uint64_t picked = 0;
         REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
         REQUIRE(picked != 0);
-        REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-        REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-        REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
-        REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
         base = {kQ0, kQ1, kQ2};
         return kQ0;
     }
@@ -1247,12 +1246,15 @@ TEST_CASE("hazeWriteProgram writes the project trace without replaying", "[integ
 
     // Program dir must be set before the first compute (forwarded at init).
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetProgramDirectory(dir.string().c_str()) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    // Bind the program-directory string to a named local so its c_str() outlives
+    // the hazeConfigureDevice call (a temporary would dangle after this statement).
+    const std::string dir_str = dir.string();
+    const hazeReplayConfig replay = {.program_directory = dir_str.c_str()};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, picked) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     void *d_a = nullptr;
     void *d_b = nullptr;
@@ -1291,9 +1293,9 @@ TEST_CASE("hazeWriteProgram writes the project trace without replaying", "[integ
 
 TEST_CASE("hazeAdd with unknown source address returns error", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     void *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
@@ -1314,9 +1316,9 @@ TEST_CASE("hazeAdd with unknown source address returns error", "[unit]") {
 
 TEST_CASE("hazeAdd with invalid modulus index returns error", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     void *d_a = nullptr;
     void *d_b = nullptr;
@@ -1342,9 +1344,9 @@ TEST_CASE("hazeAdd with invalid modulus index returns error", "[unit]") {
 
 TEST_CASE("hazeMul with unknown source address returns error", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     void *d_dst = nullptr;
     REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
@@ -1361,9 +1363,9 @@ TEST_CASE("hazeMul with unknown source address returns error", "[unit]") {
 
 TEST_CASE("hazeMul with invalid modulus index returns error", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     void *d_a = nullptr;
     void *d_b = nullptr;
@@ -1394,9 +1396,9 @@ TEST_CASE("hazeMul with invalid modulus index returns error", "[unit]") {
 
 TEST_CASE("hazeAddMrp rejects null arrays / zero base length", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     const uint64_t base[] = {kQ0};
     void *dst_polys[] = {nullptr};
@@ -1417,9 +1419,9 @@ TEST_CASE("hazeAddMrp rejects null arrays / zero base length", "[unit]") {
 
 TEST_CASE("hazeAddScalarMrp rejects null scalars array", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     const uint64_t base[] = {kQ0};
     void *dst_polys[] = {nullptr};
@@ -1432,9 +1434,9 @@ TEST_CASE("hazeAddScalarMrp rejects null scalars array", "[unit]") {
 
 TEST_CASE("hazeNTTMrp rejects null arrays / zero base length", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     const uint64_t base[] = {kQ0};
     void *dst_polys[] = {nullptr};
@@ -1452,9 +1454,9 @@ TEST_CASE("hazeAutomorphMrp rejects null arrays / zero base length", "[unit]") {
     // so the validation code lives in its own shim block — covered here
     // to ensure the same null-pointer guarantees apply.
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     const uint64_t base[] = {kQ0};
     void *dst_polys[] = {nullptr};

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -1,102 +1,119 @@
 // Copyright (C) 2026, All rights reserved by Niobium Microsystems.
 #include <catch2/catch_test_macros.hpp>
+#include <cstddef>
 #include <cstdint>
 #include <haze/haze.h>       // IWYU pragma: keep
 #include <haze/haze_types.h> // IWYU pragma: keep
+#include <vector>
 
-// HAZE's public C API exposes setters for ring dimension, ciphertext
-// moduli, twiddle factors, program info, and target — but no
-// corresponding getters (see include/haze/haze.h:94-110). For accept
-// tests, we therefore can only assert that the call returned
-// HAZE_SUCCESS; the value's presence in internal state is not
-// observable through the public API. Each accept test below carries a
-// short note where read-back would otherwise belong.
+// HAZE takes the whole configuration in one hazeConfigureDevice call
+// (hazeFheParams + optional hazeReplayConfig) — the caller owns the structs and
+// no config state is held before the call. There are no getters, so accept
+// tests can only assert HAZE_SUCCESS. Per-argument problems (a bad ring
+// dimension, a zero modulus, too many moduli) surface as
+// HAZE_ERROR_INVALID_VALUE; whole-config invariants (duplicate moduli,
+// reconfiguring under live allocations) as HAZE_ERROR_CONFIGERR. Nothing is
+// installed on a failed configure.
 
-TEST_CASE("haze setters accept well-formed inputs", "[unit]") {
+TEST_CASE("hazeConfigureDevice accepts a well-formed config", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    // Ring dimension: every supported power-of-2.
-    for (uint64_t n : {4096ULL, 8192ULL, 16384ULL, 32768ULL, 65536ULL}) {
-        REQUIRE(hazeSetRingDimension(n) == HAZE_SUCCESS);
-    }
-    // Two distinct NTT-friendly primes (q ≡ 1 mod 2N) for N=4096; the
-    // same constants are used by test_basis_convert.cpp.
+    // Two distinct NTT-friendly primes (q ≡ 1 mod 2N) for N=4096; the same
+    // constants are used by test_basis_convert.cpp.
     constexpr uint64_t kQ0 = 576460752303415297ULL;
     constexpr uint64_t kQ1 = 576460752303439873ULL;
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetTwiddleFactors(0, 3) == HAZE_SUCCESS);
-    REQUIRE(hazeSetTwiddleFactors(1, 5) == HAZE_SUCCESS);
-    REQUIRE(hazeSetProgramInfo("my-program", "1.2.3", "experimental run") == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("FHE_SIM") == HAZE_SUCCESS);
-    // No public getters; HAZE_SUCCESS is the only assertion. The
-    // companion "rejects ..." TEST_CASEs cover the validation gates.
+    const uint64_t moduli[] = {kQ0, kQ1};
+    const uint64_t twiddle[] = {3, 5};
+    const hazeFheParams fhe = {.ring_dim = 4096,
+                               .moduli = moduli,
+                               .moduli_count = 2,
+                               .twiddle_generators = twiddle,
+                               .twiddle_count = 2};
+    const hazeReplayConfig replay = {.target = "FHE_SIM",
+                                     .program_name = "my-program",
+                                     .program_version = "1.2.3",
+                                     .program_description = "experimental run"};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    // No public getters; HAZE_SUCCESS is the only assertion. The "rejects ..."
+    // cases below cover the validation gates.
 }
 
-TEST_CASE("hazeSetRingDimension rejects unsupported dimensions", "[unit]") {
+TEST_CASE("hazeConfigureDevice accepts every supported ring dimension", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(0) == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeSetRingDimension(3000) == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeSetRingDimension(5000) == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeSetRingDimension(100) == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
+    for (uint64_t n : {4096ULL, 8192ULL, 16384ULL, 32768ULL, 65536ULL}) {
+        const hazeFheParams fhe = {.ring_dim = n};
+        REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+    }
 }
 
-TEST_CASE("hazeSetCiphertextModulus rejects negative index", "[unit]") {
+TEST_CASE("hazeConfigureDevice defaults the replay config when null", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(-1, 1) == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
+    const hazeFheParams fhe = {.ring_dim = 4096};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeSetCiphertextModulus rejects zero modulus", "[unit]") {
+TEST_CASE("hazeConfigureDevice rejects a null hazeFheParams", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, 0) == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-}
-
-TEST_CASE("hazeSetTwiddleFactors rejects negative index", "[unit]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTwiddleFactors(-1, 3) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeConfigureDevice(nullptr, nullptr) == HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
 }
 
-TEST_CASE("hazeConfigureDevice fails without ring dimension", "[unit]") {
+TEST_CASE("hazeConfigureDevice rejects a null moduli array with a non-zero count", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_ERROR_CONFIGERR);
+    const hazeFheParams fhe = {.ring_dim = 4096, .moduli = nullptr, .moduli_count = 2};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
+}
+
+TEST_CASE("hazeConfigureDevice rejects unsupported ring dimensions", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    // 0 (unset), and non-power-of-two / out-of-envelope values.
+    for (uint64_t n : {0ULL, 100ULL, 3000ULL, 5000ULL}) {
+        const hazeFheParams fhe = {.ring_dim = n};
+        REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_ERROR_INVALID_VALUE);
+        REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
+    }
+}
+
+TEST_CASE("hazeConfigureDevice rejects a zero modulus", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {12289, 0};
+    const hazeFheParams fhe = {.ring_dim = 4096, .moduli = moduli, .moduli_count = 2};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
+}
+
+TEST_CASE("hazeConfigureDevice rejects too many ciphertext moduli", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    // One past the device envelope (hazeDeviceProp::maxCiphertextModuli == 64);
+    // all distinct and non-zero, so only the count trips the rejection.
+    std::vector<uint64_t> moduli(65);
+    for (std::size_t i = 0; i < moduli.size(); ++i)
+        moduli[i] = 12289 + (i * 2);
+    const hazeFheParams fhe = {
+        .ring_dim = 4096, .moduli = moduli.data(), .moduli_count = moduli.size()};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
+}
+
+TEST_CASE("hazeConfigureDevice rejects duplicate ciphertext moduli", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t dup[] = {12289, 12289};
+    const hazeFheParams bad = {.ring_dim = 4096, .moduli = dup, .moduli_count = 2};
+    // Each modulus is per-slot valid but collides on the whole-config uniqueness
+    // check, which lives in build().
+    REQUIRE(hazeConfigureDevice(&bad, nullptr) == HAZE_ERROR_CONFIGERR);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_CONFIGERR);
+    // Nothing is installed on failure, so a corrected config configures cleanly.
+    const uint64_t ok[] = {12289, 40961};
+    const hazeFheParams good = {.ring_dim = 4096, .moduli = ok, .moduli_count = 2};
+    REQUIRE(hazeConfigureDevice(&good, nullptr) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeConfigureDevice succeeds when ring dimension is set", "[unit]") {
+TEST_CASE("hazeDeviceReset re-permits configuration", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
-}
-
-TEST_CASE("hazeSetProgramInfo rejects null arguments", "[unit]") {
+    const hazeFheParams fhe = {.ring_dim = 4096};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetProgramInfo(nullptr, "1.0", "desc") == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeSetProgramInfo("name", nullptr, "desc") == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeSetProgramInfo("name", "1.0", nullptr) == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-}
-
-TEST_CASE("hazeSetTarget rejects null", "[unit]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget(nullptr) == HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_INVALID_VALUE);
-}
-
-TEST_CASE("hazeDeviceReset returns success and re-permits configuration", "[unit]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    // After reset, configure_device should fail again until ring_dim re-set.
-    REQUIRE(hazeConfigureDevice() == HAZE_ERROR_CONFIGERR);
-    REQUIRE(hazeGetLastError() == HAZE_ERROR_CONFIGERR);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
+    // After reset a fresh configure still succeeds.
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 }

--- a/test/test_d2d_copy.cpp
+++ b/test/test_d2d_copy.cpp
@@ -76,15 +76,14 @@ TEST_CASE("hazeMemcpy(D2D) copies a residue into an MRP-registered addr", "[inte
     constexpr uint64_t kQ2 = 576460752303702017ULL;
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDimMrp) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDimMrp, .moduli = moduli, .moduli_count = 3};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+    // Bridge pre-init after finalize; the set modulus (kQ0) is trace-authoritative.
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDimMrp, kQ0, &picked) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, picked) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
-    const std::vector<uint64_t> base = {picked, kQ1, kQ2};
+    const std::vector<uint64_t> base = {kQ0, kQ1, kQ2};
     std::vector<std::vector<uint64_t>> src_residues = {
         haze::test::make_residue(picked, /*seed=*/1, kRingDimMrp),
         haze::test::make_residue(kQ1, /*seed=*/2, kRingDimMrp),

--- a/test/test_hardware_format.cpp
+++ b/test/test_hardware_format.cpp
@@ -22,7 +22,6 @@
 // resolution rules, the local-target rejection, and record-time trace /
 // replay-JSON / captured-input assertions via hazeWriteProgram().
 
-#include "core/config.hpp"
 #include "integration_helpers.hpp"
 #include "mod_arith_ref.hpp"
 
@@ -136,18 +135,25 @@ class EnvGuard {
     std::vector<std::pair<bool, std::string>> saved_;
 };
 
-// Record one scalar-multiply (and optionally a mod-down) into a uniquely
-// named program dir with the current data-format settings, then write
-// the project without replaying. Returns the program directory.
-std::filesystem::path record_program(const std::string &program_name, bool with_mod_down) {
-    REQUIRE(hazeSetProgramInfo(program_name.c_str(), "0.1", "data-format test") == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+// Record one scalar-multiply (and optionally a mod-down) into a uniquely named
+// program dir under the given target + data-format settings (one-shot config),
+// then write the project without replaying. Returns the program directory. The
+// caller has already reset the device.
+std::filesystem::path record_program(const std::string &program_name, bool with_mod_down,
+                                     const char *target, bool montgomery, bool bit_reversal,
+                                     bool reduced_noise) {
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = target,
+                                     .program_name = program_name.c_str(),
+                                     .program_version = "0.1",
+                                     .program_description = "data-format test",
+                                     .montgomery = montgomery ? 1 : 0,
+                                     .bit_reversal = bit_reversal ? 1 : 0,
+                                     .reduced_noise = reduced_noise ? 1 : 0};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     std::vector<uint64_t> vals(kRingDim);
     for (uint64_t i = 0; i < kRingDim; ++i)
@@ -276,66 +282,60 @@ TEST_CASE("mod_arith: switchmodulus immediates (ordinary and montgomery)", "[uni
     }
 }
 
-TEST_CASE("data format config: explicit setters, default off, reset clears", "[unit][hwfmt]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-
-    // Default: both off.
-    REQUIRE_FALSE(haze::config().montgomery());
-    REQUIRE_FALSE(haze::config().bit_reversal());
-
-    // Each flag is set independently via its explicit setter.
-    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
-    REQUIRE(haze::config().montgomery());
-    REQUIRE_FALSE(haze::config().bit_reversal());
-    REQUIRE(hazeSetBitReversal(1) == HAZE_SUCCESS);
-    REQUIRE(haze::config().bit_reversal());
-
-    // A setter turns its flag back off without touching the other.
-    REQUIRE(hazeSetMontgomery(0) == HAZE_SUCCESS);
-    REQUIRE_FALSE(haze::config().montgomery());
-    REQUIRE(haze::config().bit_reversal()); // untouched
-
-    // Reset restores both to the default.
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE_FALSE(haze::config().montgomery());
-    REQUIRE_FALSE(haze::config().bit_reversal());
-}
-
-TEST_CASE("data format on local target is rejected at flush", "[unit][hwfmt]") {
+TEST_CASE("data format on local target is rejected at bring-up", "[unit][hwfmt]") {
     EnvGuard guard({"HAZE_MONTGOMERY", "HAZE_BIT_REVERSAL"});
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    // make test-unit exports HAZE_TARGET=local; pin it programmatically so
-    // the case also holds when run standalone.
-    REQUIRE(hazeSetTarget("local") == HAZE_SUCCESS);
-    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetBitReversal(1) == HAZE_SUCCESS);
+    // make test-unit exports HAZE_TARGET=local; pin target="local" in the config
+    // so the case also holds when run standalone. The format is a valid config
+    // (configure succeeds); its incompatibility with the local simulator is an
+    // execution-time check at bring-up.
+    const hazeFheParams fhe = {.ring_dim = kRingDim};
+    const hazeReplayConfig replay = {.target = "local", .montgomery = 1, .bit_reversal = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
 
-    REQUIRE(hazeFlush() == HAZE_ERROR_NOT_SUPPORTED);
+    void *a = nullptr;
+    void *b = nullptr;
+    REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&b, kBytes) == HAZE_SUCCESS);
+    std::vector<uint64_t> data(kRingDim, 5);
+    // First H2D attempts backend bring-up; montgomery/bit-reversal on the local
+    // simulator refuses it, so the first compute op surfaces NOT_SUPPORTED.
+    REQUIRE(hazeMemcpy(a, data.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeMulScalar(b, a, 3, 0, nullptr) == HAZE_ERROR_NOT_SUPPORTED);
     REQUIRE(hazeGetLastError() == HAZE_ERROR_NOT_SUPPORTED);
 
-    // Turning the format off restores normal local operation.
-    REQUIRE(hazeSetMontgomery(0) == HAZE_SUCCESS);
-    REQUIRE(hazeSetBitReversal(0) == HAZE_SUCCESS);
-    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+    REQUIRE(hazeFree(a) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(b) == HAZE_SUCCESS);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
 
-TEST_CASE("data format rejected at flush keeps the in-flight recording", "[integration][hwfmt]") {
-    // The flush guard early-returns before replay_and_populate, leaving the
-    // epoch open. After the config is corrected the same recording must still
-    // materialize — the op is not silently dropped. Pinned local so the
-    // rejection fires regardless of the harness target.
+TEST_CASE("montgomery+local refusal leaves a clean slate; reset recovers", "[integration][hwfmt]") {
+    // A refused bring-up (montgomery on the local simulator) must not corrupt
+    // state: after hazeDeviceReset a normal computation records and materializes.
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    uint64_t picked = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, picked) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("local") == HAZE_SUCCESS);
+    {
+        const hazeFheParams fhe = {.ring_dim = kRingDim};
+        const hazeReplayConfig replay = {.target = "local", .montgomery = 1};
+        REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    }
+    {
+        void *a = nullptr;
+        void *b = nullptr;
+        REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
+        REQUIRE(hazeMalloc(&b, kBytes) == HAZE_SUCCESS);
+        std::vector<uint64_t> junk(kRingDim, 1);
+        REQUIRE(hazeMemcpy(a, junk.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+        REQUIRE(hazeMulScalar(b, a, 3, 0, nullptr) == HAZE_ERROR_NOT_SUPPORTED);
+        hazeGetLastError();
+        REQUIRE(hazeFree(a) == HAZE_SUCCESS);
+        REQUIRE(hazeFree(b) == HAZE_SUCCESS);
+    }
 
+    // Recover: a valid montgomery-off configuration records and replays correctly.
+    const uint64_t modulus = haze::test::setup_integration_compute_config(kRingDim, kQ0);
     std::vector<uint64_t> vals(kRingDim);
     for (uint64_t i = 0; i < kRingDim; ++i)
-        vals[i] = (i * 3 + 1) % picked;
+        vals[i] = (i * 3 + 1) % modulus;
     void *src = nullptr;
     void *dst = nullptr;
     REQUIRE(hazeMalloc(&src, kBytes) == HAZE_SUCCESS);
@@ -343,24 +343,16 @@ TEST_CASE("data format rejected at flush keeps the in-flight recording", "[integ
     REQUIRE(hazeMemcpy(src, vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
     REQUIRE(hazeMulScalar(dst, src, 3, 0, nullptr) == HAZE_SUCCESS);
     REQUIRE(hazeTagOutput(dst) == HAZE_SUCCESS);
-
-    // Enable the data format and flush: rejected on the local target.
-    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetBitReversal(1) == HAZE_SUCCESS);
-    REQUIRE(hazeFlush() == HAZE_ERROR_NOT_SUPPORTED);
-
-    // Correct the config; the same recorded op now materializes.
-    REQUIRE(hazeSetMontgomery(0) == HAZE_SUCCESS);
-    REQUIRE(hazeSetBitReversal(0) == HAZE_SUCCESS);
     REQUIRE(hazeFlush() == HAZE_SUCCESS);
 
     std::vector<uint64_t> out(kRingDim, 0);
     REQUIRE(hazeMemcpy(out.data(), dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
     for (uint64_t k = 0; k < kRingDim; ++k) {
         INFO("slot " << k);
-        REQUIRE(out[k] == niobium::mod_arith::mulmod(vals[k], 3, picked));
+        REQUIRE(out[k] == niobium::mod_arith::mulmod(vals[k], 3, modulus));
     }
-
+    REQUIRE(hazeFree(src) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(dst) == HAZE_SUCCESS);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
 
@@ -368,14 +360,11 @@ TEST_CASE("record-time: recording stays ordinary-form with switchmodulus markers
           "[unit][hwfmt]") {
     EnvGuard guard({"HAZE_MONTGOMERY", "HAZE_BIT_REVERSAL"});
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("FUNC_SIM") == HAZE_SUCCESS);
-    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetBitReversal(1) == HAZE_SUCCESS);
     // The mod-down's centered rebase (the 4-op switchmodulus block) is the
-    // reduced-noise FBC variant, so enable it explicitly.
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
-
-    const auto dir = record_program("haze_hwfmt_on", /*with_mod_down=*/true);
+    // reduced-noise FBC variant, so enable it too.
+    const auto dir = record_program("haze_hwfmt_on", /*with_mod_down=*/true, /*target=*/"FUNC_SIM",
+                                    /*montgomery=*/true, /*bit_reversal=*/true,
+                                    /*reduced_noise=*/true);
 
     // Client traces are ordinary-form even with the data format on:
     // encoding (input data, immediates, switchmodulus substitution)
@@ -453,9 +442,11 @@ TEST_CASE("store_input_element keeps values ordinary under the data format", "[u
 TEST_CASE("record-time: modes off leaves trace and JSON in ordinary form", "[unit][hwfmt]") {
     EnvGuard guard({"HAZE_MONTGOMERY", "HAZE_BIT_REVERSAL"});
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("FUNC_SIM") == HAZE_SUCCESS);
 
-    const auto dir = record_program("haze_hwfmt_off", /*with_mod_down=*/false);
+    const auto dir =
+        record_program("haze_hwfmt_off", /*with_mod_down=*/false, /*target=*/"FUNC_SIM",
+                       /*montgomery=*/false, /*bit_reversal=*/false,
+                       /*reduced_noise=*/false);
 
     // The scalar immediate appears verbatim and its Montgomery encoding
     // does not — identical to the toggles-on case, since recordings are
@@ -488,22 +479,27 @@ bool transport_target_active() {
     return target != nullptr && target[0] != '\0' && std::string_view{target} != "local";
 }
 
-// Record a fixed mixed computation (elementwise ops + mod-down) with the
-// current format settings under a unique program name, flush through the
-// transport, and return the D2H output vectors (sum, prod, scaled, down).
-std::vector<std::vector<uint64_t>> run_mixed_computation(bool with_mod_down) {
+// Record a fixed mixed computation (elementwise ops + mod-down) under the given
+// target + data-format settings (one-shot config) in the default shared "haze"
+// program dir, flush through the transport, and return the D2H output vectors
+// (sum, prod, scaled, down). The caller has already reset the device.
+std::vector<std::vector<uint64_t>> run_mixed_computation(bool with_mod_down, const char *target,
+                                                         bool montgomery, bool bit_reversal,
+                                                         bool reduced_noise) {
     // Use the default shared "haze" program dir: the replay bridge plants
     // program_name "haze" at init and writes cryptocontext.dat there, so a
     // per-test rename would strand the crypto context the transport driver
     // needs for probe serialization. hazeDeviceReset between cases keeps the
     // shared dir clean (same pattern as the rest of the integration suite).
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = target,
+                                     .montgomery = montgomery ? 1 : 0,
+                                     .bit_reversal = bit_reversal ? 1 : 0,
+                                     .reduced_noise = reduced_noise ? 1 : 0};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     const std::vector<uint64_t> a = haze::test::make_residue(kQ0, 101, kRingDim);
     const std::vector<uint64_t> b = haze::test::make_residue(kQ0, 202, kRingDim);
@@ -571,11 +567,10 @@ TEST_CASE("data-format transport: elementwise results byte-exact vs plain oracle
         SKIP("data format requires a transport target (run under make test-transport)");
     EnvGuard guard({"HAZE_MONTGOMERY", "HAZE_BIT_REVERSAL"});
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    haze::test::apply_target_from_env();
-    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetBitReversal(1) == HAZE_SUCCESS);
 
-    const auto results = run_mixed_computation(/*with_mod_down=*/false);
+    const auto results = run_mixed_computation(/*with_mod_down=*/false,
+                                               haze::test::target_from_env(), /*montgomery=*/true,
+                                               /*bit_reversal=*/true, /*reduced_noise=*/false);
 
     // Plain (ordinary-form) oracles — the replay engine decodes the
     // Montgomery/bit-reversed outputs back, so the data format must be
@@ -603,16 +598,15 @@ TEST_CASE("data-format transport: A/B byte-exact vs ordinary mode", "[integratio
     // internal representation, so the full output vectors (including the
     // FBC/mod-down path) must compare byte-for-byte equal.
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    haze::test::apply_target_from_env();
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
-    const auto ordinary = run_mixed_computation(/*with_mod_down=*/true);
+    const auto ordinary = run_mixed_computation(/*with_mod_down=*/true,
+                                                haze::test::target_from_env(), /*montgomery=*/false,
+                                                /*bit_reversal=*/false, /*reduced_noise=*/true);
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    haze::test::apply_target_from_env();
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetBitReversal(1) == HAZE_SUCCESS);
-    const auto encoded = run_mixed_computation(/*with_mod_down=*/true);
+    const auto encoded =
+        run_mixed_computation(/*with_mod_down=*/true, haze::test::target_from_env(),
+                              /*montgomery=*/true, /*bit_reversal=*/true,
+                              /*reduced_noise=*/true);
 
     REQUIRE(ordinary.size() == encoded.size());
     for (size_t i = 0; i < ordinary.size(); ++i) {
@@ -645,12 +639,15 @@ TEST_CASE("data-format transport: NTT round trip and automorph under data format
     // modulus-carrying path; the bare SRP hazeAutomorph is modulus-less, so
     // its output template keeps the bridge's synthetic prime and cannot be
     // probe-filled under the data format).
-    auto run_ntt = [&]() {
-        REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    auto run_ntt = [&](const char *target, bool montgomery, bool bit_reversal) {
+        const uint64_t moduli[] = {kQ0};
+        const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+        const hazeReplayConfig replay = {.target = target,
+                                         .montgomery = montgomery ? 1 : 0,
+                                         .bit_reversal = bit_reversal ? 1 : 0};
+        REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
         uint64_t picked = 0;
         REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
-        REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-        REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
         const std::vector<uint64_t> a = haze::test::make_residue(kQ0, 404, kRingDim);
         void *src = nullptr;
@@ -686,13 +683,11 @@ TEST_CASE("data-format transport: NTT round trip and automorph under data format
     };
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    haze::test::apply_target_from_env();
-    const auto ordinary = run_ntt();
+    const auto ordinary = run_ntt(haze::test::target_from_env(), /*montgomery=*/false,
+                                  /*bit_reversal=*/false);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    haze::test::apply_target_from_env();
-    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetBitReversal(1) == HAZE_SUCCESS);
-    const auto encoded = run_ntt();
+    const auto encoded = run_ntt(haze::test::target_from_env(), /*montgomery=*/true,
+                                 /*bit_reversal=*/true);
     for (size_t i = 0; i < ordinary.size(); ++i) {
         INFO("output " << i);
         REQUIRE(ordinary[i] == encoded[i]);
@@ -708,14 +703,14 @@ TEST_CASE("data-format transport: NTT round trip and automorph under data format
 TEST_CASE("trace modulus is authoritative over the bridge's scaffold prime",
           "[integration][modulus]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ1};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
     // The only prerequisite: the scaffold prime sits below the trace prime, so
     // the wrap window [picked, kQ1) used below is non-empty (and picked != kQ1).
     REQUIRE(picked < kQ1);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ1) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     // a = kQ1 - 7, b = 11  =>  a + b = kQ1 + 4.
     //   mod kQ1    = 4              (trace authoritative)
@@ -757,12 +752,12 @@ TEST_CASE("trace modulus is authoritative over the bridge's scaffold prime",
 TEST_CASE("input residues above the scaffold prime survive .bin synthesis",
           "[integration][modulus]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
     REQUIRE(picked < kQ0); // the wrap window [picked, kQ0) below relies on it
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     // Seed the wrap window: values that exceed the scaffold prime but are
     // valid mod the trace prime. A scalar-mul by 1 is the identity, so each

--- a/test/test_invariant_regressions.cpp
+++ b/test/test_invariant_regressions.cpp
@@ -29,9 +29,8 @@ constexpr uint64_t kQ0 = 576460752303415297ULL;
 constexpr uint64_t kQ1 = 576460752303439873ULL;
 constexpr uint64_t kQ2 = 576460752303702017ULL;
 
-// A pointer that was never returned by hazeMalloc (still inside the HBM
-// range so it is plausible, not merely null). The int-to-ptr cast is the
-// point of the helper — it fabricates an unknown device handle.
+// A pointer never returned by hazeMalloc but inside the HBM range (plausible, not
+// merely null); the int-to-ptr cast fabricates an unknown device handle.
 void *fake_device_ptr() {
     return reinterpret_cast<void *>( // NOLINT(performance-no-int-to-ptr)
         uintptr_t{0x4000000000ULL} + 0x123400);
@@ -39,7 +38,8 @@ void *fake_device_ptr() {
 
 void unit_setup_4096() {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const hazeFheParams fhe = {.ring_dim = kRingDim};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 }
 
 } // namespace
@@ -50,11 +50,11 @@ void unit_setup_4096() {
 
 TEST_CASE("last error is sticky: successful calls do not clear it", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    // Produce a failure, then a string of successes; the failure must
-    // survive until hazeGetLastError reads-and-clears it (CUDA parity —
-    // previously any success through set_internal_result wiped it).
+    // A failure must survive a string of successes until hazeGetLastError
+    // reads-and-clears it (CUDA parity; previously any success wiped it).
     REQUIRE(hazeStreamBeginCapture(nullptr) == HAZE_ERROR_NOT_SUPPORTED);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const hazeFheParams fhe = {.ring_dim = kRingDim};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
     void *p = nullptr;
     REQUIRE(hazeMalloc(&p, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeFree(p) == HAZE_SUCCESS);
@@ -66,52 +66,73 @@ TEST_CASE("last error is sticky: successful calls do not clear it", "[unit]") {
 // Ring-dimension envelope and freeze rules.
 // ---------------------------------------------------------------------------
 
-TEST_CASE("hazeSetRingDimension rejects out-of-envelope powers of two", "[unit]") {
+TEST_CASE("hazeConfigureDevice rejects out-of-envelope ring dimensions", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     // Below the device envelope (2^10 .. 2^16).
-    REQUIRE(hazeSetRingDimension(512) == HAZE_ERROR_INVALID_VALUE);
+    const hazeFheParams too_small = {.ring_dim = 512};
+    REQUIRE(hazeConfigureDevice(&too_small, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
     // Above the envelope; 2^61+ used to wrap n * sizeof(uint64_t) to 0 and
     // report success with a poisoned configuration.
-    REQUIRE(hazeSetRingDimension(uint64_t{1} << 17) == HAZE_ERROR_INVALID_VALUE);
+    const hazeFheParams too_big = {.ring_dim = uint64_t{1} << 17};
+    REQUIRE(hazeConfigureDevice(&too_big, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
-    REQUIRE(hazeSetRingDimension(uint64_t{1} << 62) == HAZE_ERROR_INVALID_VALUE);
+    const hazeFheParams wrap = {.ring_dim = uint64_t{1} << 62};
+    REQUIRE(hazeConfigureDevice(&wrap, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
     // The envelope bounds themselves are accepted.
-    REQUIRE(hazeSetRingDimension(uint64_t{1} << 10) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(uint64_t{1} << 16) == HAZE_SUCCESS);
+    const hazeFheParams lo = {.ring_dim = uint64_t{1} << 10};
+    REQUIRE(hazeConfigureDevice(&lo, nullptr) == HAZE_SUCCESS);
+    const hazeFheParams hi = {.ring_dim = uint64_t{1} << 16};
+    REQUIRE(hazeConfigureDevice(&hi, nullptr) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeSetRingDimension is frozen while allocations are live", "[unit]") {
+TEST_CASE("hazeConfigureDevice cannot change the ring dimension while allocations are live",
+          "[unit]") {
     unit_setup_4096();
     void *p = nullptr;
     REQUIRE(hazeMalloc(&p, kBytes) == HAZE_SUCCESS);
     // A different dimension would leave p's shadow sized under the old one
     // (previously a heap overread on the next D2H).
-    REQUIRE(hazeSetRingDimension(8192) == HAZE_ERROR_CONFIGERR);
+    const hazeFheParams grow = {.ring_dim = 8192};
+    REQUIRE(hazeConfigureDevice(&grow, nullptr) == HAZE_ERROR_CONFIGERR);
     hazeGetLastError();
-    // Re-setting the same value stays a no-op success.
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    // Reconfiguring the same dimension stays a success.
+    const hazeFheParams same = {.ring_dim = kRingDim};
+    REQUIRE(hazeConfigureDevice(&same, nullptr) == HAZE_SUCCESS);
     REQUIRE(hazeFree(p) == HAZE_SUCCESS);
     // With nothing live the dimension is changeable again.
-    REQUIRE(hazeSetRingDimension(8192) == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice(&grow, nullptr) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeSetTarget after backend bring-up is rejected", "[unit]") {
-    unit_setup_4096();
-    void *p = nullptr;
-    REQUIRE(hazeMalloc(&p, kBytes) == HAZE_SUCCESS);
-    // First H2D brings up the compiler backend with the current target.
+TEST_CASE("hazeConfigureDevice after bring-up is rejected", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    const hazeReplayConfig local = {.target = "local"};
+    REQUIRE(hazeConfigureDevice(&fhe, &local) == HAZE_SUCCESS);
+    void *a = nullptr;
+    void *b = nullptr;
+    void *c = nullptr;
+    REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&b, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&c, kBytes) == HAZE_SUCCESS);
     std::vector<uint64_t> data(kRingDim, 7);
-    REQUIRE(hazeMemcpy(p, data.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
-    // The target can no longer take effect; previously this was silently
-    // ignored and replay ran against the stale baked-in target.
-    REQUIRE(hazeSetTarget("FUNC_SIM") == HAZE_ERROR_CONFIGERR);
+    REQUIRE(hazeMemcpy(a, data.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(b, data.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    // The first compute brings the backend up, latching the config.
+    REQUIRE(hazeAdd(c, a, b, 0, nullptr) == HAZE_SUCCESS);
+    // A reconfigure could no longer take effect (backend already up); previously
+    // a stale target here silently replayed against the baked-in one.
+    const hazeReplayConfig other = {.target = "FUNC_SIM"};
+    REQUIRE(hazeConfigureDevice(&fhe, &other) == HAZE_ERROR_CONFIGERR);
     hazeGetLastError();
-    REQUIRE(hazeFree(p) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(a) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(b) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(c) == HAZE_SUCCESS);
     // hazeDeviceReset re-opens the window.
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("local") == HAZE_SUCCESS);
+    REQUIRE(hazeConfigureDevice(&fhe, &local) == HAZE_SUCCESS);
 }
 
 // ---------------------------------------------------------------------------
@@ -202,9 +223,9 @@ TEST_CASE("hazeMemcpy(D2D) validates dst liveness and count", "[unit]") {
 TEST_CASE("montgomery on local target fails at first compute; shadow round-trips survive",
           "[unit][hwfmt]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("local") == HAZE_SUCCESS);
-    REQUIRE(hazeSetMontgomery(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const hazeFheParams fhe = {.ring_dim = kRingDim};
+    const hazeReplayConfig replay = {.target = "local", .montgomery = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
 
     void *a = nullptr;
     void *b = nullptr;
@@ -217,9 +238,9 @@ TEST_CASE("montgomery on local target fails at first compute; shadow round-trips
     std::vector<uint64_t> data(kRingDim, 9);
     REQUIRE(hazeMemcpy(a, data.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(b, data.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
-    // ...but compute must fail loudly (haze.h: the first compute or flush
-    // reports NOT_SUPPORTED). Previously it returned HAZE_SUCCESS while the
-    // op was silently dropped.
+    // ...but compute must fail loudly (haze.h: first compute or flush reports
+    // NOT_SUPPORTED); previously it returned HAZE_SUCCESS and silently dropped the
+    // op.
     REQUIRE(hazeAdd(c, a, b, 0, nullptr) == HAZE_ERROR_NOT_SUPPORTED);
     hazeGetLastError();
     // The compute-free D2H round-trip still works.
@@ -342,10 +363,9 @@ TEST_CASE("untagged flush is a true no-op: recording and bindings survive", "[in
     auto dst = haze::test::allocate_dst_residues(1, kBytes);
     REQUIRE(hazeAdd(dst[0], devs[0], devs[1], 0, nullptr) == HAZE_SUCCESS);
 
-    // Nothing tagged: this must not tear down the in-flight recording.
-    // Previously it half-cleared haze state (tagging dst afterwards failed
-    // with SOURCE_UNAVAILABLE) while the vendor recorder kept the old nodes,
-    // contaminating the next epoch's trace.
+    // Nothing tagged: this must not tear down the in-flight recording. Previously
+    // it half-cleared haze state (a later tag failed with SOURCE_UNAVAILABLE)
+    // while the vendor recorder kept the old nodes, contaminating the next epoch.
     REQUIRE(hazeFlush() == HAZE_SUCCESS);
 
     REQUIRE(hazeTagOutput(dst[0]) == HAZE_SUCCESS);
@@ -424,15 +444,16 @@ TEST_CASE("bridge honors a custom program name for cryptocontext.dat", "[integra
     // program name orphaned cryptocontext.dat under cwd/haze/ while the
     // trace landed in cwd/<name>/ — replay then found no crypto context.
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    haze::test::apply_target_from_env();
-    REQUIRE(hazeSetReducedNoise(1) == HAZE_SUCCESS);
-    REQUIRE(hazeSetProgramInfo("haze_custom_prog_review", "0.0", "invariant-review case") ==
-            HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    const hazeReplayConfig replay = {.target = haze::test::target_from_env(),
+                                     .program_name = "haze_custom_prog_review",
+                                     .program_version = "0.0",
+                                     .program_description = "invariant-review case",
+                                     .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t scaffold = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     const uint64_t q = kQ0;
     auto a = haze::test::make_residue(q, 11, kRingDim);
@@ -462,9 +483,10 @@ TEST_CASE("failed materialize clears the epoch: retag fails, next flush is a no-
     // every environment (spawn failure without a compiler; unknown-target
     // error with one), exercising the materialize error path end to end.
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetTarget("HAZE_TEST_NO_SUCH_TARGET") == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
-    REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    const hazeReplayConfig replay = {.target = "HAZE_TEST_NO_SUCH_TARGET"};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
 
     void *a = nullptr;
     void *b = nullptr;
@@ -520,4 +542,40 @@ TEST_CASE("hazeDeviceReset restarts stream/event ids and the active device", "[u
     int dev = -1;
     REQUIRE(hazeGetDevice(&dev) == HAZE_SUCCESS);
     REQUIRE(dev == 0);
+}
+
+TEST_CASE("ciphertext-modulus count is bounded by the device envelope", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    hazeDeviceProp prop{};
+    REQUIRE(hazeGetDeviceProperties(&prop, 0) == HAZE_SUCCESS);
+    const auto max = static_cast<std::size_t>(prop.maxCiphertextModuli);
+    std::vector<uint64_t> moduli(max + 1);
+    for (std::size_t i = 0; i < moduli.size(); ++i)
+        moduli[i] = kQ0 + (2 * i);
+
+    // Exactly `max` distinct primes configure cleanly...
+    const hazeFheParams full = {.ring_dim = kRingDim, .moduli = moduli.data(), .moduli_count = max};
+    REQUIRE(hazeConfigureDevice(&full, nullptr) == HAZE_SUCCESS);
+    // ...and one past the envelope is rejected (previously an unbounded vector
+    // grew; now it guards a fixed array).
+    const hazeFheParams over = {
+        .ring_dim = kRingDim, .moduli = moduli.data(), .moduli_count = max + 1};
+    REQUIRE(hazeConfigureDevice(&over, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("bridge pre-init requires an explicit configure", "[unit][hwfmt]") {
+    // The bridge pre-init reads the frozen replay config via bootstrap_compiler,
+    // so it must run after hazeConfigureDevice(); calling it earlier is rejected.
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_ERROR_CONFIGERR);
+    hazeGetLastError();
+    // After the explicit configure it succeeds.
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }

--- a/test/test_memory.cpp
+++ b/test/test_memory.cpp
@@ -14,12 +14,21 @@
 
 // HAZE's device allocator is single-size: every allocation is one
 // polynomial of (ring_dim * sizeof(uint64_t)) bytes, configured via
-// hazeSetRingDimension. Tests here always set ring_dim before
-// allocating to make that contract explicit.
+// hazeConfigureDevice. Tests here always configure before allocating
+// to make that contract explicit.
+
+namespace {
+// Allocation-only [unit] setup: one-shot configure with just the ring dimension
+// (no moduli or replay config needed to size the single-size allocator).
+void configure_ring_dim(uint64_t ring_dim) {
+    const hazeFheParams fhe = {.ring_dim = ring_dim};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+}
+} // namespace
 
 TEST_CASE("hazeMalloc returns non-null pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *p = nullptr;
     REQUIRE(hazeMalloc(&p, 32768) == HAZE_SUCCESS);
     REQUIRE(p != nullptr);
@@ -32,7 +41,7 @@ TEST_CASE("hazeMalloc null ptr arg returns error", "[unit]") {
     hazeGetLastError();
 }
 
-TEST_CASE("hazeMalloc before hazeSetRingDimension is rejected", "[unit]") {
+TEST_CASE("hazeMalloc before hazeConfigureDevice is rejected", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS); // ensure ring_dim cleared
     void *p = nullptr;
     REQUIRE(hazeMalloc(&p, 32768) == HAZE_ERROR_CONFIGERR);
@@ -41,7 +50,7 @@ TEST_CASE("hazeMalloc before hazeSetRingDimension is rejected", "[unit]") {
 
 TEST_CASE("hazeMalloc with size != polynomial bytes is rejected", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *p = nullptr;
     // ring_dim=4096 → polynomial bytes = 32768; 8KB request fails.
     REQUIRE(hazeMalloc(&p, 8192) == HAZE_ERROR_SIZE_MISMATCH);
@@ -50,7 +59,7 @@ TEST_CASE("hazeMalloc with size != polynomial bytes is rejected", "[unit]") {
 
 TEST_CASE("distinct allocations produce non-overlapping addresses", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *p1 = nullptr;
     void *p2 = nullptr;
     REQUIRE(hazeMalloc(&p1, 32768) == HAZE_SUCCESS);
@@ -62,7 +71,7 @@ TEST_CASE("distinct allocations produce non-overlapping addresses", "[unit]") {
 
 TEST_CASE("free then re-allocate recycles pooled address", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
 
     void *p1 = nullptr;
     REQUIRE(hazeMalloc(&p1, 32768) == HAZE_SUCCESS);
@@ -79,7 +88,7 @@ TEST_CASE("H2D then D2H round-trip preserves data", "[unit]") {
     constexpr size_t kBytes = kN * sizeof(uint64_t);
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kN) == HAZE_SUCCESS);
+    configure_ring_dim(kN);
     void *dev = nullptr;
     REQUIRE(hazeMalloc(&dev, kBytes) == HAZE_SUCCESS);
 
@@ -99,7 +108,7 @@ TEST_CASE("H2D then D2H round-trip preserves data", "[unit]") {
 TEST_CASE("hazeMemset fills shadow buffer", "[unit]") {
     constexpr size_t kBytes = 32768;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *dev = nullptr;
     REQUIRE(hazeMalloc(&dev, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeMemset(dev, 0xAB, kBytes) == HAZE_SUCCESS);
@@ -121,7 +130,7 @@ TEST_CASE("hazeHostAlloc/Free round-trip", "[unit]") {
 
 TEST_CASE("hazeMallocAsync/FreeAsync behave like sync versions", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     hazeStream_t stream = nullptr;
     REQUIRE(hazeStreamCreate(&stream) == HAZE_SUCCESS);
 
@@ -207,7 +216,7 @@ TEST_CASE("NULL stream argument uses default stream", "[unit]") {
 
 TEST_CASE("hazePointerGetAttributes reports device type for hazeMalloc'd pointer", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *dev = nullptr;
     REQUIRE(hazeMalloc(&dev, 32768) == HAZE_SUCCESS);
 
@@ -254,7 +263,7 @@ TEST_CASE("hazeMallocMrp allocates a usable group that hazeFreeMrp releases", "[
     constexpr size_t kBytes = kN * sizeof(uint64_t);
     constexpr size_t kCount = 4;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kN) == HAZE_SUCCESS);
+    configure_ring_dim(kN);
 
     void *ptrs[kCount] = {};
     REQUIRE(hazeMallocMrp(ptrs, kCount, kBytes) == HAZE_SUCCESS);
@@ -281,7 +290,7 @@ TEST_CASE("hazeMallocMrp/hazeFreeMrp round-trip recycles the group", "[unit]") {
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
     constexpr size_t kCount = 3;
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
 
     void *g1[kCount] = {};
     REQUIRE(hazeMallocMrp(g1, kCount, kBytes) == HAZE_SUCCESS);
@@ -297,14 +306,14 @@ TEST_CASE("hazeMallocMrp/hazeFreeMrp round-trip recycles the group", "[unit]") {
 
 TEST_CASE("hazeMallocMrp with count 0 is a success no-op", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *const sentinel = reinterpret_cast<void *>(0x5A5A);
     void *ptrs[1] = {sentinel};
     REQUIRE(hazeMallocMrp(ptrs, 0, 32768) == HAZE_SUCCESS);
     REQUIRE(ptrs[0] == sentinel); // left untouched
 }
 
-TEST_CASE("hazeMallocMrp before hazeSetRingDimension is rejected", "[unit]") {
+TEST_CASE("hazeMallocMrp before hazeConfigureDevice is rejected", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     void *ptrs[2] = {};
     REQUIRE(hazeMallocMrp(ptrs, 2, 32768) == HAZE_ERROR_CONFIGERR);
@@ -313,14 +322,14 @@ TEST_CASE("hazeMallocMrp before hazeSetRingDimension is rejected", "[unit]") {
 
 TEST_CASE("hazeMallocMrp with null ptrs is rejected", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     REQUIRE(hazeMallocMrp(nullptr, 4, 32768) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 }
 
 TEST_CASE("hazeMallocMrp with wrong size is rejected and allocates nothing", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     const auto &alloc = haze::allocator();
     REQUIRE(haze::test::AllocatorTestAccess::alloc_set_size(alloc) == 0);
 
@@ -339,7 +348,7 @@ TEST_CASE("hazeMallocMrp rolls back reserved polys on a mid-batch failure", "[un
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
     auto &alloc = haze::allocator();
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
 
     // p stays live; r is freed so the batch can recycle it as residue 0.
     void *p = nullptr;
@@ -381,7 +390,7 @@ TEST_CASE("hazeFreeMrp with count 0 is a success no-op", "[unit]") {
 TEST_CASE("hazeFreeMrp skips null entries and frees the rest", "[unit]") {
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *a = nullptr;
     void *b = nullptr;
     REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
@@ -406,7 +415,7 @@ TEST_CASE("hazeFreeMrp skips null entries and frees the rest", "[unit]") {
 
 TEST_CASE("hazeMallocMrp rejects an out-of-range count without allocating", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     const auto &alloc = haze::allocator();
     void *ptrs[1] = {reinterpret_cast<void *>(0x1234)};
 
@@ -435,7 +444,7 @@ TEST_CASE("hazeFreeMrp rejects an out-of-range count", "[unit]") {
 TEST_CASE("hazeFree of an already-freed address is rejected", "[unit]") {
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *p = nullptr;
     REQUIRE(hazeMalloc(&p, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeFree(p) == HAZE_SUCCESS);
@@ -446,7 +455,7 @@ TEST_CASE("hazeFree of an already-freed address is rejected", "[unit]") {
 TEST_CASE("malloc after free does not alias a second live allocation", "[unit]") {
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *a = nullptr;
     REQUIRE(hazeMalloc(&a, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeFree(a) == HAZE_SUCCESS);
@@ -462,7 +471,7 @@ TEST_CASE("malloc after free does not alias a second live allocation", "[unit]")
 TEST_CASE("hazeFreeMrp of an already-freed group is rejected and does not alias", "[unit]") {
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *g[1] = {};
     REQUIRE(hazeMallocMrp(g, 1, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeFreeMrp(g, 1) == HAZE_SUCCESS);
@@ -484,7 +493,7 @@ TEST_CASE("hazeFreeMrp frees every entry and returns the first error", "[unit]")
     constexpr size_t kBytes = 4096 * sizeof(uint64_t);
     auto &alloc = haze::allocator();
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(4096) == HAZE_SUCCESS);
+    configure_ring_dim(4096);
     void *a = nullptr;
     void *bad = nullptr;
     void *b = nullptr;

--- a/test/test_mul_rotation.cpp
+++ b/test/test_mul_rotation.cpp
@@ -69,14 +69,12 @@ struct MrpDriver {
 
     uint64_t setup() {
         REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-        REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
+        const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+        const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+        REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
         uint64_t picked = 0;
         REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &picked) == HAZE_SUCCESS);
         REQUIRE(picked != 0);
-        REQUIRE(hazeSetCiphertextModulus(0, kQ0) == HAZE_SUCCESS);
-        REQUIRE(hazeSetCiphertextModulus(1, kQ1) == HAZE_SUCCESS);
-        REQUIRE(hazeSetCiphertextModulus(2, kQ2) == HAZE_SUCCESS);
-        REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
         base = {kQ0, kQ1, kQ2};
         return kQ0;
     }

--- a/test/test_replay_bridge_program_dir.cpp
+++ b/test/test_replay_bridge_program_dir.cpp
@@ -17,11 +17,11 @@
 // project doesn't land under the "niobium_trace" default). set_program_info()
 // also resets the project directory to cwd/<name>. A library integrator (e.g.
 // FIDESlib's HazeEngine) pins a custom project directory via
-// hazeSetProgramDirectory() BEFORE calling the bridge; if the bridge's rename
-// resets it, cryptocontext.dat is written under cwd/haze/ while the .fhetch
-// trace lands in the pinned dir. nbcc_fhetch_replay --project=<pinned> then
-// fails with "Cannot load crypto context — skipping probe serialization" and
-// returns no probes, so the transport readback fails.
+// hazeReplayConfig::program_directory BEFORE calling the bridge; if the bridge's
+// rename resets it, cryptocontext.dat is written under cwd/haze/ while the
+// .fhetch trace lands in the pinned dir. nbcc_fhetch_replay --project=<pinned>
+// then fails with "Cannot load crypto context — skipping probe serialization"
+// and returns no probes, so the transport readback fails.
 //
 // The existing suites never set a custom program directory (they use the
 // cwd/<name> default), so cryptocontext.dat and the trace always coincided and
@@ -46,21 +46,22 @@ constexpr uint64_t kQ = 576460752303415297ULL; // standard CKKS test prime
 
 TEST_CASE("replay bridge honors a caller-pinned program directory", "[replay_bridge]") {
     // A project directory that is NOT the cwd/<program_name> default — exactly
-    // what a library integrator pins via hazeSetProgramDirectory().
+    // what a library integrator pins via hazeReplayConfig::program_directory.
     const fs::path pinned = fs::temp_directory_path() / "haze_replay_bridge_progdir_test";
     std::error_code ec;
     fs::remove_all(pinned, ec);
     REQUIRE(fs::create_directories(pinned, ec));
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kN) == HAZE_SUCCESS);
     // Pin the project directory BEFORE the bridge init, mirroring the HazeEngine
-    // bring-up order (hazeSetProgramDirectory precedes the first compute call).
-    // This stores the directory in haze::config(); the compiler only learns it at
-    // bring-up, so niobium::compiler().get_program_directory() is still the default
-    // here — the bridge init is what must propagate it.
-    REQUIRE(hazeSetProgramDirectory(pinned.c_str()) == HAZE_SUCCESS);
-
+    // bring-up order (the replay config's program_directory precedes the first
+    // compute call). hazeConfigureDevice freezes the directory into the replay
+    // config; the compiler only learns it at bring-up, so
+    // niobium::compiler().get_program_directory() is still the default here — the
+    // bridge init is what must propagate it.
+    const hazeFheParams fhe = {.ring_dim = kN};
+    const hazeReplayConfig replay = {.program_directory = pinned.c_str()};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kN, kQ, &picked) == HAZE_SUCCESS);
     REQUIRE(picked != 0);

--- a/test/test_user_crypto_context.cpp
+++ b/test/test_user_crypto_context.cpp
@@ -35,7 +35,6 @@ TEST_CASE("user CC primes: hazeAddMrp round-trips through FIXEDAUTO", "[integrat
     using namespace lbcrypto;
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(kRingDim) == HAZE_SUCCESS);
 
     // Caller-built CC with a non-default scaling technique (FIXEDAUTO) and a
     // chain deeper than the 3-residue MRP add below, so the primes come from a
@@ -63,12 +62,12 @@ TEST_CASE("user CC primes: hazeAddMrp round-trips through FIXEDAUTO", "[integrat
     for (std::size_t i = 0; i < 3; ++i)
         base.push_back(eparams[i]->GetModulus().ConvertToInt());
 
+    const hazeFheParams fhe = {
+        .ring_dim = kRingDim, .moduli = base.data(), .moduli_count = base.size()};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
     uint64_t picked = 0;
     REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, base.front(), &picked) == HAZE_SUCCESS);
     REQUIRE(picked != 0);
-    for (std::size_t i = 0; i < 3; ++i)
-        REQUIRE(hazeSetCiphertextModulus(static_cast<int>(i), base[i]) == HAZE_SUCCESS);
-    REQUIRE(hazeConfigureDevice() == HAZE_SUCCESS);
 
     // Build per-residue inputs + expected output for hazeAddMrp.
     std::vector<std::vector<uint64_t>> a(3);

--- a/test/test_zero_copy_promotion.cpp
+++ b/test/test_zero_copy_promotion.cpp
@@ -22,7 +22,8 @@ TEST_CASE("zero-copy input promotion: shadow buffer flows into Polynomial withou
     constexpr size_t bytes = ring_dim * sizeof(uint64_t);
 
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    REQUIRE(hazeSetRingDimension(ring_dim) == HAZE_SUCCESS);
+    const hazeFheParams fhe = {.ring_dim = ring_dim};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
     void *dev = nullptr;
     REQUIRE(hazeMalloc(&dev, bytes) == HAZE_SUCCESS);


### PR DESCRIPTION
Ring dimension, the moduli slots (a fixed atomic array bounded by the device envelope), the format toggles, and a target-is-local flag become relaxed atomics: the compute preludes no longer take Config's mutex under the epoch lock, deleting the epoch -> config edge from the lock DAG. The mutex remains for setter freeze-checks and cold string metadata; setter semantics are unchanged except moduli indexes are now bounded by maxCiphertextModuli (INVALID_VALUE beyond it, in both configured and unconfigured states — pinned by a unit test).
