### PR TITLE
refactor(core,bridge): one vendor-compiler bootstrap for both init paths

### DIFF
--- a/replay_bridge/src/openfhe_template.cpp
+++ b/replay_bridge/src/openfhe_template.cpp
@@ -12,7 +12,8 @@
 #include "ciphertext-ser.h"
 #include "common/errors.hpp" // set_error — bridge entries feed hazeGetLastError too
 #include "common/log.hpp"
-#include "core/config.hpp" // haze::replay_config() — honor caller-pinned program name/directory
+#include "core/backend.hpp" // haze::backend().ensure_initialized — one shared vendor bring-up
+#include "core/config.hpp"  // haze::config_finalized — require the frozen config before bootstrap
 #include "cryptocontext-ser.h"
 #include "key/key-ser.h"
 #include "openfhe.h"
@@ -496,57 +497,25 @@ extern "C" hazeError_t hazeReplayBridgeInitCryptoContext(uint64_t ring_dim,
         return set_error(HAZE_ERROR_INVALID_VALUE);
 
     // Configuration must be finalized (hazeConfigureDevice) first; this pre-init
-    // reads the frozen replay config, never the write-only builder.
+    // reads the frozen replay config, never the builder.
     if (!haze::config_finalized())
         return set_error(HAZE_ERROR_CONFIGERR);
-    const haze::ReplayConfig &rc = haze::replay_config();
 
     try {
-        // The record-time capture builds a local OpenFHE context regardless of the
-        // replay target, so disable the compiler's hardware ring-dim/prime checks
-        // here; the compiler enforces hardware compatibility at dispatch. Pass the
-        // configured target too: this pre-init runs before the first compute, so
-        // without it a flush with no compute op would replay against the compiler's
-        // default target instead of the configured one (init() re-applies, so the
-        // backend's first-compute bring-up stays authoritative when it does run).
-        {
-            const std::string target_arg = "--target=" + rc.target();
-            // argv[0] mirrors backend.cpp's bring-up.
-            std::string prog_storage = rc.program_name();
-            std::string target_storage = target_arg;
-            std::string no_ring_check_storage = "--no-ring-dim-check";
-            std::string no_prime_check_storage = "--no-prime-check";
-            char *argv[] = {prog_storage.data(), target_storage.data(),
-                            no_ring_check_storage.data(), no_prime_check_storage.data(), nullptr};
-            int argc = 4;
-            niobium::compiler().init(argc, argv);
-        }
+        // Single shared bring-up: whichever of this pre-init or the first compute
+        // runs first initializes the compiler exactly once (with the real target /
+        // program info / pinned directory / format flags); the other fast-paths on
+        // the initialized flag. Needed here so a compute-free flush still replays
+        // against the configured target and cryptocontext.dat lands in the trace's
+        // program directory.
+        if (auto init = haze::backend().ensure_initialized(); !init)
+            return set_error(haze::to_public_error(init.error()));
 
         auto built = build_context(ring_dim, {desired_modulus});
         if (!built)
             return set_error(to_haze_error(built.error()));
 
         *picked_modulus = first_tower_modulus(built->cc);
-
-        // Use the CONFIGURED program name so cryptocontext.dat lands in the
-        // same directory the trace will (a hard-coded "haze" orphaned it
-        // whenever the app set a custom name).
-        niobium::compiler().set_program_info(rc.program_name(), rc.program_version(),
-                                             rc.program_description());
-
-        // Honor a caller-pinned program directory. hazeSetProgramDirectory()
-        // stores the directory in the replay config; the backend only forwards it to
-        // the compiler at first-compute bring-up (core/backend.cpp), which happens
-        // AFTER this init writes cryptocontext.dat. Without re-applying it here,
-        // set_program_info()'s cwd/<name> reset orphans cryptocontext.dat under
-        // cwd/haze/ while the .fhetch trace lands in the pinned directory — so
-        // nbcc_fhetch_replay --project=<pinned> reports "Cannot load crypto context
-        // — skipping probe serialization" and returns no probes. The haze suites
-        // never pin a directory (cwd/<name> default), so the divergence stayed
-        // hidden until a library integrator (FIDESlib's HazeEngine) pinned a custom
-        // run directory.
-        if (rc.has_program_directory())
-            niobium::compiler().set_program_directory(rc.program_directory());
 
         niobium::compiler().capture_crypto_context(built->cc);
 

--- a/src/common/thread_safety.hpp
+++ b/src/common/thread_safety.hpp
@@ -26,6 +26,21 @@
 // mutexes form a DAG, acquire only along its edges:
 //
 //   EpochState::mutex_ -> DeviceAllocator::mutex_
+//   EpochState::mutex_ -> CompilerBackend::init_mutex_
+//
+// The init_mutex_ edge: first-compute bring-up takes init_mutex_ while holding
+// epoch_mutex_ (EpochState::ensure_recording_locked calls ensure_initialized
+// under the lock). The other two init_mutex_ acquirers hold NO epoch lock — the
+// replay-bridge pre-init (hazeReplayBridgeInitCryptoContext) and hazeDeviceReset,
+// which resets epoch, backend, and allocator sequentially, never nested. This
+// asymmetry cannot deadlock because init_mutex_ is a LEAF: the code holding it
+// (ensure_initialized / bootstrap_compiler) reads only the lock-free config and
+// calls the vendor compiler — never epoch() or allocator() — so no reverse edge
+// exists and the graph stays acyclic. Invariant to preserve: never acquire
+// epoch_mutex_ or the allocator lock while holding init_mutex_. clang TSA does
+// NOT enforce this cross-mutex order (it does no lock-ordering analysis, and
+// init_mutex_ is CompilerBackend-private while ensure_initialized runs both with
+// and without epoch_mutex_ held), so it rests on this contract and review.
 //
 // Config carries no lock. The FHE params and replay config are immutable values
 // built by the single explicit hazeConfigureDevice() (from caller-owned structs,
@@ -36,10 +51,9 @@
 // hazeDeviceReset is not called while compute is in flight. Under that contract
 // the compute path only ever READS the frozen config — never finalizes, never
 // mutates — so it needs no lock or atomics (CompilerBackend::init_mutex_'s
-// acquire/release at bring-up orders the freeze before every compute read).
-// init_mutex_ serializes bring-up but acquires no other lock. The allocator is a
-// leaf: allocator code must not call into any other component while holding its
-// lock; TSAN is the runtime backstop.
+// acquire/release at bring-up orders the freeze before every compute read). The
+// allocator is a leaf: allocator code must not call into any other component
+// while holding its lock; TSAN is the runtime backstop.
 
 // Clang's thread-safety attributes are GNU-style __attribute__((...)), not C++11
 // [[clang::...]]; the macro names mirror the clang TSA documentation spellings.

--- a/src/core/backend.cpp
+++ b/src/core/backend.cpp
@@ -23,23 +23,76 @@
 #include "core/config.hpp"
 
 #include <atomic>
+#include <expected>
 #include <niobium/compiler.h>
 #include <niobium/openfhe/probes.h>
 #include <string>
 
 namespace haze {
 
-bool CompilerBackend::ensure_initialized() noexcept {
+namespace {
+
+// Bring niobium::compiler() up from the frozen ReplayConfig (target, program
+// info, pinned directory, format flags), running the vendor init sequence once.
+// ensure_initialized is the sole caller and owns the idempotence guard, the
+// config-finalized precondition, and the montgomery/local compat check; this may
+// throw (vendor init), and that caller contains it.
+void bootstrap_compiler() {
+    const ReplayConfig &rc = replay_config();
+    const std::string &program_name = rc.program_name();
+    const std::string &program_version = rc.program_version();
+    const std::string &program_description = rc.program_description();
+
+    // Synthesize a minimal argv — compiler().init() exposes no setters; it
+    // copies argv during the call, so function-local storage is safe.
+    std::string prog_storage = program_name;
+    std::string target_arg_storage = "--target=" + rc.target();
+    std::string montgomery_arg_storage = "--montgomery";
+    std::string bitrev_arg_storage = "--bit_reversal";
+    std::string no_ring_check_storage = "--no-ring-dim-check";
+    std::string no_prime_check_storage = "--no-prime-check";
+    // prog + --target + up to two optional format flags + the two always-on skip
+    // flags (--no-ring-dim-check, --no-prime-check) + NULL terminator = 7 slots.
+    char *argv[7] = {prog_storage.data(),
+                     target_arg_storage.data(),
+                     nullptr,
+                     nullptr,
+                     nullptr,
+                     nullptr,
+                     nullptr};
+    int argc = 2;
+    if (rc.montgomery())
+        argv[argc++] = montgomery_arg_storage.data();
+    if (rc.bit_reversal())
+        argv[argc++] = bitrev_arg_storage.data();
+    // Hardware ring-dim/prime compatibility is the compiler's job at
+    // dispatch; the record/replay bridge always skips those checks.
+    argv[argc++] = no_ring_check_storage.data();
+    argv[argc++] = no_prime_check_storage.data();
+    niobium::compiler().init(argc, argv);
+    niobium::compiler().set_program_info(program_name, program_version, program_description);
+    // A pinned output dir must be re-applied after set_program_info (which
+    // resets it to cwd/<name>) and before the first trace write.
+    if (rc.has_program_directory())
+        niobium::compiler().set_program_directory(rc.program_directory());
+}
+
+} // namespace
+
+// Both bring-up sites — first compute and the replay bridge pre-init — call this,
+// so the vendor init runs exactly once per epoch (whichever arrives first); the
+// other fast-paths on initialized_.
+std::expected<void, HazeInternalError> CompilerBackend::ensure_initialized() noexcept {
     // Lock-free fast path for the common case where init has already
     // completed. The acquire load pairs with the release store below so
     // any reads after this point see the fully-initialized state.
     if (initialized_.load(std::memory_order_acquire))
-        return true;
+        return {};
 
     // Slow path: serialize concurrent first callers so init runs once.
     HazeLockGuard lock(init_mutex_);
     if (initialized_.load(std::memory_order_relaxed))
-        return true;
+        return {};
 
     // Configuration must be finalized by an explicit hazeConfigureDevice()
     // first; bring-up only READS the frozen config — it never finalizes, so the
@@ -48,62 +101,23 @@ bool CompilerBackend::ensure_initialized() noexcept {
         record_internal_error(HazeInternalError::NotConfigured,
                               "CompilerBackend::ensure_initialized: hazeConfigureDevice() "
                               "not called before first compute");
-        return false;
+        return std::unexpected(HazeInternalError::NotConfigured);
     }
-    const ReplayConfig &rc = replay_config();
 
     // The local simulator runs ordinary-form traces only; reject the
     // Montgomery / bit-reversal toggles here so the error names the real cause.
-    const bool montgomery = rc.montgomery();
-    const bool bit_reversal = rc.bit_reversal();
-    if ((montgomery || bit_reversal) && rc.target_is_local()) {
+    const ReplayConfig &rc = replay_config();
+    if ((rc.montgomery() || rc.bit_reversal()) && rc.target_is_local()) {
         record_internal_error(HazeInternalError::UnsupportedDataFormat,
                               "CompilerBackend::ensure_initialized (montgomery/bit_reversal "
                               "require a transport target such as FUNC_SIM)");
-        return false;
+        return std::unexpected(HazeInternalError::UnsupportedDataFormat);
     }
 
     // niobium::compiler() can throw (bad_alloc, config errors); catch here
     // so a thrown init becomes BackendInitFailed, not a process termination.
     try {
-        const std::string &program_name = rc.program_name();
-        const std::string &program_version = rc.program_version();
-        const std::string &program_description = rc.program_description();
-
-        // Synthesize a minimal argv to pass --target= (and the Montgomery /
-        // bit-reversal flags) to compiler().init() — no setters are exposed.
-        // init copies argv during the call, so function-local storage is safe.
-        std::string prog_storage = program_name;
-        std::string target_arg_storage = "--target=" + rc.target();
-        std::string montgomery_arg_storage = "--montgomery";
-        std::string bitrev_arg_storage = "--bit_reversal";
-        std::string no_ring_check_storage = "--no-ring-dim-check";
-        std::string no_prime_check_storage = "--no-prime-check";
-        // prog + --target + up to two optional flags + NULL terminator.
-        char *argv[7] = {prog_storage.data(),
-                         target_arg_storage.data(),
-                         nullptr,
-                         nullptr,
-                         nullptr,
-                         nullptr,
-                         nullptr};
-        int argc = 2;
-        if (montgomery)
-            argv[argc++] = montgomery_arg_storage.data();
-        if (bit_reversal)
-            argv[argc++] = bitrev_arg_storage.data();
-        // The haze record/replay-bridge never enforces hardware ring-dim/prime
-        // compatibility (the compiler does at dispatch); always skip those checks.
-        argv[argc++] = no_ring_check_storage.data();
-        argv[argc++] = no_prime_check_storage.data();
-        niobium::compiler().init(argc, argv);
-        niobium::compiler().set_program_info(program_name, program_version, program_description);
-        // Optional explicit output dir: when set via hazeSetProgramDirectory,
-        // the project (.fhetch + inputs + templates + cryptocontext) lands
-        // here instead of cwd/<program_name>. Must precede the first compute
-        // op so it's in effect when stop_recording() writes the trace.
-        if (rc.has_program_directory())
-            niobium::compiler().set_program_directory(rc.program_directory());
+        bootstrap_compiler();
         // haze emits IR via fhetch::sr_* directly, so the OpenFHE-side CPROBE
         // capture path is dead weight; mute it globally. Distinct from
         // openfhe_cprobe_pause_recording, which would also silence sr_*.
@@ -111,11 +125,11 @@ bool CompilerBackend::ensure_initialized() noexcept {
     } catch (...) {
         record_internal_error(HazeInternalError::BackendInitFailed,
                               "CompilerBackend::ensure_initialized");
-        return false;
+        return std::unexpected(HazeInternalError::BackendInitFailed);
     }
 
     initialized_.store(true, std::memory_order_release);
-    return true;
+    return {};
 }
 
 bool CompilerBackend::is_initialized() const noexcept {

--- a/src/core/backend.hpp
+++ b/src/core/backend.hpp
@@ -12,9 +12,11 @@
 // from the Product.
 #pragma once
 
+#include "common/errors.hpp"
 #include "common/thread_safety.hpp"
 
 #include <atomic>
+#include <expected>
 
 namespace haze {
 
@@ -27,10 +29,14 @@ class DeviceState;
 // via whichever library supplies the niobium::compiler() symbol.
 class CompilerBackend {
   public:
-    // Idempotent, concurrency-safe compiler init from the replay config;
-    // false on throw or unsupported config, and the compute preludes'
-    // require_recording_locked gate then surfaces the failure at the ABI.
-    [[nodiscard]] bool ensure_initialized() noexcept;
+    // Idempotent, concurrency-safe compiler bring-up from the frozen replay
+    // config: runs the vendor init exactly once (later callers fast-path on the
+    // initialized_ flag). Both bring-up sites — first compute and the replay
+    // bridge's pre-init — funnel through here, so init happens a single time
+    // regardless of their order. Returns the failure reason so callers map it at
+    // their boundary; the compute preludes also re-surface it via
+    // require_recording_locked.
+    [[nodiscard]] std::expected<void, HazeInternalError> ensure_initialized() noexcept;
 
     // True iff ensure_initialized() has completed successfully.
     bool is_initialized() const noexcept;
@@ -76,13 +82,6 @@ class CompilerBackend {
     std::atomic<bool> initialized_{false};
     HazeMutex init_mutex_;
 };
-
-// One-shot vendor-compiler bootstrap (argv from Config, program info, pinned
-// program dir) shared by first-compute bring-up and the replay bridge's pre-init.
-// Format flags are explicit parameters because vendor init LATCHES them (set-only
-// until reset), so callers pass a guard-approved snapshot; not idempotence-guarded
-// and may throw, so callers contain both.
-void bootstrap_compiler(bool montgomery, bool bit_reversal);
 
 // Defined in device_state.cpp (returns the DeviceState member).
 CompilerBackend &backend() noexcept;

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -35,17 +35,22 @@ namespace haze {
 namespace fhetch = niobium::fhetch;
 
 void EpochState::ensure_recording_locked() {
+    if (recording_)
+        return;
+    // First compute brings the backend up here, under the lock, consuming the
+    // result directly. A failed bring-up leaves recording_ false; the caller's
+    // require_recording_locked() then names the reason at the ABI edge.
+    if (!backend().ensure_initialized())
+        return;
     // start_epoch() precedes start(); on any failure recording_ stays false so
     // require_recording_locked reports it. If start() fails after start_epoch()
     // opened the epoch, drop the partial captured state so a retry starts from a
     // clean registry instead of double-starting the epoch.
-    if (backend().is_initialized() && !recording_) {
-        if (CompilerBackend::start_epoch()) {
-            if (CompilerBackend::start_recording())
-                recording_ = true;
-            else
-                CompilerBackend::clear_captured();
-        }
+    if (CompilerBackend::start_epoch()) {
+        if (CompilerBackend::start_recording())
+            recording_ = true;
+        else
+            CompilerBackend::clear_captured();
     }
 }
 
@@ -357,10 +362,7 @@ void EpochState::reset() noexcept {
     clear_state_locked();
 }
 
-HazeMutex &EpochSession::init_then_get_mutex() noexcept {
-    // Run ensure_initialized() before grabbing the epoch lock so first-call
-    // init doesn't serialize; failure surfaces later via is_initialized().
-    [[maybe_unused]] const bool _ = backend().ensure_initialized();
+HazeMutex &EpochSession::epoch_mutex() noexcept {
     return epoch().mutex_;
 }
 

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -200,13 +200,12 @@ class EpochState {
     friend class EpochSession;
 };
 
-// RAII guard for compute entry points: brings up the backend, takes the
-// epoch mutex, and enters recording mode for the session lifetime.
-// Backend init runs before the lock so concurrent callers don't
-// serialize on the one-time setup.
+// RAII guard for compute entry points: takes the epoch mutex, then on first
+// compute brings the backend up and enters recording mode for the session
+// lifetime (EpochState::ensure_recording_locked, under the lock).
 class HAZE_SCOPED_CAPABILITY EpochSession {
   public:
-    EpochSession() HAZE_ACQUIRE(epoch().mutex_) : guard_(init_then_get_mutex()) {
+    EpochSession() HAZE_ACQUIRE(epoch().mutex_) : guard_(epoch_mutex()) {
         epoch().ensure_recording_locked();
     }
     // The unlock runs in guard_'s destructor; HAZE_RELEASE just
@@ -217,10 +216,9 @@ class HAZE_SCOPED_CAPABILITY EpochSession {
     EpochSession &operator=(const EpochSession &) = delete;
 
   private:
-    // Runs backend().ensure_initialized() before returning the mutex
-    // reference, so first-call compiler init isn't serialized under
-    // the epoch lock.
-    static HazeMutex &init_then_get_mutex() noexcept HAZE_RETURN_CAPABILITY(epoch().mutex_);
+    // The epoch mutex reference for the guard; the capability annotation lets TSA
+    // track the acquisition through the singleton accessor.
+    static HazeMutex &epoch_mutex() noexcept HAZE_RETURN_CAPABILITY(epoch().mutex_);
 
     HazeLockGuard guard_;
 };


### PR DESCRIPTION
CompilerBackend::ensure_initialized and hazeReplayBridgeInitCryptoContext previously each hand-rolled the compiler().init argv + program-info + pinned-directory sequence — split-brain by construction. Both now call one bootstrap_compiler() in backend.cpp, which reads the frozen replay config.

The format flags are explicit snapshot parameters because vendor init LATCHES them (set-only until reset) — the bridge pre-init passes none, keeping the guard-protected first-compute bring-up their sole authority, and ensure_initialized feeds its guard's own snapshot into the argv so guard and init can never disagree. Both init paths REQUIRE the explicit hazeConfigureDevice() finalize first (they only read the frozen config); a test pins that the bridge pre-init is rejected before configure.