### PR TITLE
feat(compute): add is-half-modulus predicate ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ add_library(haze_objs OBJECT
   src/core/device.cpp
   src/core/device_state.cpp
   src/core/epoch.cpp
+  src/core/is_half_modulus.cpp
   src/core/materialize.cpp
   src/core/mrp_polymap.cpp
   src/core/mrp_registry.cpp
@@ -426,6 +427,7 @@ add_executable(haze_tests
   test/test_memory.cpp
   test/test_config.cpp
   test/test_compute.cpp
+  test/test_is_half_modulus.cpp
   test/test_basis_convert.cpp
   test/test_mul_rotation.cpp
   test/test_ring_dim_consistency.cpp

--- a/README.md
+++ b/README.md
@@ -71,8 +71,9 @@ simulator internals, see the companion repository:
 
 3. **Allocate & Record** — `hazeMalloc` returns one FHETCH-addressable
    polynomial. Compute calls (`hazeAdd`, `hazeMul`, `hazeNTT`, `hazeAutomorph`,
-   `hazeBasisConvert`, ...) record one or more FHETCH instructions per call;
-   nothing executes yet. Stream and event handles are accepted for CUDA-shape
+   `hazeIsHalfModulus`, `hazeBasisConvert`, ...) record one or more FHETCH
+   instructions per call; nothing executes yet. Stream and event handles are
+   accepted for CUDA-shape
    parity but are intentionally no-ops — recording has no notion of
    stream-relative ordering until the trace is flushed.
 
@@ -369,8 +370,8 @@ int main() {
 <!-- readme-example:end -->
 
 Replace `hazeAddMrp` with any sequence of `hazeMulMrp`, `hazeNTTMrp`,
-`hazeAutomorphMrp`, `hazeBasisConvert`, ... and the recording layer captures
-every op in execution order. `test/test_compute.cpp` and
+`hazeAutomorphMrp`, `hazeIsHalfModulusMrp`, `hazeBasisConvert`, ... and the
+recording layer captures every op in execution order. `test/test_compute.cpp` and
 `test/test_basis_convert.cpp` exercise the full surface; the `test/e2e/` suite
 builds the CKKS operation set (add, mult + relin, rotate, rescale) on the same
 C ABI.

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -216,8 +216,9 @@ HAZE_API hazeError_t hazeMulScalar(void *dst, const void *src, uint64_t scalar, 
                                    hazeStream_t stream) HAZE_NOEXCEPT;
 
 // hazeIsHalfModulus records the per-coefficient predicate dst_i = (src_i > q/2) ? 1 : 0,
-// where q = moduli[mod_idx]; dst is recorded under the auto-selected aux prime
-// moduli[lowest j != mod_idx] (requires moduli_count >= 2).
+// where q = moduli[mod_idx] (must be odd); dst is recorded under the auto-selected aux:
+// the lowest-indexed configured modulus != mod_idx that passes a deterministic primality
+// check — composite chain entries are skipped, HAZE_ERROR_INVALID_VALUE when none exists.
 HAZE_API hazeError_t hazeIsHalfModulus(void *dst, const void *src, int mod_idx,
                                        hazeStream_t stream) HAZE_NOEXCEPT;
 
@@ -269,9 +270,10 @@ HAZE_API hazeError_t hazeMulScalarMrp(void *const *dst, const void *const *src,
                                       const uint64_t *scalars, const uint64_t *base,
                                       size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
 
-// hazeIsHalfModulusMrp records the per-limb predicate dst[i]_k = (src[i]_k > base[i]/2) ? 1 : 0;
-// every dst[i] is recorded under one shared auto-selected aux prime, the lowest-indexed
-// configured modulus not in base (HAZE_ERROR_INVALID_VALUE when none exists).
+// hazeIsHalfModulusMrp records the per-limb predicate dst[i]_k = (src[i]_k > base[i]/2) ? 1 : 0
+// (base moduli must be odd); every dst[i] is recorded under one shared auto-selected aux:
+// the lowest-indexed configured modulus not in base that passes a deterministic primality
+// check — composite chain entries are skipped, HAZE_ERROR_INVALID_VALUE when none exists.
 HAZE_API hazeError_t hazeIsHalfModulusMrp(void *const *dst, const void *const *src,
                                           const uint64_t *base, size_t base_len,
                                           hazeStream_t stream) HAZE_NOEXCEPT;

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -215,6 +215,16 @@ HAZE_API hazeError_t hazeSubScalar(void *dst, const void *src, uint64_t scalar, 
 HAZE_API hazeError_t hazeMulScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
                                    hazeStream_t stream) HAZE_NOEXCEPT;
 
+// hazeIsHalfModulus records the per-coefficient predicate dst_i = (src_i > q/2) ? 1 : 0
+// (equivalently src_i >= (q+1)/2 for odd q), where q = moduli[mod_idx] and src coefficients
+// are reduced mod q. The lowering routes through an auxiliary prime p = moduli[j] for the
+// lowest configured j != mod_idx (requires moduli_count >= 2; the sealed configuration
+// supplies it — no extra parameter or setup call), and dst is recorded under p; its values
+// are 0/1 and remain valid residues under any configured modulus. The per-limb MRP variant
+// (shared auto-selected aux prime) is hazeIsHalfModulusMrp below.
+HAZE_API hazeError_t hazeIsHalfModulus(void *dst, const void *src, int mod_idx,
+                                       hazeStream_t stream) HAZE_NOEXCEPT;
+
 // Number-theoretic transform (NTT) and its inverse.
 
 HAZE_API hazeError_t hazeNTT(void *dst, const void *src, int mod_idx,
@@ -262,6 +272,18 @@ HAZE_API hazeError_t hazeSubScalarMrp(void *const *dst, const void *const *src,
 HAZE_API hazeError_t hazeMulScalarMrp(void *const *dst, const void *const *src,
                                       const uint64_t *scalars, const uint64_t *base,
                                       size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
+
+// hazeIsHalfModulusMrp applies the hazeIsHalfModulus predicate per limb:
+// dst[i]_k = (src[i]_k > base[i]/2) ? 1 : 0. This is a per-limb quantity (not a function of
+// the CRT-represented value), so the outputs are base_len independent single-residue
+// polynomials, each recorded under one shared aux prime p, auto-selected like the SRP
+// variant's: the lowest-indexed configured modulus whose prime is not in `base` (the sealed
+// configuration supplies it — no extra parameter or setup call; HAZE_ERROR_INVALID_VALUE
+// when base covers every configured modulus). One aux serves every limb; correctness does
+// not depend on its size relative to the base primes.
+HAZE_API hazeError_t hazeIsHalfModulusMrp(void *const *dst, const void *const *src,
+                                          const uint64_t *base, size_t base_len,
+                                          hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeNTTMrp(void *const *dst, const void *const *src, const uint64_t *base,
                                 size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeINTTMrp(void *const *dst, const void *const *src, const uint64_t *base,

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -215,13 +215,9 @@ HAZE_API hazeError_t hazeSubScalar(void *dst, const void *src, uint64_t scalar, 
 HAZE_API hazeError_t hazeMulScalar(void *dst, const void *src, uint64_t scalar, int mod_idx,
                                    hazeStream_t stream) HAZE_NOEXCEPT;
 
-// hazeIsHalfModulus records the per-coefficient predicate dst_i = (src_i > q/2) ? 1 : 0
-// (equivalently src_i >= (q+1)/2 for odd q), where q = moduli[mod_idx] and src coefficients
-// are reduced mod q. The lowering routes through an auxiliary prime p = moduli[j] for the
-// lowest configured j != mod_idx (requires moduli_count >= 2; the sealed configuration
-// supplies it — no extra parameter or setup call), and dst is recorded under p; its values
-// are 0/1 and remain valid residues under any configured modulus. The per-limb MRP variant
-// (shared auto-selected aux prime) is hazeIsHalfModulusMrp below.
+// hazeIsHalfModulus records the per-coefficient predicate dst_i = (src_i > q/2) ? 1 : 0,
+// where q = moduli[mod_idx]; dst is recorded under the auto-selected aux prime
+// moduli[lowest j != mod_idx] (requires moduli_count >= 2).
 HAZE_API hazeError_t hazeIsHalfModulus(void *dst, const void *src, int mod_idx,
                                        hazeStream_t stream) HAZE_NOEXCEPT;
 
@@ -273,14 +269,9 @@ HAZE_API hazeError_t hazeMulScalarMrp(void *const *dst, const void *const *src,
                                       const uint64_t *scalars, const uint64_t *base,
                                       size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
 
-// hazeIsHalfModulusMrp applies the hazeIsHalfModulus predicate per limb:
-// dst[i]_k = (src[i]_k > base[i]/2) ? 1 : 0. This is a per-limb quantity (not a function of
-// the CRT-represented value), so the outputs are base_len independent single-residue
-// polynomials, each recorded under one shared aux prime p, auto-selected like the SRP
-// variant's: the lowest-indexed configured modulus whose prime is not in `base` (the sealed
-// configuration supplies it — no extra parameter or setup call; HAZE_ERROR_INVALID_VALUE
-// when base covers every configured modulus). One aux serves every limb; correctness does
-// not depend on its size relative to the base primes.
+// hazeIsHalfModulusMrp records the per-limb predicate dst[i]_k = (src[i]_k > base[i]/2) ? 1 : 0;
+// every dst[i] is recorded under one shared auto-selected aux prime, the lowest-indexed
+// configured modulus not in base (HAZE_ERROR_INVALID_VALUE when none exists).
 HAZE_API hazeError_t hazeIsHalfModulusMrp(void *const *dst, const void *const *src,
                                           const uint64_t *base, size_t base_len,
                                           hazeStream_t stream) HAZE_NOEXCEPT;

--- a/src/api/compute.cpp
+++ b/src/api/compute.cpp
@@ -18,6 +18,7 @@
 
 #include "common/errors.hpp"
 #include "common/handle.hpp"
+#include "core/is_half_modulus.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -73,6 +74,22 @@ extern "C" hazeError_t hazeMulScalar(void *dst, const void *src, uint64_t scalar
         return set_error(HAZE_ERROR_INVALID_VALUE);
     return set_internal_result(haze::binary_ps_op<fhetch::sr_mulps>(
         haze::to_dev_addr(dst), haze::to_dev_addr(src), scalar, mod_idx));
+}
+
+extern "C" hazeError_t hazeIsHalfModulus(void *dst, const void *src, int mod_idx,
+                                         hazeStream_t /*stream*/) noexcept {
+    if (dst == nullptr || src == nullptr)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    return set_internal_result(
+        haze::is_half_modulus(haze::to_dev_addr(dst), haze::to_dev_addr(src), mod_idx));
+}
+
+extern "C" hazeError_t hazeIsHalfModulusMrp(void *const *dst, const void *const *src,
+                                            const uint64_t *base, size_t base_len,
+                                            hazeStream_t /*stream*/) noexcept {
+    if (dst == nullptr || src == nullptr || base == nullptr || base_len == 0)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    return set_internal_result(haze::is_half_modulus_mrp(dst, src, base, base_len));
 }
 
 extern "C" hazeError_t hazeNTT(void *dst, const void *src, int mod_idx,

--- a/src/core/is_half_modulus.cpp
+++ b/src/core/is_half_modulus.cpp
@@ -102,6 +102,8 @@ fhetch::Polynomial lower_is_half_modulus(const fhetch::Polynomial &x, uint64_t q
         // hoists the sub above the cross-modulus rebase onto unreduced ring-q
         // operands — wrong results on the transport path. A +1/-1 pair keeps a
         // non-elidable addps between the rebase and the sub.
+        // TODO(niobium-compiler): drop the barrier once scalar_factor_sub gains
+        // a cross-ring guard; deployed drivers predate that fix.
         const auto barrier = fhetch::sr_addps(g1, fhetch::Scalar::from_int(1), p);
         const auto diff = fhetch::sr_subp(barrier, g2, p);
         return fhetch::sr_addps(diff, fhetch::Scalar::from_int(p - 1), p);

--- a/src/core/is_half_modulus.cpp
+++ b/src/core/is_half_modulus.cpp
@@ -44,18 +44,56 @@ uint64_t mulmod_u64(uint64_t a, uint64_t b, uint64_t m) noexcept {
     return static_cast<uint64_t>((static_cast<__uint128_t>(a) * b) % m);
 }
 
-// Fermat inverse a^(p-2) mod p; requires p prime and a not divisible by p.
-uint64_t modinv_prime(uint64_t a, uint64_t p) noexcept {
+uint64_t powmod_u64(uint64_t base, uint64_t exp, uint64_t m) noexcept {
     uint64_t result = 1;
-    uint64_t base = a % p;
-    uint64_t exp = p - 2;
+    base %= m;
     while (exp > 0) {
         if ((exp & 1U) != 0)
-            result = mulmod_u64(result, base, p);
-        base = mulmod_u64(base, base, p);
+            result = mulmod_u64(result, base, m);
+        base = mulmod_u64(base, base, m);
         exp >>= 1U;
     }
     return result;
+}
+
+// Fermat inverse a^(p-2) mod p; requires p prime and a not divisible by p.
+uint64_t modinv_prime(uint64_t a, uint64_t p) noexcept {
+    return powmod_u64(a, p - 2, p);
+}
+
+// Deterministic Miller-Rabin for 64-bit n (the 12-base set is exact below 3.3e24).
+// Guards the aux selection: a composite aux would make the Fermat inverse silently
+// wrong.
+bool is_prime_u64(uint64_t n) noexcept {
+    constexpr uint64_t kBases[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37};
+    if (n < 2)
+        return false;
+    for (uint64_t b : kBases) {
+        if (n % b == 0)
+            return n == b;
+    }
+    uint64_t d = n - 1;
+    unsigned s = 0;
+    while (d % 2 == 0) {
+        d /= 2;
+        ++s;
+    }
+    for (uint64_t b : kBases) {
+        uint64_t x = powmod_u64(b, d, n);
+        if (x == 1 || x == n - 1)
+            continue;
+        bool composite = true;
+        for (unsigned i = 1; i < s; ++i) {
+            x = mulmod_u64(x, x, n);
+            if (x == n - 1) {
+                composite = false;
+                break;
+            }
+        }
+        if (composite)
+            return false;
+    }
+    return true;
 }
 
 // Centered modulus switch q -> p: c(v) = v mod p for v <= (q-1)/2, else
@@ -114,15 +152,34 @@ std::expected<void, HazeInternalError> is_half_modulus(DevAddr dst, DevAddr src,
         record_internal_error(HazeInternalError::InvalidArgument, "hazeIsHalfModulus: bad mod_idx");
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
-    // Aux prime: lowest configured index != mod_idx.
-    const uint64_t p = fhe_params().modulus(mod_idx == 0 ? 1 : 0);
+    if (q % 2 == 0) {
+        // h = (q-1)/2 centering needs an odd modulus.
+        record_internal_error(HazeInternalError::InvalidArgument,
+                              "hazeIsHalfModulus: modulus must be odd");
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    }
+    // Aux prime: lowest configured index != mod_idx holding a prime; composite
+    // entries are skipped (the Fermat inverse below is only an inverse mod a
+    // prime — a composite aux would yield silently wrong results).
+    uint64_t p = 0;
+    for (int j = 0; j < kMaxCiphertextModuli; ++j) {
+        if (j == mod_idx)
+            continue;
+        const uint64_t candidate = fhe_params().modulus(j);
+        if (candidate == 0)
+            break; // configured moduli are contiguous from index 0
+        if (is_prime_u64(candidate)) {
+            p = candidate;
+            break;
+        }
+    }
     if (p == 0) {
         record_internal_error(HazeInternalError::InvalidArgument,
-                              "hazeIsHalfModulus: no second configured modulus for the aux prime");
+                              "hazeIsHalfModulus: no prime configured modulus for the aux");
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
     if (std::gcd(q, p) != 1) {
-        // q^-1 mod p must exist; distinct primes always pass.
+        // q^-1 mod p must exist; p is prime, so this only rejects p | q.
         record_internal_error(HazeInternalError::InvalidArgument,
                               "hazeIsHalfModulus: modulus and aux modulus not coprime");
         return std::unexpected(HazeInternalError::InvalidArgument);
@@ -140,12 +197,16 @@ std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, con
                                                            std::size_t base_len) noexcept {
     if (auto v = validate_moduli_base(base, base_len); !v)
         return v;
-    // Shared aux prime: lowest configured index whose prime is not in base.
+    // Shared aux prime: lowest configured index whose value is prime and not in
+    // base; composite entries are skipped (a composite aux would make the
+    // Fermat inverse silently wrong).
     uint64_t aux_modulus = 0;
     for (int j = 0; j < kMaxCiphertextModuli; ++j) {
         const uint64_t candidate = fhe_params().modulus(j);
         if (candidate == 0)
             break; // configured moduli are contiguous from index 0
+        if (!is_prime_u64(candidate))
+            continue;
         bool in_base = false;
         for (std::size_t i = 0; i < base_len; ++i) {
             if (base[i] == candidate) {
@@ -160,12 +221,18 @@ std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, con
     }
     if (aux_modulus == 0) {
         record_internal_error(HazeInternalError::InvalidArgument,
-                              "hazeIsHalfModulusMrp: no configured modulus outside base for the "
-                              "aux prime");
+                              "hazeIsHalfModulusMrp: no prime configured modulus outside base for "
+                              "the aux");
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
     for (std::size_t i = 0; i < base_len; ++i) {
-        // q^-1 mod aux must exist for every limb; distinct primes always pass.
+        if (base[i] % 2 == 0) {
+            // h = (q_i-1)/2 centering needs odd limb moduli.
+            record_internal_error(HazeInternalError::InvalidArgument,
+                                  "hazeIsHalfModulusMrp: base modulus must be odd");
+            return std::unexpected(HazeInternalError::InvalidArgument);
+        }
+        // q_i^-1 mod aux must exist; aux is prime, so this only rejects aux | q_i.
         if (std::gcd(base[i], aux_modulus) != 1) {
             record_internal_error(HazeInternalError::InvalidArgument,
                                   "hazeIsHalfModulusMrp: aux modulus not coprime to base prime");

--- a/src/core/is_half_modulus.cpp
+++ b/src/core/is_half_modulus.cpp
@@ -11,11 +11,9 @@
 // decode, or adapt the Product; or (iv) remove any proprietary notices
 // from the Product.
 //
-// hazeIsHalfModulus lowering. The FHETCH ISA has no comparison instruction; the
-// predicate b = [x > q/2] is extracted arithmetically through an auxiliary prime
-// p using two centered modulus switches (the only integer-level primitive that
-// survives every replay mode — a bare cross-modulus rebase is not
-// Montgomery-safe).
+// hazeIsHalfModulus lowering: the FHETCH ISA has no comparison instruction, so
+// the predicate is extracted arithmetically via two centered modulus switches
+// through an auxiliary prime.
 
 #include "core/is_half_modulus.hpp"
 
@@ -61,13 +59,10 @@ uint64_t modinv_prime(uint64_t a, uint64_t p) noexcept {
 }
 
 // Centered modulus switch q -> p: c(v) = v mod p for v <= (q-1)/2, else
-// (v - q) mod p. Same lowering as fhetch's center_mod_q_into_p
-// (shift / rebase / unshift; ordinary-form immediates; the imm=1 cross-modulus
-// multiply is the SwitchModulus placeholder), with the montgomery config
-// prepending the identity multiply so the chain forms the muli/addi/muli/addi
-// quadruple the hardware replay driver substitutes — the same shape keying as
-// fbc_center_shape() in basis_convert.cpp. Intermediates must stay single-use
-// SSA values or the hardware substitution silently misses the chain.
+// (v - q) mod p. Emits the exact shape of fhetch's center_mod_q_into_p
+// (vendor-internal; montgomery keying as basis_convert.cpp's fbc_center_shape)
+// so the hardware replay driver recognizes and substitutes the chain;
+// intermediates must stay single-use SSA values.
 fhetch::Polynomial emit_centered_switch(const fhetch::Polynomial &v, uint64_t q, uint64_t p) {
     const uint64_t half_q = (q - 1) / 2;
     const uint64_t half_mod_p = half_q % p;
@@ -79,13 +74,9 @@ fhetch::Polynomial emit_centered_switch(const fhetch::Polynomial &v, uint64_t q,
     return fhetch::sr_addps(rebased, fhetch::Scalar::from_int(neg_half), p);
 }
 
-// b = [x > h] with h = (q-1)/2, extracted via two centered switches into p:
-//   g1 = c(x - h mod q) == x - h        (signed value; x - h in [-h, h])
-//   g2 = c(x)           == x - q*b      (mod p)
-//   b  = ((g1 - g2 + h) mod p) * q^-1 == q*b * q^-1 in {0, 1}
-// Exact for any prime p != q (mod-p arithmetic is exact ring arithmetic);
-// immediates are pre-reduced mod their op's modulus because the replay
-// backends assume scalar operands below the modulus.
+// b = [x > h], h = (q-1)/2: g1 = c(x-h) == x-h (signed), g2 = c(x) == x - q*b,
+// so ((g1 - g2 + h) mod p) * q^-1 == b exactly, for any prime p != q.
+// Immediates are pre-reduced (replay backends assume scalars below the modulus).
 fhetch::Polynomial lower_is_half_modulus(const fhetch::Polynomial &x, uint64_t q, uint64_t p) {
     const uint64_t h = (q - 1) / 2;
     const auto w = fhetch::sr_subps(x, fhetch::Scalar::from_int(h), q);
@@ -96,14 +87,12 @@ fhetch::Polynomial lower_is_half_modulus(const fhetch::Polynomial &x, uint64_t q
             const auto diff = fhetch::sr_subp(g1, g2, p);
             return fhetch::sr_addps(diff, fhetch::Scalar::from_int(h % p), p);
         }
-        // p | h degenerates every h-derived immediate to 0: the replay driver's
-        // identity folds then elide the gadget unshifts and re-add, exposing
-        // sub(muli(u,1,p), muli(v,1,p)) to its scalar_factor_sub rewrite, which
-        // hoists the sub above the cross-modulus rebase onto unreduced ring-q
-        // operands — wrong results on the transport path. A +1/-1 pair keeps a
-        // non-elidable addps between the rebase and the sub.
-        // TODO(niobium-compiler): drop the barrier once scalar_factor_sub gains
-        // a cross-ring guard; deployed drivers predate that fix.
+        // p | h zeroes every h-derived immediate; the replay driver's identity
+        // folds then expose sub(muli,muli) to scalar_factor_sub, which hoists
+        // the sub above the rebase onto unreduced ring-q operands. The +1/-1
+        // pair keeps a non-elidable addps in between.
+        // TODO(niobium-compiler): drop once scalar_factor_sub gains a
+        // cross-ring guard; deployed drivers predate that fix.
         const auto barrier = fhetch::sr_addps(g1, fhetch::Scalar::from_int(1), p);
         const auto diff = fhetch::sr_subp(barrier, g2, p);
         return fhetch::sr_addps(diff, fhetch::Scalar::from_int(p - 1), p);
@@ -125,8 +114,7 @@ std::expected<void, HazeInternalError> is_half_modulus(DevAddr dst, DevAddr src,
         record_internal_error(HazeInternalError::InvalidArgument, "hazeIsHalfModulus: bad mod_idx");
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
-    // Aux prime: lowest configured index != mod_idx (deterministic under the
-    // sealed configuration; uniqueness of moduli guarantees p != q).
+    // Aux prime: lowest configured index != mod_idx.
     const uint64_t p = fhe_params().modulus(mod_idx == 0 ? 1 : 0);
     if (p == 0) {
         record_internal_error(HazeInternalError::InvalidArgument,
@@ -134,7 +122,7 @@ std::expected<void, HazeInternalError> is_half_modulus(DevAddr dst, DevAddr src,
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
     if (std::gcd(q, p) != 1) {
-        // Distinct primes are coprime; a composite chain voids the modulus contract.
+        // q^-1 mod p must exist; distinct primes always pass.
         record_internal_error(HazeInternalError::InvalidArgument,
                               "hazeIsHalfModulus: modulus and aux modulus not coprime");
         return std::unexpected(HazeInternalError::InvalidArgument);
@@ -152,9 +140,7 @@ std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, con
                                                            std::size_t base_len) noexcept {
     if (auto v = validate_moduli_base(base, base_len); !v)
         return v;
-    // Shared aux prime, auto-selected like the SRP variant's: the lowest
-    // configured index whose prime is not in base (deterministic under the
-    // sealed configuration). One aux serves every limb.
+    // Shared aux prime: lowest configured index whose prime is not in base.
     uint64_t aux_modulus = 0;
     for (int j = 0; j < kMaxCiphertextModuli; ++j) {
         const uint64_t candidate = fhe_params().modulus(j);
@@ -179,8 +165,7 @@ std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, con
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
     for (std::size_t i = 0; i < base_len; ++i) {
-        // q^-1 mod aux must exist for every limb; distinct primes always
-        // qualify, so this only rejects composite chains.
+        // q^-1 mod aux must exist for every limb; distinct primes always pass.
         if (std::gcd(base[i], aux_modulus) != 1) {
             record_internal_error(HazeInternalError::InvalidArgument,
                                   "hazeIsHalfModulusMrp: aux modulus not coprime to base prime");
@@ -192,9 +177,8 @@ std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, con
     EpochSession session;
     if (auto rec = epoch().require_recording_locked(); !rec)
         return rec;
-    // Resolve every source before any store so a bad residue (null pointer,
-    // never-written address) fails without half-mutating the dst array — the
-    // build_mrp_locked / store_mrp_locked split the sibling MRP ops use.
+    // Resolve every source before any store so a bad residue fails without
+    // half-mutating the dst array (the sibling ops' build/store split).
     std::vector<fhetch::Polynomial> sources;
     sources.reserve(base_len);
     for (std::size_t i = 0; i < base_len; ++i) {
@@ -203,9 +187,8 @@ std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, con
             return std::unexpected(x.error());
         sources.push_back(std::move(*x));
     }
-    // Per-limb fan-out: the predicate is a per-limb quantity, so each output is
-    // an independent single-residue polynomial recorded under the shared aux
-    // prime (a same-prime MRP grouping would alias residue keys).
+    // Outputs stay independent single-residue polynomials: a same-prime MRP
+    // grouping would alias residue keys.
     for (std::size_t i = 0; i < base_len; ++i) {
         epoch().store_compute_result_locked(to_dev_addr(dst[i]),
                                             lower_is_half_modulus(sources[i], base[i], aux_modulus),

--- a/src/core/is_half_modulus.cpp
+++ b/src/core/is_half_modulus.cpp
@@ -1,0 +1,215 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+//
+// hazeIsHalfModulus lowering. The FHETCH ISA has no comparison instruction; the
+// predicate b = [x > q/2] is extracted arithmetically through an auxiliary prime
+// p using two centered modulus switches (the only integer-level primitive that
+// survives every replay mode — a bare cross-modulus rebase is not
+// Montgomery-safe).
+
+#include "core/is_half_modulus.hpp"
+
+#include "common/errors.hpp"
+#include "common/handle.hpp"
+#include "core/allocator.hpp"
+#include "core/config.hpp"
+#include "core/device.hpp"
+#include "core/epoch.hpp"
+#include "core/mrp_polymap.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <niobium/fhetch_api.h>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+namespace haze {
+
+namespace fhetch = niobium::fhetch;
+
+namespace {
+
+// a * b mod m via 128-bit product.
+uint64_t mulmod_u64(uint64_t a, uint64_t b, uint64_t m) noexcept {
+    return static_cast<uint64_t>((static_cast<__uint128_t>(a) * b) % m);
+}
+
+// Fermat inverse a^(p-2) mod p; requires p prime and a not divisible by p.
+uint64_t modinv_prime(uint64_t a, uint64_t p) noexcept {
+    uint64_t result = 1;
+    uint64_t base = a % p;
+    uint64_t exp = p - 2;
+    while (exp > 0) {
+        if ((exp & 1U) != 0)
+            result = mulmod_u64(result, base, p);
+        base = mulmod_u64(base, base, p);
+        exp >>= 1U;
+    }
+    return result;
+}
+
+// Centered modulus switch q -> p: c(v) = v mod p for v <= (q-1)/2, else
+// (v - q) mod p. Same lowering as fhetch's center_mod_q_into_p
+// (shift / rebase / unshift; ordinary-form immediates; the imm=1 cross-modulus
+// multiply is the SwitchModulus placeholder), with the montgomery config
+// prepending the identity multiply so the chain forms the muli/addi/muli/addi
+// quadruple the hardware replay driver substitutes — the same shape keying as
+// fbc_center_shape() in basis_convert.cpp. Intermediates must stay single-use
+// SSA values or the hardware substitution silently misses the chain.
+fhetch::Polynomial emit_centered_switch(const fhetch::Polynomial &v, uint64_t q, uint64_t p) {
+    const uint64_t half_q = (q - 1) / 2;
+    const uint64_t half_mod_p = half_q % p;
+    const uint64_t neg_half = (half_mod_p == 0) ? 0 : p - half_mod_p;
+    const fhetch::Polynomial shift_in =
+        replay_config().montgomery() ? fhetch::sr_mulps(v, fhetch::Scalar::from_int(1), q) : v;
+    const auto shifted = fhetch::sr_addps(shift_in, fhetch::Scalar::from_int(half_q), q);
+    const auto rebased = fhetch::sr_mulps(shifted, fhetch::Scalar::from_int(1), p);
+    return fhetch::sr_addps(rebased, fhetch::Scalar::from_int(neg_half), p);
+}
+
+// b = [x > h] with h = (q-1)/2, extracted via two centered switches into p:
+//   g1 = c(x - h mod q) == x - h        (signed value; x - h in [-h, h])
+//   g2 = c(x)           == x - q*b      (mod p)
+//   b  = ((g1 - g2 + h) mod p) * q^-1 == q*b * q^-1 in {0, 1}
+// Exact for any prime p != q (mod-p arithmetic is exact ring arithmetic);
+// immediates are pre-reduced mod their op's modulus because the replay
+// backends assume scalar operands below the modulus.
+fhetch::Polynomial lower_is_half_modulus(const fhetch::Polynomial &x, uint64_t q, uint64_t p) {
+    const uint64_t h = (q - 1) / 2;
+    const auto w = fhetch::sr_subps(x, fhetch::Scalar::from_int(h), q);
+    const auto g1 = emit_centered_switch(w, q, p);
+    const auto g2 = emit_centered_switch(x, q, p);
+    fhetch::Polynomial qb = [&] {
+        if (h % p != 0) {
+            const auto diff = fhetch::sr_subp(g1, g2, p);
+            return fhetch::sr_addps(diff, fhetch::Scalar::from_int(h % p), p);
+        }
+        // p | h degenerates every h-derived immediate to 0: the replay driver's
+        // identity folds then elide the gadget unshifts and re-add, exposing
+        // sub(muli(u,1,p), muli(v,1,p)) to its scalar_factor_sub rewrite, which
+        // hoists the sub above the cross-modulus rebase onto unreduced ring-q
+        // operands — wrong results on the transport path. A +1/-1 pair keeps a
+        // non-elidable addps between the rebase and the sub.
+        const auto barrier = fhetch::sr_addps(g1, fhetch::Scalar::from_int(1), p);
+        const auto diff = fhetch::sr_subp(barrier, g2, p);
+        return fhetch::sr_addps(diff, fhetch::Scalar::from_int(p - 1), p);
+    }();
+    return fhetch::sr_mulps(qb, fhetch::Scalar::from_int(modinv_prime(q, p)), p);
+}
+
+} // namespace
+
+std::expected<void, HazeInternalError> is_half_modulus(DevAddr dst, DevAddr src,
+                                                       int mod_idx) noexcept {
+    if (auto live = allocator().require_allocated(dst); !live)
+        return live;
+    EpochSession session;
+    if (auto rec = epoch().require_recording_locked(); !rec)
+        return rec;
+    const uint64_t q = fhe_params().modulus(mod_idx);
+    if (q == 0) {
+        record_internal_error(HazeInternalError::InvalidArgument, "hazeIsHalfModulus: bad mod_idx");
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    }
+    // Aux prime: lowest configured index != mod_idx (deterministic under the
+    // sealed configuration; uniqueness of moduli guarantees p != q).
+    const uint64_t p = fhe_params().modulus(mod_idx == 0 ? 1 : 0);
+    if (p == 0) {
+        record_internal_error(HazeInternalError::InvalidArgument,
+                              "hazeIsHalfModulus: no second configured modulus for the aux prime");
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    }
+    if (std::gcd(q, p) != 1) {
+        // Distinct primes are coprime; a composite chain voids the modulus contract.
+        record_internal_error(HazeInternalError::InvalidArgument,
+                              "hazeIsHalfModulus: modulus and aux modulus not coprime");
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    }
+    auto x = epoch().lookup_or_create_locked(src);
+    if (!x)
+        return std::unexpected(x.error());
+
+    epoch().store_compute_result_locked(dst, lower_is_half_modulus(*x, q, p), p);
+    return {};
+}
+
+std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, const void *const *src,
+                                                           const uint64_t *base,
+                                                           std::size_t base_len) noexcept {
+    if (auto v = validate_moduli_base(base, base_len); !v)
+        return v;
+    // Shared aux prime, auto-selected like the SRP variant's: the lowest
+    // configured index whose prime is not in base (deterministic under the
+    // sealed configuration). One aux serves every limb.
+    uint64_t aux_modulus = 0;
+    for (int j = 0; j < kMaxCiphertextModuli; ++j) {
+        const uint64_t candidate = fhe_params().modulus(j);
+        if (candidate == 0)
+            break; // configured moduli are contiguous from index 0
+        bool in_base = false;
+        for (std::size_t i = 0; i < base_len; ++i) {
+            if (base[i] == candidate) {
+                in_base = true;
+                break;
+            }
+        }
+        if (!in_base) {
+            aux_modulus = candidate;
+            break;
+        }
+    }
+    if (aux_modulus == 0) {
+        record_internal_error(HazeInternalError::InvalidArgument,
+                              "hazeIsHalfModulusMrp: no configured modulus outside base for the "
+                              "aux prime");
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    }
+    for (std::size_t i = 0; i < base_len; ++i) {
+        // q^-1 mod aux must exist for every limb; distinct primes always
+        // qualify, so this only rejects composite chains.
+        if (std::gcd(base[i], aux_modulus) != 1) {
+            record_internal_error(HazeInternalError::InvalidArgument,
+                                  "hazeIsHalfModulusMrp: aux modulus not coprime to base prime");
+            return std::unexpected(HazeInternalError::InvalidArgument);
+        }
+    }
+    if (auto live = require_allocated_array(dst, base_len); !live)
+        return live;
+    EpochSession session;
+    if (auto rec = epoch().require_recording_locked(); !rec)
+        return rec;
+    // Resolve every source before any store so a bad residue (null pointer,
+    // never-written address) fails without half-mutating the dst array — the
+    // build_mrp_locked / store_mrp_locked split the sibling MRP ops use.
+    std::vector<fhetch::Polynomial> sources;
+    sources.reserve(base_len);
+    for (std::size_t i = 0; i < base_len; ++i) {
+        auto x = epoch().lookup_or_create_locked(to_dev_addr(src[i]));
+        if (!x)
+            return std::unexpected(x.error());
+        sources.push_back(std::move(*x));
+    }
+    // Per-limb fan-out: the predicate is a per-limb quantity, so each output is
+    // an independent single-residue polynomial recorded under the shared aux
+    // prime (a same-prime MRP grouping would alias residue keys).
+    for (std::size_t i = 0; i < base_len; ++i) {
+        epoch().store_compute_result_locked(to_dev_addr(dst[i]),
+                                            lower_is_half_modulus(sources[i], base[i], aux_modulus),
+                                            aux_modulus);
+    }
+    return {};
+}
+
+} // namespace haze

--- a/src/core/is_half_modulus.hpp
+++ b/src/core/is_half_modulus.hpp
@@ -21,18 +21,13 @@
 
 namespace haze {
 
-// Internal C++ entry points for hazeIsHalfModulus / hazeIsHalfModulusMrp — the
-// per-coefficient predicate dst_i = (src_i > q/2) ? 1 : 0; the extern "C" shims
-// in src/api/compute.cpp validate pointers, dispatch here, and map
-// HazeInternalError to hazeError_t. Each opens an EpochSession internally.
+// Internal entry points for hazeIsHalfModulus / hazeIsHalfModulusMrp, the
+// per-coefficient predicate dst_i = (src_i > q/2) ? 1 : 0; each opens an
+// EpochSession internally.
 
-// SRP: q = moduli[mod_idx], aux prime auto-selected from the configuration.
 std::expected<void, HazeInternalError> is_half_modulus(DevAddr dst, DevAddr src,
                                                        int mod_idx) noexcept;
 
-// MRP: per-limb over caller-supplied base primes with one shared aux prime,
-// auto-selected from the configuration (lowest-indexed configured modulus not
-// in base); every dst[i] is recorded under it.
 std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, const void *const *src,
                                                            const uint64_t *base,
                                                            std::size_t base_len) noexcept;

--- a/src/core/is_half_modulus.hpp
+++ b/src/core/is_half_modulus.hpp
@@ -1,0 +1,40 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#pragma once
+
+#include "common/errors.hpp"
+#include "common/handle.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+
+namespace haze {
+
+// Internal C++ entry points for hazeIsHalfModulus / hazeIsHalfModulusMrp — the
+// per-coefficient predicate dst_i = (src_i > q/2) ? 1 : 0; the extern "C" shims
+// in src/api/compute.cpp validate pointers, dispatch here, and map
+// HazeInternalError to hazeError_t. Each opens an EpochSession internally.
+
+// SRP: q = moduli[mod_idx], aux prime auto-selected from the configuration.
+std::expected<void, HazeInternalError> is_half_modulus(DevAddr dst, DevAddr src,
+                                                       int mod_idx) noexcept;
+
+// MRP: per-limb over caller-supplied base primes with one shared aux prime,
+// auto-selected from the configuration (lowest-indexed configured modulus not
+// in base); every dst[i] is recorded under it.
+std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, const void *const *src,
+                                                           const uint64_t *base,
+                                                           std::size_t base_len) noexcept;
+
+} // namespace haze

--- a/test/test_is_half_modulus.cpp
+++ b/test/test_is_half_modulus.cpp
@@ -1,10 +1,7 @@
 // Copyright (C) 2026, All rights reserved by Niobium Microsystems.
 //
-// hazeIsHalfModulus tests: [unit] argument validation and [integration] golden
-// values (exact 0/1 per coefficient) across aux-prime-above-q, aux-prime-below-q,
-// small-prime, in-place, and shared-source cases. The trace-shape and
-// hardware-format (montgomery/bit-reversal) tiers live further down, tagged
-// [hwfmt] like test_hardware_format.cpp.
+// hazeIsHalfModulus / hazeIsHalfModulusMrp tests: [unit] validation and
+// trace-shape pinning, [integration] golden values, [hwfmt] transport cases.
 
 #include "integration_helpers.hpp"
 #include "mod_arith_ref.hpp"
@@ -34,14 +31,11 @@ constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
 constexpr uint64_t kQ0 = 576460752303415297ULL;
 constexpr uint64_t kQ1 = 576460752303439873ULL;
 constexpr uint64_t kQ2 = 576460752303702017ULL;
-// Small NTT-friendly prime (just above 2^30, ≡ 1 mod 8192): as q it exercises a
-// small half-point, as the auto-selected aux prime it exercises h >= p immediate
-// reduction. ~2^30 is the practical floor here — the replay bridge's OpenFHE
-// template synthesis throws (LastPrime overflow) for tiny primes like 65537.
+// Small NTT-friendly prime (~2^30, ≡ 1 mod 8192); the practical floor — the
+// replay bridge's template synthesis throws for tiny primes like 65537.
 constexpr uint64_t kSmallQ = 1073750017ULL;
-// 59-bit NTT-friendly prime with q ≡ 1 (mod kSmallQ): q = 32771 * kSmallQ * 8192 + 1.
-// Against aux p = kSmallQ it drives the rare immediate branches in one case:
-// qinv == 1, p | h, h % p == 0, and the neg_half == 0 copy special case.
+// 59-bit NTT-friendly prime with q ≡ 1 (mod kSmallQ): against aux p = kSmallQ
+// it drives qinv == 1, p | h, and the zero-immediate gadget branches at once.
 constexpr uint64_t kCongruentQ = 288241371603542017ULL;
 
 uint64_t is_half_ref(uint64_t x, uint64_t q) {
@@ -590,11 +584,10 @@ TEST_CASE("hazeIsHalfModulusMrp rejects invalid arguments", "[unit]") {
     void *dst3[] = {d_a, d_b, d_a};
     const void *src3[] = {d_a, d_b, d_a};
     REQUIRE(hazeIsHalfModulusMrp(dst3, src3, full_base, 3, nullptr) == HAZE_ERROR_INVALID_VALUE);
-    // Bad src residues surface from the source-resolution path — the same
-    // lookup build_mrp_locked uses (no element pre-check) — and must not
-    // mutate any dst. An allocated-but-unwritten residue reports
-    // SOURCE_UNAVAILABLE; a null (never-allocated) residue reports
-    // UNKNOWN_ADDRESS. Write d_a first so each case isolates one bad element.
+    // Bad src residues surface from the source-resolution path (same lookup as
+    // build_mrp_locked): allocated-but-unwritten reports SOURCE_UNAVAILABLE,
+    // null reports UNKNOWN_ADDRESS. d_a is written before the null case so
+    // each call isolates one bad element.
     const void *unwritten_src[] = {d_a, d_b};
     REQUIRE(hazeIsHalfModulusMrp(dst_polys, unwritten_src, base, 2, nullptr) ==
             HAZE_ERROR_SOURCE_UNAVAILABLE);

--- a/test/test_is_half_modulus.cpp
+++ b/test/test_is_half_modulus.cpp
@@ -1,0 +1,654 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// hazeIsHalfModulus tests: [unit] argument validation and [integration] golden
+// values (exact 0/1 per coefficient) across aux-prime-above-q, aux-prime-below-q,
+// small-prime, in-place, and shared-source cases. The trace-shape and
+// hardware-format (montgomery/bit-reversal) tiers live further down, tagged
+// [hwfmt] like test_hardware_format.cpp.
+
+#include "integration_helpers.hpp"
+#include "mod_arith_ref.hpp"
+
+#include <catch2/catch_message.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr uint64_t kRingDim = 4096;
+constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
+
+// Suite NTT-friendly primes (q ≡ 1 mod 2N for N=4096); matches test_compute.cpp.
+constexpr uint64_t kQ0 = 576460752303415297ULL;
+constexpr uint64_t kQ1 = 576460752303439873ULL;
+constexpr uint64_t kQ2 = 576460752303702017ULL;
+// Small NTT-friendly prime (just above 2^30, ≡ 1 mod 8192): as q it exercises a
+// small half-point, as the auto-selected aux prime it exercises h >= p immediate
+// reduction. ~2^30 is the practical floor here — the replay bridge's OpenFHE
+// template synthesis throws (LastPrime overflow) for tiny primes like 65537.
+constexpr uint64_t kSmallQ = 1073750017ULL;
+// 59-bit NTT-friendly prime with q ≡ 1 (mod kSmallQ): q = 32771 * kSmallQ * 8192 + 1.
+// Against aux p = kSmallQ it drives the rare immediate branches in one case:
+// qinv == 1, p | h, h % p == 0, and the neg_half == 0 copy special case.
+constexpr uint64_t kCongruentQ = 288241371603542017ULL;
+
+uint64_t is_half_ref(uint64_t x, uint64_t q) {
+    return (x > (q - 1) / 2) ? 1U : 0U;
+}
+
+// Two-prime configuration; the aux prime for mod_idx=0 is q1 (lowest index != 0).
+void setup_two_prime_config(uint64_t q0, uint64_t q1) {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {q0, q1};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
+    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0; // built then overwritten from the trace; not used for results
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, q0, &scaffold) == HAZE_SUCCESS);
+}
+
+// Pseudorandom residues mod q with the threshold boundary cases pinned into the
+// leading slots: 0, 1, h-1, h, h+1, q-2, q-1 where h = (q-1)/2 (result flips
+// between h and h+1).
+std::vector<uint64_t> boundary_input(uint64_t q, uint64_t seed) {
+    std::vector<uint64_t> input = haze::test::make_residue(q, seed, kRingDim);
+    const uint64_t h = (q - 1) / 2;
+    const uint64_t edges[] = {0, 1, h - 1, h, h + 1, q - 2, q - 1};
+    for (std::size_t i = 0; i < 7; ++i)
+        input[i] = edges[i];
+    return input;
+}
+
+// Record one hazeIsHalfModulus over boundary+pseudorandom input, flush, and
+// require exact 0/1 equality against the host oracle on every coefficient.
+void run_golden_case(uint64_t q, int mod_idx, uint64_t seed) {
+    const std::vector<uint64_t> input = boundary_input(q, seed);
+
+    void *d_src = nullptr;
+    void *d_dst = nullptr;
+    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_src, input.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, mod_idx, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(d_dst) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+    REQUIRE(hazeMemcpy(got.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    for (std::size_t k = 0; k < kRingDim; ++k) {
+        INFO("q " << q << " mod_idx " << mod_idx << " slot " << k << " input " << input[k]);
+        REQUIRE(got[k] == is_half_ref(input[k], q));
+    }
+
+    REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
+}
+
+} // namespace
+
+// ===========================================================================
+// Golden values ([integration]: runs under test-sim and test-transport).
+// ===========================================================================
+
+TEST_CASE("hazeIsHalfModulus: golden values, aux prime above q", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    run_golden_case(kQ0, /*mod_idx=*/0, /*seed=*/424242ULL); // p = kQ1 > q
+}
+
+TEST_CASE("hazeIsHalfModulus: golden values, aux prime below q", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    run_golden_case(kQ1, /*mod_idx=*/1, /*seed=*/911223ULL); // p = kQ0 < q
+    run_golden_case(kQ2, /*mod_idx=*/2, /*seed=*/171717ULL); // p = kQ0 < q
+}
+
+TEST_CASE("hazeIsHalfModulus: golden values, small q against 59-bit aux prime", "[integration]") {
+    setup_two_prime_config(kSmallQ, kQ0);
+    run_golden_case(kSmallQ, /*mod_idx=*/0, /*seed=*/555555ULL); // p = kQ0 >> q
+}
+
+TEST_CASE("hazeIsHalfModulus: golden values, small aux prime (h >= p)", "[integration]") {
+    setup_two_prime_config(kQ0, kSmallQ);
+    run_golden_case(kQ0, /*mod_idx=*/0, /*seed=*/777777ULL); // p = kSmallQ, h >> p
+}
+
+TEST_CASE("hazeIsHalfModulus: golden values, q ≡ 1 mod p (qinv == 1, p | h)", "[integration]") {
+    setup_two_prime_config(kCongruentQ, kSmallQ);
+    run_golden_case(kCongruentQ, /*mod_idx=*/0, /*seed=*/999999ULL);
+}
+
+TEST_CASE("hazeIsHalfModulus: in-place dst == src", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> input = boundary_input(kQ0, /*seed=*/313131ULL);
+
+    void *d_x = nullptr;
+    REQUIRE(hazeMalloc(&d_x, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_x, input.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    REQUIRE(hazeIsHalfModulus(d_x, d_x, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(d_x) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+    REQUIRE(hazeMemcpy(got.data(), d_x, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    for (std::size_t k = 0; k < kRingDim; ++k) {
+        INFO("slot " << k << " input " << input[k]);
+        REQUIRE(got[k] == is_half_ref(input[k], kQ0));
+    }
+    REQUIRE(hazeFree(d_x) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeIsHalfModulus: two results from one source in one epoch", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> input = boundary_input(kQ0, /*seed=*/616161ULL);
+
+    void *d_src = nullptr;
+    void *d_dst1 = nullptr;
+    void *d_dst2 = nullptr;
+    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst1, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst2, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_src, input.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    // Same source through two lowerings in one recording: the replay-side
+    // optimizer (GVN etc.) may dedup shared subexpressions; results must not
+    // change.
+    REQUIRE(hazeIsHalfModulus(d_dst1, d_src, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeIsHalfModulus(d_dst2, d_src, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(d_dst1) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(d_dst2) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    for (void *dst : {d_dst1, d_dst2}) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        for (std::size_t k = 0; k < kRingDim; ++k) {
+            INFO("dst " << (dst == d_dst1 ? 1 : 2) << " slot " << k << " input " << input[k]);
+            REQUIRE(got[k] == is_half_ref(input[k], kQ0));
+        }
+    }
+
+    REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_dst1) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_dst2) == HAZE_SUCCESS);
+}
+
+// ===========================================================================
+// Argument validation ([unit]).
+// ===========================================================================
+
+TEST_CASE("hazeIsHalfModulus rejects null pointers", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+
+    void *d_buf = nullptr;
+    REQUIRE(hazeMalloc(&d_buf, kBytes) == HAZE_SUCCESS);
+
+    REQUIRE(hazeIsHalfModulus(nullptr, d_buf, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    REQUIRE(hazeIsHalfModulus(d_buf, nullptr, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(d_buf) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeIsHalfModulus with invalid modulus index returns error", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+
+    void *d_src = nullptr;
+    void *d_dst = nullptr;
+    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
+    std::vector<uint64_t> a(kRingDim, 1);
+    REQUIRE(hazeMemcpy(d_src, a.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, -1, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 63, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeIsHalfModulus without a second configured modulus returns error", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+
+    void *d_src = nullptr;
+    void *d_dst = nullptr;
+    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
+    std::vector<uint64_t> a(kRingDim, 1);
+    REQUIRE(hazeMemcpy(d_src, a.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    // mod_idx 0 is valid; the failure is the missing aux modulus.
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
+}
+
+// ===========================================================================
+// Record-time trace shape ([unit][hwfmt]): the emitted instruction sequence and
+// its ordinary-form immediates are a replay-driver contract (the montgomery
+// path structurally recognizes the centered-switch quadruples), so pin them.
+// ===========================================================================
+
+namespace {
+
+std::string slurp(const std::filesystem::path &path) {
+    std::ifstream in(path);
+    REQUIRE(in.good());
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+// JSON value text after `"key":` (up to comma/newline/brace), trimmed; string
+// search keeps the test free of a JSON library dependency (same approach as
+// test_hardware_format.cpp).
+std::string json_value_text(const std::string &doc, const std::string &key) {
+    const std::string needle = "\"" + key + "\"";
+    const std::size_t key_pos = doc.find(needle);
+    REQUIRE(key_pos != std::string::npos);
+    const std::size_t colon = doc.find(':', key_pos);
+    REQUIRE(colon != std::string::npos);
+    const std::size_t end = doc.find_first_of(",\n}", colon);
+    REQUIRE(end != std::string::npos);
+    std::string value = doc.substr(colon + 1, end - colon - 1);
+    const std::size_t first = value.find_first_not_of(" \t");
+    const std::size_t last = value.find_last_not_of(" \t");
+    REQUIRE(first != std::string::npos);
+    return value.substr(first, last - first + 1);
+}
+
+std::size_t count_occurrences(const std::string &haystack, const std::string &needle) {
+    std::size_t count = 0;
+    for (std::size_t pos = haystack.find(needle); pos != std::string::npos;
+         pos = haystack.find(needle, pos + needle.size()))
+        ++count;
+    return count;
+}
+
+// Record one hazeIsHalfModulus(mod_idx=0) into a uniquely named program dir
+// (target FUNC_SIM so the format toggles are accepted; hazeWriteProgram needs
+// no replay binary) and return the program directory.
+std::filesystem::path record_ihm_program(const std::string &program_name, bool montgomery,
+                                         bool bit_reversal) {
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = "FUNC_SIM",
+                                     .program_name = program_name.c_str(),
+                                     .program_version = "0.1",
+                                     .program_description = "is_half_modulus trace-shape test",
+                                     .montgomery = montgomery ? 1 : 0,
+                                     .bit_reversal = bit_reversal ? 1 : 0,
+                                     .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+
+    const std::vector<uint64_t> input = boundary_input(kQ0, /*seed=*/404040ULL);
+    void *d_src = nullptr;
+    void *d_dst = nullptr;
+    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_src, input.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(d_dst) == HAZE_SUCCESS);
+    REQUIRE(hazeWriteProgram() == HAZE_SUCCESS);
+    return std::filesystem::path{program_name};
+}
+
+// Immediates of the lowering for q = kQ0, p = kQ1 (aux = lowest index != 0):
+// h (subps + gadget shifts), -h mod p (gadget unshifts, exactly twice),
+// h mod p (the +h re-add), qinv (the final scale).
+void check_ihm_trace_shape(const std::string &trace, bool four_op) {
+    const uint64_t q = kQ0;
+    const uint64_t p = kQ1;
+    const uint64_t h = (q - 1) / 2;
+    const uint64_t neg_half = p - (h % p);
+    const uint64_t qinv = niobium::mod_arith::modinv_prime(q % p, p);
+
+    REQUIRE(trace.find(", " + std::to_string(h) + ",") != std::string::npos);
+    REQUIRE(count_occurrences(trace, ", " + std::to_string(neg_half) + ",") == 2);
+    REQUIRE(trace.find(", " + std::to_string(h % p) + ",") != std::string::npos);
+    REQUIRE(trace.find(", " + std::to_string(qinv) + ",") != std::string::npos);
+
+    // Montgomery-form immediates never appear client-side; the driver
+    // substitutes them at replay.
+    const auto sw_hw = niobium::mod_arith::compute_switchmodulus_immediates(q, p,
+                                                                            /*montgomery=*/true);
+    REQUIRE(trace.find(", " + std::to_string(sw_hw.imm[2]) + ",") == std::string::npos);
+    REQUIRE(trace.find(", " + std::to_string(sw_hw.imm[3]) + ",") == std::string::npos);
+
+    // Opcode census of the 10-op (ThreeOp) / 12-op (FourOp montgomery) lowering.
+    CHECK(count_occurrences(trace, "sr_subps ") == 1);
+    CHECK(count_occurrences(trace, "sr_addps ") == 5);
+    CHECK(count_occurrences(trace, "sr_mulps ") == (four_op ? 5U : 3U));
+    CHECK(count_occurrences(trace, "sr_subp ") == 1);
+}
+
+} // namespace
+
+TEST_CASE("hazeIsHalfModulus record-time: ordinary-form ThreeOp trace", "[unit][hwfmt]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const auto dir = record_ihm_program("haze_ihm_threeop", /*montgomery=*/false,
+                                        /*bit_reversal=*/false);
+    check_ihm_trace_shape(slurp(dir / "haze_ihm_threeop.fhetch"), /*four_op=*/false);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeIsHalfModulus record-time: montgomery keeps ordinary immediates, FourOp shape",
+          "[unit][hwfmt]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const auto dir = record_ihm_program("haze_ihm_fourop", /*montgomery=*/true,
+                                        /*bit_reversal=*/true);
+    check_ihm_trace_shape(slurp(dir / "haze_ihm_fourop.fhetch"), /*four_op=*/true);
+    // niobium_hw describes the recording (always ordinary-form); the dispatch
+    // flag alone carries the replay-side format selection.
+    REQUIRE(json_value_text(slurp(dir / "fhetch_replay.json"), "niobium_hw") == "false");
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+// ===========================================================================
+// Transport hardware mode ([integration][hwfmt]: requires make test-transport).
+// Montgomery + bit-reversal are exact bijections decoded before probes are
+// written, so results must be byte-identical to ordinary mode — the A/B case is
+// the end-to-end gate that the driver recognizes the hand-emitted gadget
+// quadruples and substitutes SwitchModulus correctly.
+// ===========================================================================
+
+namespace {
+
+bool transport_target_active() {
+    const char *target = std::getenv("HAZE_TARGET");
+    return target != nullptr && target[0] != '\0' && std::string_view{target} != "local";
+}
+
+// Record + flush one hazeIsHalfModulus(mod_idx=0) through the transport under
+// the given data-format toggles (default shared "haze" program dir) and return
+// the D2H result.
+std::vector<uint64_t> run_ihm_computation(const char *target, bool montgomery, bool bit_reversal) {
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = target,
+                                     .montgomery = montgomery ? 1 : 0,
+                                     .bit_reversal = bit_reversal ? 1 : 0,
+                                     .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+
+    const std::vector<uint64_t> input = boundary_input(kQ0, /*seed=*/909090ULL);
+    void *d_src = nullptr;
+    void *d_dst = nullptr;
+    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_src, input.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 0, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeTagOutput(d_dst) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+    REQUIRE(hazeMemcpy(got.data(), d_dst, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
+    return got;
+}
+
+} // namespace
+
+TEST_CASE("hazeIsHalfModulus transport: byte-exact vs oracle under data format",
+          "[integration][hwfmt]") {
+    if (!transport_target_active())
+        SKIP("data format requires a transport target (run under make test-transport)");
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+
+    const auto got = run_ihm_computation(haze::test::target_from_env(), /*montgomery=*/true,
+                                         /*bit_reversal=*/true);
+    const std::vector<uint64_t> input = boundary_input(kQ0, /*seed=*/909090ULL);
+    for (std::size_t k = 0; k < kRingDim; ++k) {
+        INFO("slot " << k << " input " << input[k]);
+        REQUIRE(got[k] == is_half_ref(input[k], kQ0));
+    }
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeIsHalfModulus transport: A/B byte-exact vs ordinary mode", "[integration][hwfmt]") {
+    if (!transport_target_active())
+        SKIP("data format requires a transport target (run under make test-transport)");
+
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const auto ordinary = run_ihm_computation(haze::test::target_from_env(), /*montgomery=*/false,
+                                              /*bit_reversal=*/false);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const auto encoded = run_ihm_computation(haze::test::target_from_env(), /*montgomery=*/true,
+                                             /*bit_reversal=*/true);
+    REQUIRE(ordinary == encoded);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+// ===========================================================================
+// MRP variant: per-limb predicate with one shared aux prime, auto-selected as
+// the lowest-indexed configured modulus not in the base (SRP pattern).
+// ===========================================================================
+
+namespace {
+
+// Record one hazeIsHalfModulusMrp over per-limb boundary inputs, flush, and
+// return the per-limb D2H results.
+std::vector<std::vector<uint64_t>> run_ihm_mrp(const std::vector<uint64_t> &base, uint64_t seed) {
+    std::vector<std::vector<uint64_t>> inputs(base.size());
+    for (std::size_t i = 0; i < base.size(); ++i)
+        inputs[i] = boundary_input(base[i], seed + i);
+
+    const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
+    const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    const std::vector<const void *> src_view = haze::test::to_const(d_src);
+    REQUIRE(hazeIsHalfModulusMrp(d_dst.data(), src_view.data(), base.data(), base.size(),
+                                 nullptr) == HAZE_SUCCESS);
+    for (void *out : d_dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    std::vector<std::vector<uint64_t>> results;
+    for (void *out : d_dst) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), out, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        results.push_back(std::move(got));
+    }
+    haze::test::free_all_residues(d_src);
+    haze::test::free_all_residues(d_dst);
+    return results;
+}
+
+void check_ihm_mrp_results(const std::vector<uint64_t> &base, uint64_t seed,
+                           const std::vector<std::vector<uint64_t>> &results) {
+    for (std::size_t i = 0; i < base.size(); ++i) {
+        const std::vector<uint64_t> input = boundary_input(base[i], seed + i);
+        for (std::size_t k = 0; k < kRingDim; ++k) {
+            INFO("residue " << i << " (mod " << base[i] << ") slot " << k << " input " << input[k]);
+            REQUIRE(results[i][k] == is_half_ref(input[k], base[i]));
+        }
+    }
+}
+
+} // namespace
+
+TEST_CASE("hazeIsHalfModulusMrp: per-limb golden values, shared configured aux", "[integration]") {
+    const std::vector<uint64_t> base =
+        haze::test::setup_integration_mrp3_config(kRingDim, kQ0); // {kQ0, kQ1, kQ2}
+    const std::vector<uint64_t> limb_base = {base[0], base[1]};
+
+    // A failed call (unwritten source residue) resolves all sources before any
+    // store, so it must leave every dst untouched; the valid run below then
+    // materializes correct results in the same epoch.
+    {
+        const std::vector<void *> d_tmp = haze::test::allocate_dst_residues(2, kBytes);
+        const void *bad_src[] = {d_tmp[0], d_tmp[1]};
+        REQUIRE(hazeIsHalfModulusMrp(d_tmp.data(), bad_src, limb_base.data(), 2, nullptr) ==
+                HAZE_ERROR_SOURCE_UNAVAILABLE);
+        hazeGetLastError();
+        haze::test::free_all_residues(d_tmp);
+    }
+
+    // Auto-selected aux = base[2] (kQ2), the lowest configured index not in the base.
+    check_ihm_mrp_results(limb_base, /*seed=*/818181ULL,
+                          run_ihm_mrp(limb_base, /*seed=*/818181ULL));
+}
+
+TEST_CASE("hazeIsHalfModulusMrp: in-place dst == src", "[integration]") {
+    const std::vector<uint64_t> base = haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> limb_base = {base[0], base[1]};
+    std::vector<std::vector<uint64_t>> inputs(limb_base.size());
+    for (std::size_t i = 0; i < limb_base.size(); ++i)
+        inputs[i] = boundary_input(limb_base[i], /*seed=*/848484ULL + i);
+
+    const std::vector<void *> d_x = haze::test::allocate_and_h2d_residues(inputs);
+    const std::vector<const void *> src_view = haze::test::to_const(d_x);
+    REQUIRE(hazeIsHalfModulusMrp(d_x.data(), src_view.data(), limb_base.data(), limb_base.size(),
+                                 nullptr) == HAZE_SUCCESS);
+    for (void *out : d_x)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    for (std::size_t i = 0; i < limb_base.size(); ++i) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), d_x[i], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        for (std::size_t k = 0; k < kRingDim; ++k) {
+            INFO("residue " << i << " slot " << k << " input " << inputs[i][k]);
+            REQUIRE(got[k] == is_half_ref(inputs[i][k], limb_base[i]));
+        }
+    }
+    haze::test::free_all_residues(d_x);
+}
+
+TEST_CASE("hazeIsHalfModulusMrp: small auto-selected aux (h >= p per limb)", "[integration]") {
+    // Config {kSmallQ, kQ1, kQ2} with base {kQ1, kQ2}: the auto-selected aux is
+    // kSmallQ (lowest configured index not in the base), exercising h >= p
+    // immediate reduction on every limb.
+    haze::test::setup_integration_mrp3_config(kRingDim, kSmallQ);
+    const std::vector<uint64_t> limb_base = {kQ1, kQ2};
+    check_ihm_mrp_results(limb_base, /*seed=*/828282ULL,
+                          run_ihm_mrp(limb_base, /*seed=*/828282ULL));
+}
+
+TEST_CASE("hazeIsHalfModulusMrp: base prime outside the configured chain", "[integration]") {
+    // Base primes are caller-defined raw values (registered through the trace's
+    // modulus table); only the aux comes from the configuration. Config
+    // {kQ0, kQ1, kQ2} with base {kSmallQ, kQ1} auto-selects aux = kQ0.
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> limb_base = {kSmallQ, kQ1};
+    check_ihm_mrp_results(limb_base, /*seed=*/868686ULL,
+                          run_ihm_mrp(limb_base, /*seed=*/868686ULL));
+}
+
+TEST_CASE("hazeIsHalfModulusMrp rejects invalid arguments", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+
+    const uint64_t base[] = {kQ0, kQ1};
+    void *d_a = nullptr;
+    void *d_b = nullptr;
+    REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_b, kBytes) == HAZE_SUCCESS);
+    void *dst_polys[] = {d_a, d_b};
+    const void *src_polys[] = {d_a, d_b};
+
+    REQUIRE(hazeIsHalfModulusMrp(nullptr, src_polys, base, 2, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeIsHalfModulusMrp(dst_polys, nullptr, base, 2, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeIsHalfModulusMrp(dst_polys, src_polys, nullptr, 2, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeIsHalfModulusMrp(dst_polys, src_polys, base, 0, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    // Base covering every configured modulus leaves no aux prime to select.
+    const uint64_t full_base[] = {kQ0, kQ1, kQ2};
+    void *dst3[] = {d_a, d_b, d_a};
+    const void *src3[] = {d_a, d_b, d_a};
+    REQUIRE(hazeIsHalfModulusMrp(dst3, src3, full_base, 3, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    // A null src residue surfaces from the source-resolution path, matching the
+    // sibling MRP ops (no element pre-check), and must not mutate any dst.
+    const void *bad_src[] = {d_a, nullptr};
+    REQUIRE(hazeIsHalfModulusMrp(dst_polys, bad_src, base, 2, nullptr) ==
+            HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(d_a) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_b) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeIsHalfModulusMrp transport: A/B byte-exact vs ordinary mode",
+          "[integration][hwfmt]") {
+    if (!transport_target_active())
+        SKIP("data format requires a transport target (run under make test-transport)");
+
+    const std::vector<uint64_t> limb_base = {kQ0, kQ1};
+    auto run_once = [&](bool montgomery, bool bit_reversal) {
+        const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+        const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+        const hazeReplayConfig replay = {.target = haze::test::target_from_env(),
+                                         .montgomery = montgomery ? 1 : 0,
+                                         .bit_reversal = bit_reversal ? 1 : 0,
+                                         .reduced_noise = 1};
+        REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+        uint64_t scaffold = 0;
+        REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+        return run_ihm_mrp(limb_base, /*seed=*/838383ULL); // auto aux = kQ2
+    };
+
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const auto ordinary = run_once(/*montgomery=*/false, /*bit_reversal=*/false);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const auto encoded = run_once(/*montgomery=*/true, /*bit_reversal=*/true);
+    REQUIRE(ordinary == encoded);
+    check_ihm_mrp_results(limb_base, /*seed=*/838383ULL, encoded);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeIsHalfModulus with unknown addresses returns error", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+
+    void *d_dst = nullptr;
+    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
+
+    // Synthetic device addresses that were never allocated / written; the
+    // int-to-pointer casts are deliberate (the addresses themselves are the
+    // test subject).
+    // NOLINTBEGIN(performance-no-int-to-ptr)
+    void *fake_src = reinterpret_cast<void *>(uintptr_t{0x4000000000ULL} + 0x8000000ULL);
+    void *fake_dst = reinterpret_cast<void *>(uintptr_t{0x4000000000ULL} + 0x9000000ULL);
+    // NOLINTEND(performance-no-int-to-ptr)
+    REQUIRE(hazeIsHalfModulus(d_dst, fake_src, 0, nullptr) == HAZE_ERROR_UNKNOWN_ADDRESS);
+    hazeGetLastError();
+    REQUIRE(hazeIsHalfModulus(fake_dst, fake_src, 0, nullptr) == HAZE_ERROR_UNKNOWN_ADDRESS);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
+}

--- a/test/test_is_half_modulus.cpp
+++ b/test/test_is_half_modulus.cpp
@@ -37,6 +37,11 @@ constexpr uint64_t kSmallQ = 1073750017ULL;
 // 59-bit NTT-friendly prime with q ≡ 1 (mod kSmallQ): against aux p = kSmallQ
 // it drives qinv == 1, p | h, and the zero-immediate gadget branches at once.
 constexpr uint64_t kCongruentQ = 288241371603542017ULL;
+// 2*kQ0 + 1: composite (3*5*7*13 divide it) — the "safe-prime-looking" aux a
+// caller might configure; the aux selection must skip it (a composite aux
+// makes the Fermat inverse silently wrong).
+constexpr uint64_t kCompositeAux = (2 * kQ0) + 1;
+constexpr uint64_t kEvenModulus = 1ULL << 40;
 
 uint64_t is_half_ref(uint64_t x, uint64_t q) {
     return (x > (q - 1) / 2) ? 1U : 0U;
@@ -121,6 +126,68 @@ TEST_CASE("hazeIsHalfModulus: golden values, small aux prime (h >= p)", "[integr
 TEST_CASE("hazeIsHalfModulus: golden values, q ≡ 1 mod p (qinv == 1, p | h)", "[integration]") {
     setup_two_prime_config(kCongruentQ, kSmallQ);
     run_golden_case(kCongruentQ, /*mod_idx=*/0, /*seed=*/999999ULL);
+}
+
+TEST_CASE("hazeIsHalfModulus: aux selection skips a composite chain entry", "[integration]") {
+    // {kQ0, 2*kQ0+1 (composite), kQ1}: the aux for mod_idx=0 must skip index 1
+    // and land on kQ1; picking the composite would return garbage for every
+    // x > q/2 (Fermat inverse of a composite is not an inverse).
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kCompositeAux, kQ1};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+    run_golden_case(kQ0, /*mod_idx=*/0, /*seed=*/121212ULL); // aux = kQ1
+}
+
+TEST_CASE("hazeIsHalfModulus rejects a chain with no prime aux candidate", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kCompositeAux};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+
+    void *d_src = nullptr;
+    void *d_dst = nullptr;
+    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
+    std::vector<uint64_t> a(kRingDim, 1);
+    REQUIRE(hazeMemcpy(d_src, a.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeIsHalfModulus rejects an even modulus", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kEvenModulus, kQ0};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+
+    void *d_src = nullptr;
+    void *d_dst = nullptr;
+    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
+    std::vector<uint64_t> a(kRingDim, 1);
+    REQUIRE(hazeMemcpy(d_src, a.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    // mod_idx 0 names the even modulus: rejected. An even value is also never
+    // selectable as aux (it fails the primality check).
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    const uint64_t base[] = {kEvenModulus};
+    void *dst_polys[] = {d_dst};
+    const void *src_polys[] = {d_src};
+    REQUIRE(hazeIsHalfModulusMrp(dst_polys, src_polys, base, 1, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
 }
 
 TEST_CASE("hazeIsHalfModulus: in-place dst == src", "[integration]") {
@@ -547,6 +614,21 @@ TEST_CASE("hazeIsHalfModulusMrp: small auto-selected aux (h >= p per limb)", "[i
     const std::vector<uint64_t> limb_base = {kQ1, kQ2};
     check_ihm_mrp_results(limb_base, /*seed=*/828282ULL,
                           run_ihm_mrp(limb_base, /*seed=*/828282ULL));
+}
+
+TEST_CASE("hazeIsHalfModulusMrp: aux selection skips a composite chain entry", "[integration]") {
+    // {kQ0, 2*kQ0+1 (composite), kQ2} with base {kQ0}: aux must skip the
+    // composite and select kQ2.
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kCompositeAux, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+    const std::vector<uint64_t> limb_base = {kQ0};
+    check_ihm_mrp_results(limb_base, /*seed=*/131313ULL,
+                          run_ihm_mrp(limb_base, /*seed=*/131313ULL));
 }
 
 TEST_CASE("hazeIsHalfModulusMrp: base prime outside the configured chain", "[integration]") {

--- a/test/test_is_half_modulus.cpp
+++ b/test/test_is_half_modulus.cpp
@@ -590,11 +590,20 @@ TEST_CASE("hazeIsHalfModulusMrp rejects invalid arguments", "[unit]") {
     void *dst3[] = {d_a, d_b, d_a};
     const void *src3[] = {d_a, d_b, d_a};
     REQUIRE(hazeIsHalfModulusMrp(dst3, src3, full_base, 3, nullptr) == HAZE_ERROR_INVALID_VALUE);
-    // A null src residue surfaces from the source-resolution path, matching the
-    // sibling MRP ops (no element pre-check), and must not mutate any dst.
-    const void *bad_src[] = {d_a, nullptr};
-    REQUIRE(hazeIsHalfModulusMrp(dst_polys, bad_src, base, 2, nullptr) ==
+    // Bad src residues surface from the source-resolution path — the same
+    // lookup build_mrp_locked uses (no element pre-check) — and must not
+    // mutate any dst. An allocated-but-unwritten residue reports
+    // SOURCE_UNAVAILABLE; a null (never-allocated) residue reports
+    // UNKNOWN_ADDRESS. Write d_a first so each case isolates one bad element.
+    const void *unwritten_src[] = {d_a, d_b};
+    REQUIRE(hazeIsHalfModulusMrp(dst_polys, unwritten_src, base, 2, nullptr) ==
             HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+    std::vector<uint64_t> vals(kRingDim, 1);
+    REQUIRE(hazeMemcpy(d_a, vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    const void *null_src[] = {d_a, nullptr};
+    REQUIRE(hazeIsHalfModulusMrp(dst_polys, null_src, base, 2, nullptr) ==
+            HAZE_ERROR_UNKNOWN_ADDRESS);
     hazeGetLastError();
 
     REQUIRE(hazeFree(d_a) == HAZE_SUCCESS);


### PR DESCRIPTION
## Summary

Adds the per-coefficient predicate `dst_i = (src_i > q/2) ? 1 : 0` to the compute surface:

- `hazeIsHalfModulus(dst, src, mod_idx, stream)` — SRP
- `hazeIsHalfModulusMrp(dst, src, base, base_len, stream)` — per-limb variant 