### PR TITLE
feat(compute): add broadcast MRP ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,8 @@ add_library(haze_objs OBJECT
   src/core/allocator.cpp
   src/core/backend.cpp
   src/core/basis_convert.cpp
+  src/core/broadcast.cpp
+  src/core/centered_switch.cpp
   src/core/config.cpp
   src/core/device.cpp
   src/core/device_state.cpp
@@ -428,6 +430,7 @@ add_executable(haze_tests
   test/test_config.cpp
   test/test_compute.cpp
   test/test_is_half_modulus.cpp
+  test/test_broadcast.cpp
   test/test_basis_convert.cpp
   test/test_mul_rotation.cpp
   test/test_ring_dim_consistency.cpp

--- a/README.md
+++ b/README.md
@@ -370,8 +370,9 @@ int main() {
 <!-- readme-example:end -->
 
 Replace `hazeAddMrp` with any sequence of `hazeMulMrp`, `hazeNTTMrp`,
-`hazeAutomorphMrp`, `hazeIsHalfModulusMrp`, `hazeBasisConvert`, ... and the
-recording layer captures every op in execution order. `test/test_compute.cpp` and
+`hazeAutomorphMrp`, `hazeIsHalfModulusMrp`, `hazeBroadcastMulMrp`,
+`hazeBasisConvert`, ... and the recording layer captures every op in execution
+order. `test/test_compute.cpp` and
 `test/test_basis_convert.cpp` exercise the full surface; the `test/e2e/` suite
 builds the CKKS operation set (add, mult + relin, rotate, rescale) on the same
 C ABI.

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -279,32 +279,34 @@ HAZE_API hazeError_t hazeIsHalfModulusMrp(void *const *dst, const void *const *s
                                           hazeStream_t stream) HAZE_NOEXCEPT;
 
 // hazeBroadcastAddMrp records dst[i]_k = src[i]_k + lift(operand)_k mod base[i]:
-// `operand` is one single-residue polynomial under `operand_modulus`, lifted into every
-// base prime by the centered modulus switch (a base prime equal to operand_modulus
-// passes the operand through verbatim; on transport targets operand_modulus must be
-// bridge-synthesizable, i.e. a prime ≡ 1 mod 2*ring_dim). Non-zero `operand_in_range`
-// asserts every coefficient is <= (operand_modulus-1)/2 and that the coefficient is
-// below every base prime (e.g. a hazeIsHalfModulus mask) — unvalidated — and elides the
-// lift wherever the RECORDED data format allows; an ordinary-form recording that used
-// the flag with base_len > 1 must not be replayed under --niobium_hw (the driver
+// `operand` is one single-residue polynomial lifted into every base prime by the
+// centered modulus switch. Its ring p is the modulus haze recorded for the op that
+// produced it (e.g. the hazeIsHalfModulus aux prime); a raw H2D operand has none and
+// is rejected — run it through a modulus-carrying op first. A base prime equal to p
+// passes the operand through verbatim; on transport targets p must be
+// bridge-synthesizable, i.e. a prime ≡ 1 mod 2*ring_dim. Non-zero `operand_in_range`
+// asserts every coefficient is <= (p-1)/2 and that the coefficient is below every
+// base prime (e.g. a hazeIsHalfModulus mask) — unvalidated — and elides the lift
+// wherever the RECORDED data format allows; an ordinary-form recording that used the
+// flag with base_len > 1 must not be replayed under --niobium_hw (the driver
 // re-encodes each input under one modulus only). Sub subtracts the lifted operand;
 // Rsub subtracts src from it.
 HAZE_API hazeError_t hazeBroadcastAddMrp(void *const *dst, const void *const *src,
-                                         const void *operand, uint64_t operand_modulus,
-                                         int operand_in_range, const uint64_t *base,
-                                         size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
+                                         const void *operand, int operand_in_range,
+                                         const uint64_t *base, size_t base_len,
+                                         hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeBroadcastSubMrp(void *const *dst, const void *const *src,
-                                         const void *operand, uint64_t operand_modulus,
-                                         int operand_in_range, const uint64_t *base,
-                                         size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
+                                         const void *operand, int operand_in_range,
+                                         const uint64_t *base, size_t base_len,
+                                         hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeBroadcastRsubMrp(void *const *dst, const void *const *src,
-                                          const void *operand, uint64_t operand_modulus,
-                                          int operand_in_range, const uint64_t *base,
-                                          size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
+                                          const void *operand, int operand_in_range,
+                                          const uint64_t *base, size_t base_len,
+                                          hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeBroadcastMulMrp(void *const *dst, const void *const *src,
-                                         const void *operand, uint64_t operand_modulus,
-                                         int operand_in_range, const uint64_t *base,
-                                         size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
+                                         const void *operand, int operand_in_range,
+                                         const uint64_t *base, size_t base_len,
+                                         hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeNTTMrp(void *const *dst, const void *const *src, const uint64_t *base,
                                 size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeINTTMrp(void *const *dst, const void *const *src, const uint64_t *base,

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -277,6 +277,34 @@ HAZE_API hazeError_t hazeMulScalarMrp(void *const *dst, const void *const *src,
 HAZE_API hazeError_t hazeIsHalfModulusMrp(void *const *dst, const void *const *src,
                                           const uint64_t *base, size_t base_len,
                                           hazeStream_t stream) HAZE_NOEXCEPT;
+
+// hazeBroadcastAddMrp records dst[i]_k = src[i]_k + lift(operand)_k mod base[i]:
+// `operand` is one single-residue polynomial under `operand_modulus`, lifted into every
+// base prime by the centered modulus switch (a base prime equal to operand_modulus
+// passes the operand through verbatim; on transport targets operand_modulus must be
+// bridge-synthesizable, i.e. a prime ≡ 1 mod 2*ring_dim). Non-zero `operand_in_range`
+// asserts every coefficient is <= (operand_modulus-1)/2 and that the coefficient is
+// below every base prime (e.g. a hazeIsHalfModulus mask) — unvalidated — and elides the
+// lift wherever the RECORDED data format allows; an ordinary-form recording that used
+// the flag with base_len > 1 must not be replayed under --niobium_hw (the driver
+// re-encodes each input under one modulus only). Sub subtracts the lifted operand;
+// Rsub subtracts src from it.
+HAZE_API hazeError_t hazeBroadcastAddMrp(void *const *dst, const void *const *src,
+                                         const void *operand, uint64_t operand_modulus,
+                                         int operand_in_range, const uint64_t *base,
+                                         size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeBroadcastSubMrp(void *const *dst, const void *const *src,
+                                         const void *operand, uint64_t operand_modulus,
+                                         int operand_in_range, const uint64_t *base,
+                                         size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeBroadcastRsubMrp(void *const *dst, const void *const *src,
+                                          const void *operand, uint64_t operand_modulus,
+                                          int operand_in_range, const uint64_t *base,
+                                          size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
+HAZE_API hazeError_t hazeBroadcastMulMrp(void *const *dst, const void *const *src,
+                                         const void *operand, uint64_t operand_modulus,
+                                         int operand_in_range, const uint64_t *base,
+                                         size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeNTTMrp(void *const *dst, const void *const *src, const uint64_t *base,
                                 size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
 HAZE_API hazeError_t hazeINTTMrp(void *const *dst, const void *const *src, const uint64_t *base,

--- a/src/api/compute.cpp
+++ b/src/api/compute.cpp
@@ -215,43 +215,43 @@ extern "C" hazeError_t hazeRotAutomorphCoeffMrp(void *const *dst, const void *co
 // Broadcast MRP ops: one single-residue operand applied to every limb.
 
 extern "C" hazeError_t hazeBroadcastAddMrp(void *const *dst, const void *const *src,
-                                           const void *operand, uint64_t operand_modulus,
-                                           int operand_in_range, const uint64_t *base,
-                                           size_t base_len, hazeStream_t /*stream*/) noexcept {
+                                           const void *operand, int operand_in_range,
+                                           const uint64_t *base, size_t base_len,
+                                           hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || operand == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return set_internal_result(haze::broadcast_add(dst, src, operand, operand_modulus,
-                                                   operand_in_range != 0, base, base_len));
+    return set_internal_result(
+        haze::broadcast_add(dst, src, operand, operand_in_range != 0, base, base_len));
 }
 
 extern "C" hazeError_t hazeBroadcastSubMrp(void *const *dst, const void *const *src,
-                                           const void *operand, uint64_t operand_modulus,
-                                           int operand_in_range, const uint64_t *base,
-                                           size_t base_len, hazeStream_t /*stream*/) noexcept {
+                                           const void *operand, int operand_in_range,
+                                           const uint64_t *base, size_t base_len,
+                                           hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || operand == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return set_internal_result(haze::broadcast_sub(dst, src, operand, operand_modulus,
-                                                   operand_in_range != 0, base, base_len));
+    return set_internal_result(
+        haze::broadcast_sub(dst, src, operand, operand_in_range != 0, base, base_len));
 }
 
 extern "C" hazeError_t hazeBroadcastRsubMrp(void *const *dst, const void *const *src,
-                                            const void *operand, uint64_t operand_modulus,
-                                            int operand_in_range, const uint64_t *base,
-                                            size_t base_len, hazeStream_t /*stream*/) noexcept {
+                                            const void *operand, int operand_in_range,
+                                            const uint64_t *base, size_t base_len,
+                                            hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || operand == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return set_internal_result(haze::broadcast_rsub(dst, src, operand, operand_modulus,
-                                                    operand_in_range != 0, base, base_len));
+    return set_internal_result(
+        haze::broadcast_rsub(dst, src, operand, operand_in_range != 0, base, base_len));
 }
 
 extern "C" hazeError_t hazeBroadcastMulMrp(void *const *dst, const void *const *src,
-                                           const void *operand, uint64_t operand_modulus,
-                                           int operand_in_range, const uint64_t *base,
-                                           size_t base_len, hazeStream_t /*stream*/) noexcept {
+                                           const void *operand, int operand_in_range,
+                                           const uint64_t *base, size_t base_len,
+                                           hazeStream_t /*stream*/) noexcept {
     if (dst == nullptr || src == nullptr || operand == nullptr || base == nullptr || base_len == 0)
         return set_error(HAZE_ERROR_INVALID_VALUE);
-    return set_internal_result(haze::broadcast_mul(dst, src, operand, operand_modulus,
-                                                   operand_in_range != 0, base, base_len));
+    return set_internal_result(
+        haze::broadcast_mul(dst, src, operand, operand_in_range != 0, base, base_len));
 }
 
 // CRT basis conversion lives in basis_convert.cpp; graph capture stubs live in graph.cpp.

--- a/src/api/compute.cpp
+++ b/src/api/compute.cpp
@@ -18,6 +18,7 @@
 
 #include "common/errors.hpp"
 #include "common/handle.hpp"
+#include "core/broadcast.hpp"
 #include "core/is_half_modulus.hpp"
 
 #include <cstddef>
@@ -209,6 +210,48 @@ extern "C" hazeError_t hazeRotAutomorphCoeffMrp(void *const *dst, const void *co
         return set_error(HAZE_ERROR_INVALID_VALUE);
     return set_internal_result(
         haze::unary_pi_op_mrp<fhetch::mr_rot_automorph_coeff>(dst, src, offset, base, base_len));
+}
+
+// Broadcast MRP ops: one single-residue operand applied to every limb.
+
+extern "C" hazeError_t hazeBroadcastAddMrp(void *const *dst, const void *const *src,
+                                           const void *operand, uint64_t operand_modulus,
+                                           int operand_in_range, const uint64_t *base,
+                                           size_t base_len, hazeStream_t /*stream*/) noexcept {
+    if (dst == nullptr || src == nullptr || operand == nullptr || base == nullptr || base_len == 0)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    return set_internal_result(haze::broadcast_add(dst, src, operand, operand_modulus,
+                                                   operand_in_range != 0, base, base_len));
+}
+
+extern "C" hazeError_t hazeBroadcastSubMrp(void *const *dst, const void *const *src,
+                                           const void *operand, uint64_t operand_modulus,
+                                           int operand_in_range, const uint64_t *base,
+                                           size_t base_len, hazeStream_t /*stream*/) noexcept {
+    if (dst == nullptr || src == nullptr || operand == nullptr || base == nullptr || base_len == 0)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    return set_internal_result(haze::broadcast_sub(dst, src, operand, operand_modulus,
+                                                   operand_in_range != 0, base, base_len));
+}
+
+extern "C" hazeError_t hazeBroadcastRsubMrp(void *const *dst, const void *const *src,
+                                            const void *operand, uint64_t operand_modulus,
+                                            int operand_in_range, const uint64_t *base,
+                                            size_t base_len, hazeStream_t /*stream*/) noexcept {
+    if (dst == nullptr || src == nullptr || operand == nullptr || base == nullptr || base_len == 0)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    return set_internal_result(haze::broadcast_rsub(dst, src, operand, operand_modulus,
+                                                    operand_in_range != 0, base, base_len));
+}
+
+extern "C" hazeError_t hazeBroadcastMulMrp(void *const *dst, const void *const *src,
+                                           const void *operand, uint64_t operand_modulus,
+                                           int operand_in_range, const uint64_t *base,
+                                           size_t base_len, hazeStream_t /*stream*/) noexcept {
+    if (dst == nullptr || src == nullptr || operand == nullptr || base == nullptr || base_len == 0)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    return set_internal_result(haze::broadcast_mul(dst, src, operand, operand_modulus,
+                                                   operand_in_range != 0, base, base_len));
 }
 
 // CRT basis conversion lives in basis_convert.cpp; graph capture stubs live in graph.cpp.

--- a/src/core/broadcast.cpp
+++ b/src/core/broadcast.cpp
@@ -1,0 +1,125 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+//
+// hazeBroadcast*Mrp lowering: lift one single-residue operand into every base
+// prime via the centered switch, then apply the pointwise op per limb.
+
+#include "core/broadcast.hpp"
+
+#include "common/errors.hpp"
+#include "common/handle.hpp"
+#include "core/centered_switch.hpp"
+#include "core/config.hpp"
+#include "core/epoch.hpp"
+#include "core/mrp_polymap.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <niobium/fhetch_api.h>
+#include <utility>
+#include <vector>
+
+namespace haze {
+
+namespace fhetch = niobium::fhetch;
+
+namespace {
+
+// dst[i] = src[i] op lift(operand) per limb (kReversed swaps the operands).
+// The lift is skipped when the limb already lives in the operand's ring, or
+// when the caller asserts in-range coefficients and the RECORDED format is
+// ordinary (under montgomery the switch is the data-format conversion and
+// cannot be elided; an ordinary-form direct-path recording is not portable to
+// --niobium_hw replay — see the haze.h contract).
+template <auto OpFn, bool kReversed = false>
+std::expected<void, HazeInternalError> broadcast_op(void *const *dst, const void *const *src,
+                                                    const void *operand, uint64_t operand_modulus,
+                                                    bool operand_in_range, const uint64_t *base,
+                                                    std::size_t base_len) noexcept {
+    if (auto v = validate_moduli_base(base, base_len); !v)
+        return v;
+    if (operand_modulus == 0) {
+        record_internal_error(HazeInternalError::InvalidArgument,
+                              "hazeBroadcastMrp: zero operand modulus");
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    }
+    if (auto live = require_allocated_array(dst, base_len); !live)
+        return live;
+    EpochSession session;
+    if (auto rec = epoch().require_recording_locked(); !rec)
+        return rec;
+    // A recorded modulus that disagrees with the caller's is a caller bug;
+    // raw H2D operands have none recorded and pass.
+    const uint64_t recorded = epoch().recorded_modulus_locked(to_dev_addr(operand));
+    if (recorded != kCopyModulus && recorded != operand_modulus) {
+        record_internal_error(HazeInternalError::InvalidArgument,
+                              "hazeBroadcastMrp: operand modulus disagrees with recorded modulus");
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    }
+    auto x = build_mrp_locked(src, base, base_len);
+    if (!x)
+        return std::unexpected(x.error());
+    auto m = epoch().lookup_or_create_locked(to_dev_addr(operand));
+    if (!m)
+        return std::unexpected(m.error());
+
+    const bool direct = operand_in_range && !replay_config().montgomery();
+    std::vector<std::pair<fhetch::Polynomial, uint64_t>> pairs;
+    pairs.reserve(base_len);
+    for (std::size_t i = 0; i < base_len; ++i) {
+        const uint64_t q = base[i];
+        const fhetch::Polynomial lifted =
+            (direct || q == operand_modulus) ? *m : emit_centered_switch(*m, operand_modulus, q);
+        const fhetch::Polynomial &limb = (*x)[q];
+        pairs.emplace_back(kReversed ? OpFn(lifted, limb, q) : OpFn(limb, lifted, q), q);
+    }
+    const fhetch::MRP result = fhetch::MRP::from_pairs(pairs);
+    return store_mrp_locked(dst, result, base, base_len);
+}
+
+} // namespace
+
+std::expected<void, HazeInternalError> broadcast_add(void *const *dst, const void *const *src,
+                                                     const void *operand, uint64_t operand_modulus,
+                                                     bool operand_in_range, const uint64_t *base,
+                                                     std::size_t base_len) noexcept {
+    return broadcast_op<fhetch::sr_addp>(dst, src, operand, operand_modulus, operand_in_range, base,
+                                         base_len);
+}
+
+std::expected<void, HazeInternalError> broadcast_sub(void *const *dst, const void *const *src,
+                                                     const void *operand, uint64_t operand_modulus,
+                                                     bool operand_in_range, const uint64_t *base,
+                                                     std::size_t base_len) noexcept {
+    return broadcast_op<fhetch::sr_subp>(dst, src, operand, operand_modulus, operand_in_range, base,
+                                         base_len);
+}
+
+std::expected<void, HazeInternalError> broadcast_rsub(void *const *dst, const void *const *src,
+                                                      const void *operand, uint64_t operand_modulus,
+                                                      bool operand_in_range, const uint64_t *base,
+                                                      std::size_t base_len) noexcept {
+    return broadcast_op<fhetch::sr_subp, /*kReversed=*/true>(dst, src, operand, operand_modulus,
+                                                             operand_in_range, base, base_len);
+}
+
+std::expected<void, HazeInternalError> broadcast_mul(void *const *dst, const void *const *src,
+                                                     const void *operand, uint64_t operand_modulus,
+                                                     bool operand_in_range, const uint64_t *base,
+                                                     std::size_t base_len) noexcept {
+    return broadcast_op<fhetch::sr_mulp>(dst, src, operand, operand_modulus, operand_in_range, base,
+                                         base_len);
+}
+
+} // namespace haze

--- a/src/core/broadcast.cpp
+++ b/src/core/broadcast.cpp
@@ -43,28 +43,29 @@ namespace {
 // cannot be elided; an ordinary-form direct-path recording is not portable to
 // --niobium_hw replay — see the haze.h contract).
 template <auto OpFn, bool kReversed = false>
-std::expected<void, HazeInternalError> broadcast_op(void *const *dst, const void *const *src,
-                                                    const void *operand, uint64_t operand_modulus,
-                                                    bool operand_in_range, const uint64_t *base,
-                                                    std::size_t base_len) noexcept {
+std::expected<void, HazeInternalError>
+broadcast_op(void *const *dst, const void *const *src, const void *operand, bool operand_in_range,
+             const uint64_t *base, std::size_t base_len) noexcept {
     if (auto v = validate_moduli_base(base, base_len); !v)
         return v;
-    if (operand_modulus == 0) {
-        record_internal_error(HazeInternalError::InvalidArgument,
-                              "hazeBroadcastMrp: zero operand modulus");
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    }
     if (auto live = require_allocated_array(dst, base_len); !live)
         return live;
     EpochSession session;
     if (auto rec = epoch().require_recording_locked(); !rec)
         return rec;
-    // A recorded modulus that disagrees with the caller's is a caller bug;
-    // raw H2D operands have none recorded and pass.
-    const uint64_t recorded = epoch().recorded_modulus_locked(to_dev_addr(operand));
-    if (recorded != kCopyModulus && recorded != operand_modulus) {
+    // The operand's ring is the modulus haze recorded for the op that produced
+    // it (e.g. the hazeIsHalfModulus aux prime); a raw H2D operand has none —
+    // record one first (any modulus-carrying op).
+    const uint64_t operand_modulus = epoch().recorded_modulus_locked(to_dev_addr(operand));
+    if (operand_modulus == kCopyModulus) {
         record_internal_error(HazeInternalError::InvalidArgument,
-                              "hazeBroadcastMrp: operand modulus disagrees with recorded modulus");
+                              "hazeBroadcastMrp: operand has no recorded modulus");
+        return std::unexpected(HazeInternalError::InvalidArgument);
+    }
+    if (operand_modulus % 2 == 0) {
+        // h = (p-1)/2 centering needs an odd operand ring.
+        record_internal_error(HazeInternalError::InvalidArgument,
+                              "hazeBroadcastMrp: operand modulus must be odd");
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
     auto x = build_mrp_locked(src, base, base_len);
@@ -91,35 +92,32 @@ std::expected<void, HazeInternalError> broadcast_op(void *const *dst, const void
 } // namespace
 
 std::expected<void, HazeInternalError> broadcast_add(void *const *dst, const void *const *src,
-                                                     const void *operand, uint64_t operand_modulus,
-                                                     bool operand_in_range, const uint64_t *base,
+                                                     const void *operand, bool operand_in_range,
+                                                     const uint64_t *base,
                                                      std::size_t base_len) noexcept {
-    return broadcast_op<fhetch::sr_addp>(dst, src, operand, operand_modulus, operand_in_range, base,
-                                         base_len);
+    return broadcast_op<fhetch::sr_addp>(dst, src, operand, operand_in_range, base, base_len);
 }
 
 std::expected<void, HazeInternalError> broadcast_sub(void *const *dst, const void *const *src,
-                                                     const void *operand, uint64_t operand_modulus,
-                                                     bool operand_in_range, const uint64_t *base,
+                                                     const void *operand, bool operand_in_range,
+                                                     const uint64_t *base,
                                                      std::size_t base_len) noexcept {
-    return broadcast_op<fhetch::sr_subp>(dst, src, operand, operand_modulus, operand_in_range, base,
-                                         base_len);
+    return broadcast_op<fhetch::sr_subp>(dst, src, operand, operand_in_range, base, base_len);
 }
 
 std::expected<void, HazeInternalError> broadcast_rsub(void *const *dst, const void *const *src,
-                                                      const void *operand, uint64_t operand_modulus,
-                                                      bool operand_in_range, const uint64_t *base,
+                                                      const void *operand, bool operand_in_range,
+                                                      const uint64_t *base,
                                                       std::size_t base_len) noexcept {
-    return broadcast_op<fhetch::sr_subp, /*kReversed=*/true>(dst, src, operand, operand_modulus,
-                                                             operand_in_range, base, base_len);
+    return broadcast_op<fhetch::sr_subp, /*kReversed=*/true>(dst, src, operand, operand_in_range,
+                                                             base, base_len);
 }
 
 std::expected<void, HazeInternalError> broadcast_mul(void *const *dst, const void *const *src,
-                                                     const void *operand, uint64_t operand_modulus,
-                                                     bool operand_in_range, const uint64_t *base,
+                                                     const void *operand, bool operand_in_range,
+                                                     const uint64_t *base,
                                                      std::size_t base_len) noexcept {
-    return broadcast_op<fhetch::sr_mulp>(dst, src, operand, operand_modulus, operand_in_range, base,
-                                         base_len);
+    return broadcast_op<fhetch::sr_mulp>(dst, src, operand, operand_in_range, base, base_len);
 }
 
 } // namespace haze

--- a/src/core/broadcast.hpp
+++ b/src/core/broadcast.hpp
@@ -25,23 +25,23 @@ namespace haze {
 // EpochSession internally.
 
 std::expected<void, HazeInternalError> broadcast_add(void *const *dst, const void *const *src,
-                                                     const void *operand, uint64_t operand_modulus,
-                                                     bool operand_in_range, const uint64_t *base,
+                                                     const void *operand, bool operand_in_range,
+                                                     const uint64_t *base,
                                                      std::size_t base_len) noexcept;
 
 std::expected<void, HazeInternalError> broadcast_sub(void *const *dst, const void *const *src,
-                                                     const void *operand, uint64_t operand_modulus,
-                                                     bool operand_in_range, const uint64_t *base,
+                                                     const void *operand, bool operand_in_range,
+                                                     const uint64_t *base,
                                                      std::size_t base_len) noexcept;
 
 std::expected<void, HazeInternalError> broadcast_rsub(void *const *dst, const void *const *src,
-                                                      const void *operand, uint64_t operand_modulus,
-                                                      bool operand_in_range, const uint64_t *base,
+                                                      const void *operand, bool operand_in_range,
+                                                      const uint64_t *base,
                                                       std::size_t base_len) noexcept;
 
 std::expected<void, HazeInternalError> broadcast_mul(void *const *dst, const void *const *src,
-                                                     const void *operand, uint64_t operand_modulus,
-                                                     bool operand_in_range, const uint64_t *base,
+                                                     const void *operand, bool operand_in_range,
+                                                     const uint64_t *base,
                                                      std::size_t base_len) noexcept;
 
 } // namespace haze

--- a/src/core/broadcast.hpp
+++ b/src/core/broadcast.hpp
@@ -1,0 +1,47 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#pragma once
+
+#include "common/errors.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+
+namespace haze {
+
+// Internal entry points for hazeBroadcast{Add,Sub,Rsub,Mul}Mrp — one
+// single-residue operand applied to every limb of an MRP; each opens an
+// EpochSession internally.
+
+std::expected<void, HazeInternalError> broadcast_add(void *const *dst, const void *const *src,
+                                                     const void *operand, uint64_t operand_modulus,
+                                                     bool operand_in_range, const uint64_t *base,
+                                                     std::size_t base_len) noexcept;
+
+std::expected<void, HazeInternalError> broadcast_sub(void *const *dst, const void *const *src,
+                                                     const void *operand, uint64_t operand_modulus,
+                                                     bool operand_in_range, const uint64_t *base,
+                                                     std::size_t base_len) noexcept;
+
+std::expected<void, HazeInternalError> broadcast_rsub(void *const *dst, const void *const *src,
+                                                      const void *operand, uint64_t operand_modulus,
+                                                      bool operand_in_range, const uint64_t *base,
+                                                      std::size_t base_len) noexcept;
+
+std::expected<void, HazeInternalError> broadcast_mul(void *const *dst, const void *const *src,
+                                                     const void *operand, uint64_t operand_modulus,
+                                                     bool operand_in_range, const uint64_t *base,
+                                                     std::size_t base_len) noexcept;
+
+} // namespace haze

--- a/src/core/centered_switch.cpp
+++ b/src/core/centered_switch.cpp
@@ -1,0 +1,37 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+
+#include "core/centered_switch.hpp"
+
+#include "core/config.hpp"
+
+#include <cstdint>
+#include <niobium/fhetch_api.h>
+
+namespace haze {
+
+namespace fhetch = niobium::fhetch;
+
+niobium::fhetch::Polynomial emit_centered_switch(const niobium::fhetch::Polynomial &v, uint64_t q,
+                                                 uint64_t p) {
+    const uint64_t half_q = (q - 1) / 2;
+    const uint64_t half_mod_p = half_q % p;
+    const uint64_t neg_half = (half_mod_p == 0) ? 0 : p - half_mod_p;
+    const fhetch::Polynomial shift_in =
+        replay_config().montgomery() ? fhetch::sr_mulps(v, fhetch::Scalar::from_int(1), q) : v;
+    const auto shifted = fhetch::sr_addps(shift_in, fhetch::Scalar::from_int(half_q), q);
+    const auto rebased = fhetch::sr_mulps(shifted, fhetch::Scalar::from_int(1), p);
+    return fhetch::sr_addps(rebased, fhetch::Scalar::from_int(neg_half), p);
+}
+
+} // namespace haze

--- a/src/core/centered_switch.hpp
+++ b/src/core/centered_switch.hpp
@@ -21,7 +21,7 @@ namespace haze {
 // (v - q) mod p. Emits the exact shape of fhetch's center_mod_q_into_p
 // (vendor-internal; montgomery keying as basis_convert.cpp's fbc_center_shape)
 // so the hardware replay driver recognizes and substitutes the chain;
-// intermediates must stay single-use SSA values.
+// intermediates must stay single-use SSA values. Callers validate q, p != 0.
 niobium::fhetch::Polynomial emit_centered_switch(const niobium::fhetch::Polynomial &v, uint64_t q,
                                                  uint64_t p);
 

--- a/src/core/centered_switch.hpp
+++ b/src/core/centered_switch.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#pragma once
+
+#include <cstdint>
+#include <niobium/fhetch_api.h>
+
+namespace haze {
+
+// Centered modulus switch q -> p: c(v) = v mod p for v <= (q-1)/2, else
+// (v - q) mod p. Emits the exact shape of fhetch's center_mod_q_into_p
+// (vendor-internal; montgomery keying as basis_convert.cpp's fbc_center_shape)
+// so the hardware replay driver recognizes and substitutes the chain;
+// intermediates must stay single-use SSA values.
+niobium::fhetch::Polynomial emit_centered_switch(const niobium::fhetch::Polynomial &v, uint64_t q,
+                                                 uint64_t p);
+
+} // namespace haze

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -201,10 +201,12 @@ std::expected<void, HazeInternalError> EpochState::tag_h2d_input_locked(DevAddr 
         fhetch::Polynomial::from_data(std::move(*components), ring_dim, fhetch::Format::Evaluation);
     const std::string name = "haze_in_" + std::to_string(input_counter_++);
     fhetch::tag_input(name, poly);
-    // New H2D bytes overwrite the binding, drop any output tag, and reclassify
-    // the addr as a live-in input (MRP-group claims stay).
+    // New H2D bytes overwrite the binding, drop any output tag and stale
+    // modulus, and reclassify the addr as a live-in input (MRP-group claims
+    // stay).
     poly_map_.insert_or_assign(addr, std::move(poly));
     pending_outputs_.erase(addr);
+    addr_modulus_.erase(addr);
     input_addrs_.insert(addr);
     return {};
 }

--- a/src/core/is_half_modulus.cpp
+++ b/src/core/is_half_modulus.cpp
@@ -20,6 +20,7 @@
 #include "common/errors.hpp"
 #include "common/handle.hpp"
 #include "core/allocator.hpp"
+#include "core/centered_switch.hpp"
 #include "core/config.hpp"
 #include "core/device.hpp"
 #include "core/epoch.hpp"
@@ -94,22 +95,6 @@ bool is_prime_u64(uint64_t n) noexcept {
             return false;
     }
     return true;
-}
-
-// Centered modulus switch q -> p: c(v) = v mod p for v <= (q-1)/2, else
-// (v - q) mod p. Emits the exact shape of fhetch's center_mod_q_into_p
-// (vendor-internal; montgomery keying as basis_convert.cpp's fbc_center_shape)
-// so the hardware replay driver recognizes and substitutes the chain;
-// intermediates must stay single-use SSA values.
-fhetch::Polynomial emit_centered_switch(const fhetch::Polynomial &v, uint64_t q, uint64_t p) {
-    const uint64_t half_q = (q - 1) / 2;
-    const uint64_t half_mod_p = half_q % p;
-    const uint64_t neg_half = (half_mod_p == 0) ? 0 : p - half_mod_p;
-    const fhetch::Polynomial shift_in =
-        replay_config().montgomery() ? fhetch::sr_mulps(v, fhetch::Scalar::from_int(1), q) : v;
-    const auto shifted = fhetch::sr_addps(shift_in, fhetch::Scalar::from_int(half_q), q);
-    const auto rebased = fhetch::sr_mulps(shifted, fhetch::Scalar::from_int(1), p);
-    return fhetch::sr_addps(rebased, fhetch::Scalar::from_int(neg_half), p);
 }
 
 // b = [x > h], h = (q-1)/2: g1 = c(x-h) == x-h (signed), g2 = c(x) == x - q*b,

--- a/test/test_broadcast.cpp
+++ b/test/test_broadcast.cpp
@@ -1,0 +1,647 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+//
+// hazeBroadcast{Add,Sub,Rsub,Mul}Mrp tests: [unit] validation and trace-shape
+// pinning, [integration] golden values, [hwfmt] transport cases.
+
+#include "integration_helpers.hpp"
+#include "mod_arith_ref.hpp"
+
+#include <catch2/catch_message.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <haze/haze.h>
+#include <haze/haze_types.h>
+#include <haze/replay_bridge.h>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+constexpr uint64_t kRingDim = 4096;
+constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
+
+// Suite NTT-friendly primes (q ≡ 1 mod 2N for N=4096); matches test_compute.cpp.
+constexpr uint64_t kQ0 = 576460752303415297ULL;
+constexpr uint64_t kQ1 = 576460752303439873ULL;
+constexpr uint64_t kQ2 = 576460752303702017ULL;
+// Small NTT-friendly prime (~2^30, ≡ 1 mod 8192); the replay bridge's floor.
+constexpr uint64_t kSmallQ = 1073750017ULL;
+// 48-bit NTT-friendly prime with kSmallQ | (p-1)/2: lifting from it into a
+// kSmallQ limb zeroes the gadget's unshift immediate (the sim copy path).
+constexpr uint64_t kCongruentP = 211107843342337ULL;
+
+enum class Op : std::uint8_t { Add, Sub, Rsub, Mul };
+
+hazeError_t call_broadcast(Op op, void *const *dst, const void *const *src, const void *operand,
+                           uint64_t p, int in_range, const uint64_t *base, std::size_t len) {
+    switch (op) {
+    case Op::Add:
+        return hazeBroadcastAddMrp(dst, src, operand, p, in_range, base, len, nullptr);
+    case Op::Sub:
+        return hazeBroadcastSubMrp(dst, src, operand, p, in_range, base, len, nullptr);
+    case Op::Rsub:
+        return hazeBroadcastRsubMrp(dst, src, operand, p, in_range, base, len, nullptr);
+    case Op::Mul:
+        return hazeBroadcastMulMrp(dst, src, operand, p, in_range, base, len, nullptr);
+    }
+    return HAZE_ERROR_INVALID_VALUE;
+}
+
+// Centered lift oracle: m for m <= (p-1)/2, else m - p, reduced mod q.
+uint64_t lift_ref(uint64_t m, uint64_t p, uint64_t q) {
+    if (m <= (p - 1) / 2)
+        return m % q;
+    const uint64_t neg = (p - m) % q;
+    return neg == 0 ? 0 : q - neg;
+}
+
+uint64_t op_ref(Op op, uint64_t a, uint64_t b, uint64_t q) {
+    switch (op) {
+    case Op::Add:
+        return (a + b) % q;
+    case Op::Sub:
+        return (a >= b) ? a - b : a + (q - b);
+    case Op::Rsub:
+        return (b >= a) ? b - a : b + (q - a);
+    case Op::Mul:
+        return niobium::mod_arith::mulmod(a, b, q);
+    }
+    return 0;
+}
+
+// Run one broadcast over pseudorandom limbs and operand, flush, and require
+// exact equality against the lift+op oracle on every coefficient. The operand
+// limb for base[i] == p is used verbatim (no lift), matching the pass-through.
+void run_broadcast_golden(Op op, const std::vector<uint64_t> &base, uint64_t p,
+                          const std::vector<uint64_t> &operand_vals, int in_range, uint64_t seed) {
+    std::vector<std::vector<uint64_t>> inputs(base.size());
+    for (std::size_t i = 0; i < base.size(); ++i)
+        inputs[i] = haze::test::make_residue(base[i], seed + i, kRingDim);
+
+    const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
+    const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    void *d_m = nullptr;
+    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_m, operand_vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
+            HAZE_SUCCESS);
+
+    const std::vector<const void *> src_view = haze::test::to_const(d_src);
+    REQUIRE(call_broadcast(op, d_dst.data(), src_view.data(), d_m, p, in_range, base.data(),
+                           base.size()) == HAZE_SUCCESS);
+    for (void *out : d_dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    for (std::size_t i = 0; i < base.size(); ++i) {
+        const uint64_t q = base[i];
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), d_dst[i], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+                HAZE_SUCCESS);
+        for (std::size_t k = 0; k < kRingDim; ++k) {
+            const uint64_t lifted = (q == p) ? operand_vals[k] : lift_ref(operand_vals[k], p, q);
+            INFO("op " << static_cast<int>(op) << " residue " << i << " (mod " << q << ") slot "
+                       << k << " x " << inputs[i][k] << " m " << operand_vals[k]);
+            REQUIRE(got[k] == op_ref(op, inputs[i][k], lifted, q));
+        }
+    }
+
+    haze::test::free_all_residues(d_src);
+    haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
+}
+
+std::vector<uint64_t> binary_mask(uint64_t seed) {
+    std::vector<uint64_t> m(kRingDim);
+    for (std::size_t k = 0; k < kRingDim; ++k)
+        m[k] = ((seed >> (k % 17U)) ^ k) & 1U;
+    return m;
+}
+
+// Pseudorandom operand mod p with the centered-lift boundary values pinned
+// into the leading slots (the sign flips between h and h+1, h = (p-1)/2).
+std::vector<uint64_t> boundary_operand(uint64_t p, uint64_t seed) {
+    std::vector<uint64_t> vals = haze::test::make_residue(p, seed, kRingDim);
+    const uint64_t h = (p - 1) / 2;
+    const uint64_t edges[] = {0, 1, h - 1, h, h + 1, p - 2, p - 1};
+    for (std::size_t i = 0; i < 7; ++i)
+        vals[i] = edges[i];
+    return vals;
+}
+
+} // namespace
+
+// ===========================================================================
+// Golden values ([integration]: runs under test-sim and test-transport).
+// ===========================================================================
+
+TEST_CASE("hazeBroadcastMulMrp: hazeIsHalfModulus mask applied to all limbs", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0); // {kQ0, kQ1, kQ2}
+
+    // Mask: SRP predicate of a value under kQ0; recorded under the auto aux kQ1.
+    const std::vector<uint64_t> pred_in = haze::test::make_residue(kQ0, 424242ULL, kRingDim);
+    void *d_pred_in = nullptr;
+    void *d_mask = nullptr;
+    REQUIRE(hazeMalloc(&d_pred_in, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_mask, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_pred_in, pred_in.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
+            HAZE_SUCCESS);
+    REQUIRE(hazeIsHalfModulus(d_mask, d_pred_in, 0, nullptr) == HAZE_SUCCESS);
+
+    // Ciphertext limbs under {kQ0, kQ2}; both lift from kQ1.
+    const std::vector<uint64_t> base = {kQ0, kQ2};
+    std::vector<std::vector<uint64_t>> inputs(base.size());
+    for (std::size_t i = 0; i < base.size(); ++i)
+        inputs[i] = haze::test::make_residue(base[i], 515151ULL + i, kRingDim);
+    const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
+    const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    const std::vector<const void *> src_view = haze::test::to_const(d_src);
+
+    const int in_range = GENERATE(0, 1);
+    REQUIRE(hazeBroadcastMulMrp(d_dst.data(), src_view.data(), d_mask, kQ1, in_range, base.data(),
+                                base.size(), nullptr) == HAZE_SUCCESS);
+    for (void *out : d_dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    const uint64_t h = (kQ0 - 1) / 2;
+    for (std::size_t i = 0; i < base.size(); ++i) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), d_dst[i], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+                HAZE_SUCCESS);
+        for (std::size_t k = 0; k < kRingDim; ++k) {
+            const uint64_t bit = (pred_in[k] > h) ? 1U : 0U;
+            INFO("in_range " << in_range << " residue " << i << " slot " << k);
+            REQUIRE(got[k] == niobium::mod_arith::mulmod(inputs[i][k], bit, base[i]));
+        }
+    }
+
+    haze::test::free_all_residues(d_src);
+    haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_pred_in) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_mask) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeBroadcast: general values, small operand prime (p < q)", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    const std::vector<uint64_t> vals = boundary_operand(kSmallQ, 626262ULL);
+    for (Op op : {Op::Add, Op::Sub, Op::Rsub, Op::Mul})
+        run_broadcast_golden(op, base, kSmallQ, vals, /*in_range=*/0,
+                             /*seed=*/700000ULL + static_cast<uint64_t>(op));
+}
+
+TEST_CASE("hazeBroadcast: general values, large operand prime (p > q)", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    const std::vector<uint64_t> vals = boundary_operand(kQ2, 636363ULL);
+    for (Op op : {Op::Add, Op::Sub, Op::Rsub, Op::Mul})
+        run_broadcast_golden(op, base, kQ2, vals, /*in_range=*/0,
+                             /*seed=*/710000ULL + static_cast<uint64_t>(op));
+}
+
+TEST_CASE("hazeBroadcast: zero unshift immediate (base prime divides half the operand prime)",
+          "[integration]") {
+    // kSmallQ | (kCongruentP-1)/2 zeroes the kSmallQ limb's unshift immediate,
+    // hitting the simulator's addps-imm-0 copy path inside the gadget.
+    haze::test::setup_integration_mrp3_config(kRingDim, kSmallQ);
+    const std::vector<uint64_t> base = {kSmallQ, kQ0};
+    const std::vector<uint64_t> vals = boundary_operand(kCongruentP, 646400ULL);
+    for (Op op : {Op::Add, Op::Sub, Op::Rsub, Op::Mul})
+        run_broadcast_golden(op, base, kCongruentP, vals, /*in_range=*/0,
+                             /*seed=*/740000ULL + static_cast<uint64_t>(op));
+}
+
+TEST_CASE("hazeBroadcast: direct path with general in-range values", "[integration]") {
+    // operand_in_range with non-binary coefficients: all values satisfy the
+    // contract (<= (p-1)/2 and below every base prime), so the lift is elided
+    // on the ordinary format and the results must match the lift oracle.
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> base = {kQ0, kQ2};
+    std::vector<uint64_t> vals =
+        haze::test::make_residue(((kSmallQ - 1) / 2) + 1, 656600ULL, kRingDim);
+    vals[0] = 0;
+    vals[1] = 1;
+    vals[2] = (kSmallQ - 1) / 2; // the contract's upper edge
+    for (Op op : {Op::Add, Op::Sub, Op::Rsub, Op::Mul})
+        run_broadcast_golden(op, base, kSmallQ, vals, /*in_range=*/1,
+                             /*seed=*/750000ULL + static_cast<uint64_t>(op));
+}
+
+TEST_CASE("hazeBroadcast: operand modulus inside the base (pass-through limb)", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    const std::vector<uint64_t> vals = boundary_operand(kQ1, 646464ULL);
+    run_broadcast_golden(Op::Sub, base, kQ1, vals, /*in_range=*/0, /*seed=*/730000ULL);
+}
+
+TEST_CASE("hazeBroadcast: H2D overwrite clears a stale recorded operand modulus", "[integration]") {
+    // An address that held a compute result (recorded under the aux prime)
+    // and is then H2D-overwritten is a fresh raw operand again; the
+    // consistency guard must accept the caller's modulus for the new bytes.
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> pred_in = haze::test::make_residue(kQ0, 767676ULL, kRingDim);
+    void *d_t = nullptr;
+    void *d_in = nullptr;
+    REQUIRE(hazeMalloc(&d_t, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_in, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_in, pred_in.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeIsHalfModulus(d_t, d_in, 0, nullptr) == HAZE_SUCCESS); // recorded under kQ1
+
+    const std::vector<uint64_t> mask = binary_mask(0x7E7EULL);
+    REQUIRE(hazeMemcpy(d_t, mask.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    const std::vector<uint64_t> base = {kQ0, kQ2};
+    std::vector<std::vector<uint64_t>> inputs(base.size());
+    for (std::size_t i = 0; i < base.size(); ++i)
+        inputs[i] = haze::test::make_residue(base[i], 777700ULL + i, kRingDim);
+    const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
+    const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    const std::vector<const void *> src_view = haze::test::to_const(d_src);
+    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_t, kSmallQ,
+                                /*operand_in_range=*/1, base.data(), base.size(),
+                                nullptr) == HAZE_SUCCESS);
+    for (void *out : d_dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+    for (std::size_t i = 0; i < base.size(); ++i) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), d_dst[i], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) ==
+                HAZE_SUCCESS);
+        for (std::size_t k = 0; k < kRingDim; ++k) {
+            INFO("residue " << i << " slot " << k);
+            REQUIRE(got[k] == (inputs[i][k] + mask[k]) % base[i]);
+        }
+    }
+    haze::test::free_all_residues(d_src);
+    haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_t) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_in) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeBroadcast: in-place dst == src", "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    std::vector<std::vector<uint64_t>> inputs(base.size());
+    for (std::size_t i = 0; i < base.size(); ++i)
+        inputs[i] = haze::test::make_residue(base[i], 656565ULL + i, kRingDim);
+    const std::vector<uint64_t> mask = binary_mask(0xA5A5ULL);
+
+    const std::vector<void *> d_x = haze::test::allocate_and_h2d_residues(inputs);
+    void *d_m = nullptr;
+    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_m, mask.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    const std::vector<const void *> src_view = haze::test::to_const(d_x);
+    REQUIRE(hazeBroadcastAddMrp(d_x.data(), src_view.data(), d_m, kSmallQ,
+                                /*operand_in_range=*/1, base.data(), base.size(),
+                                nullptr) == HAZE_SUCCESS);
+    for (void *out : d_x)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    for (std::size_t i = 0; i < base.size(); ++i) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), d_x[i], kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        for (std::size_t k = 0; k < kRingDim; ++k) {
+            INFO("residue " << i << " slot " << k);
+            REQUIRE(got[k] == (inputs[i][k] + mask[k]) % base[i]);
+        }
+    }
+    haze::test::free_all_residues(d_x);
+    REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
+}
+
+// ===========================================================================
+// Argument validation ([unit]).
+// ===========================================================================
+
+TEST_CASE("hazeBroadcast rejects invalid arguments", "[unit]") {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
+
+    const uint64_t base[] = {kQ0, kQ1};
+    void *d_a = nullptr;
+    void *d_b = nullptr;
+    void *d_m = nullptr;
+    REQUIRE(hazeMalloc(&d_a, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_b, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
+    void *dst_polys[] = {d_a, d_b};
+    const void *src_polys[] = {d_a, d_b};
+
+    REQUIRE(hazeBroadcastAddMrp(nullptr, src_polys, d_m, kQ2, 0, base, 2, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, nullptr, d_m, kQ2, 0, base, 2, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, nullptr, kQ2, 0, base, 2, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, kQ2, 0, nullptr, 2, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, kQ2, 0, base, 0, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, 0, 0, base, 2, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(d_a) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_b) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeBroadcast rejects an operand modulus that disagrees with the recorded one",
+          "[integration]") {
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+
+    // Compute a mask under the auto aux kQ1, then lie about its modulus.
+    const std::vector<uint64_t> pred_in = haze::test::make_residue(kQ0, 676767ULL, kRingDim);
+    void *d_pred_in = nullptr;
+    void *d_mask = nullptr;
+    REQUIRE(hazeMalloc(&d_pred_in, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_mask, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_pred_in, pred_in.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
+            HAZE_SUCCESS);
+    REQUIRE(hazeIsHalfModulus(d_mask, d_pred_in, 0, nullptr) == HAZE_SUCCESS);
+
+    const uint64_t base[] = {kQ0, kQ2};
+    const std::vector<void *> d_src =
+        haze::test::allocate_and_h2d_residues({haze::test::make_residue(kQ0, 1ULL, kRingDim),
+                                               haze::test::make_residue(kQ2, 2ULL, kRingDim)});
+    const std::vector<void *> d_dst = haze::test::allocate_dst_residues(2, kBytes);
+    const std::vector<const void *> src_view = haze::test::to_const(d_src);
+
+    REQUIRE(hazeBroadcastMulMrp(d_dst.data(), src_view.data(), d_mask, kQ2, 0, base, 2, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+
+    haze::test::free_all_residues(d_src);
+    haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_pred_in) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_mask) == HAZE_SUCCESS);
+}
+
+// ===========================================================================
+// Record-time trace shape ([unit][hwfmt]): pin the per-limb lift emission.
+// ===========================================================================
+
+namespace {
+
+std::string slurp(const std::filesystem::path &path) {
+    std::ifstream in(path);
+    REQUIRE(in.good());
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+std::size_t count_occurrences(const std::string &haystack, const std::string &needle) {
+    std::size_t count = 0;
+    for (std::size_t pos = haystack.find(needle); pos != std::string::npos;
+         pos = haystack.find(needle, pos + needle.size()))
+        ++count;
+    return count;
+}
+
+// Record one hazeBroadcastAddMrp (operand under kQ1, base {kQ0, kQ2}) into a
+// uniquely named program dir and return the trace text.
+std::string record_broadcast_trace(const std::string &program_name, bool montgomery, int in_range,
+                                   uint64_t operand_modulus, const std::vector<uint64_t> &base) {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = "FUNC_SIM",
+                                     .program_name = program_name.c_str(),
+                                     .program_version = "0.1",
+                                     .program_description = "broadcast trace-shape test",
+                                     .montgomery = montgomery ? 1 : 0,
+                                     .bit_reversal = montgomery ? 1 : 0,
+                                     .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+
+    std::vector<std::vector<uint64_t>> inputs(base.size());
+    for (std::size_t i = 0; i < base.size(); ++i)
+        inputs[i] = haze::test::make_residue(base[i], 686868ULL + i, kRingDim);
+    const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
+    const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    void *d_m = nullptr;
+    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
+    const std::vector<uint64_t> mask = binary_mask(0x5A5AULL);
+    REQUIRE(hazeMemcpy(d_m, mask.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    const std::vector<const void *> src_view = haze::test::to_const(d_src);
+    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_m, operand_modulus, in_range,
+                                base.data(), base.size(), nullptr) == HAZE_SUCCESS);
+    for (void *out : d_dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeWriteProgram() == HAZE_SUCCESS);
+
+    haze::test::free_all_residues(d_src);
+    haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
+    return slurp(std::filesystem::path{program_name} / (program_name + ".fhetch"));
+}
+
+} // namespace
+
+TEST_CASE("hazeBroadcast record-time: per-limb lift emission", "[unit][hwfmt]") {
+    const std::vector<uint64_t> base = {kQ0, kQ2};
+    const uint64_t half_p = (kQ1 - 1) / 2;
+
+    SECTION("flag off, ordinary: 3-op gadget per limb + pointwise") {
+        const std::string trace =
+            record_broadcast_trace("haze_bc_threeop", /*montgomery=*/false, 0, kQ1, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 4); // 2 shifts + 2 unshifts
+        CHECK(count_occurrences(trace, "sr_mulps ") == 2); // 2 rebases
+        CHECK(count_occurrences(trace, "sr_addp ") == 2);  // pointwise
+        REQUIRE(trace.find(", " + std::to_string(half_p) + ",") != std::string::npos);
+        const auto sw_hw =
+            niobium::mod_arith::compute_switchmodulus_immediates(kQ1, kQ0, /*montgomery=*/true);
+        REQUIRE(trace.find(", " + std::to_string(sw_hw.imm[2]) + ",") == std::string::npos);
+    }
+    SECTION("flag off, montgomery: 4-op gadget per limb + pointwise") {
+        const std::string trace =
+            record_broadcast_trace("haze_bc_fourop", /*montgomery=*/true, 0, kQ1, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 4);
+        CHECK(count_occurrences(trace, "sr_mulps ") == 4); // leading identities + rebases
+        CHECK(count_occurrences(trace, "sr_addp ") == 2);
+    }
+    SECTION("flag on, ordinary: no lift at all") {
+        const std::string trace =
+            record_broadcast_trace("haze_bc_direct", /*montgomery=*/false, 1, kQ1, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 0);
+        CHECK(count_occurrences(trace, "sr_mulps ") == 0);
+        CHECK(count_occurrences(trace, "sr_addp ") == 2);
+        REQUIRE(trace.find(std::to_string(half_p)) == std::string::npos);
+    }
+    SECTION("flag on, montgomery: the switch is the data-format conversion") {
+        const std::string trace =
+            record_broadcast_trace("haze_bc_direct_mont", /*montgomery=*/true, 1, kQ1, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 4);
+        CHECK(count_occurrences(trace, "sr_mulps ") == 4);
+        CHECK(count_occurrences(trace, "sr_addp ") == 2);
+    }
+    SECTION("operand modulus in the base: pass-through limb lifts nothing") {
+        const std::string trace = record_broadcast_trace("haze_bc_passthrough",
+                                                         /*montgomery=*/false, 0, kQ2, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 2); // one gadget only (kQ0 limb)
+        CHECK(count_occurrences(trace, "sr_mulps ") == 1);
+        CHECK(count_occurrences(trace, "sr_addp ") == 2);
+    }
+    SECTION("pass-through limb under montgomery: same-ring use needs no format switch") {
+        const std::string trace = record_broadcast_trace("haze_bc_passthrough_mont",
+                                                         /*montgomery=*/true, 0, kQ2, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 2); // one FourOp gadget (kQ0 limb)
+        CHECK(count_occurrences(trace, "sr_mulps ") == 2);
+        CHECK(count_occurrences(trace, "sr_addp ") == 2);
+    }
+    SECTION("zero unshift immediate stays inside the gadget shape") {
+        const std::string trace = record_broadcast_trace("haze_bc_zeroimm", /*montgomery=*/false, 0,
+                                                         kCongruentP, {kSmallQ, kQ0});
+        CHECK(count_occurrences(trace, "sr_addps ") == 4);
+        CHECK(count_occurrences(trace, "sr_mulps ") == 2);
+        CHECK(count_occurrences(trace, "sr_addp ") == 2);
+        REQUIRE(trace.find(", 0, m=") != std::string::npos); // kSmallQ | (kCongruentP-1)/2
+    }
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+// ===========================================================================
+// Transport hardware mode ([integration][hwfmt]: requires make test-transport).
+// ===========================================================================
+
+namespace {
+
+bool transport_target_active() {
+    const char *target = std::getenv("HAZE_TARGET");
+    return target != nullptr && target[0] != '\0' && std::string_view{target} != "local";
+}
+
+// Record + flush one broadcast under the given toggles and return the
+// per-limb D2H results.
+std::vector<std::vector<uint64_t>>
+run_broadcast_transport(bool montgomery, int in_range, Op op, uint64_t p,
+                        const std::vector<uint64_t> &base,
+                        const std::vector<uint64_t> &operand_vals) {
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = haze::test::target_from_env(),
+                                     .montgomery = montgomery ? 1 : 0,
+                                     .bit_reversal = montgomery ? 1 : 0,
+                                     .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+
+    std::vector<std::vector<uint64_t>> inputs(base.size());
+    for (std::size_t i = 0; i < base.size(); ++i)
+        inputs[i] = haze::test::make_residue(base[i], 696969ULL + i, kRingDim);
+    const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
+    const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    void *d_m = nullptr;
+    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_m, operand_vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
+            HAZE_SUCCESS);
+
+    const std::vector<const void *> src_view = haze::test::to_const(d_src);
+    REQUIRE(call_broadcast(op, d_dst.data(), src_view.data(), d_m, p, in_range, base.data(),
+                           base.size()) == HAZE_SUCCESS);
+    for (void *out : d_dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() == HAZE_SUCCESS);
+
+    std::vector<std::vector<uint64_t>> results;
+    for (void *out : d_dst) {
+        std::vector<uint64_t> got(kRingDim, 0xDEADBEEFULL);
+        REQUIRE(hazeMemcpy(got.data(), out, kBytes, HAZE_MEMCPY_DEVICE_TO_HOST) == HAZE_SUCCESS);
+        results.push_back(std::move(got));
+    }
+    haze::test::free_all_residues(d_src);
+    haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
+    return results;
+}
+
+} // namespace
+
+TEST_CASE("hazeBroadcast transport: A/B byte-exact vs ordinary mode", "[integration][hwfmt]") {
+    if (!transport_target_active())
+        SKIP("data format requires a transport target (run under make test-transport)");
+
+    struct Arm {
+        Op op;
+        uint64_t p;
+        std::vector<uint64_t> base;
+        std::vector<uint64_t> vals;
+        int in_range;
+    };
+    const std::vector<Arm> arms = {
+        {Op::Mul, kQ1, {kQ0, kQ2}, binary_mask(0x3C3CULL), 0},
+        {Op::Mul, kQ1, {kQ0, kQ2}, binary_mask(0x3C3CULL), 1},
+        {Op::Sub, kQ2, {kQ0, kQ2}, boundary_operand(kQ2, 787878ULL), 0}, // pass-through limb
+    };
+    for (std::size_t a = 0; a < arms.size(); ++a) {
+        const Arm &arm = arms[a];
+        REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+        const auto ordinary = run_broadcast_transport(/*montgomery=*/false, arm.in_range, arm.op,
+                                                      arm.p, arm.base, arm.vals);
+        REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+        const auto encoded = run_broadcast_transport(/*montgomery=*/true, arm.in_range, arm.op,
+                                                     arm.p, arm.base, arm.vals);
+        INFO("arm " << a << " in_range " << arm.in_range);
+        REQUIRE(ordinary == encoded);
+    }
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeBroadcast transport: non-synthesizable operand modulus fails loudly",
+          "[integration][hwfmt]") {
+    if (!transport_target_active())
+        SKIP("input synthesis runs on transport targets (run under make test-transport)");
+
+    // Flag off records the operand under its own modulus, which the replay
+    // bridge must synthesize; a prime not ≡ 1 mod 2N fails at flush — cleanly,
+    // never silently.
+    constexpr uint64_t kBadP = 1000003ULL; // prime, not ≡ 1 mod 8192
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
+    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    std::vector<std::vector<uint64_t>> inputs(base.size());
+    for (std::size_t i = 0; i < base.size(); ++i)
+        inputs[i] = haze::test::make_residue(base[i], 797979ULL + i, kRingDim);
+    const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
+    const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    void *d_m = nullptr;
+    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
+    const std::vector<uint64_t> vals = haze::test::make_residue(kBadP, 808080ULL, kRingDim);
+    REQUIRE(hazeMemcpy(d_m, vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    const std::vector<const void *> src_view = haze::test::to_const(d_src);
+    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_m, kBadP, 0, base.data(),
+                                base.size(), nullptr) == HAZE_SUCCESS);
+    for (void *out : d_dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeFlush() != HAZE_SUCCESS);
+    hazeGetLastError();
+
+    haze::test::free_all_residues(d_src);
+    haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}

--- a/test/test_broadcast.cpp
+++ b/test/test_broadcast.cpp
@@ -41,18 +41,42 @@ constexpr uint64_t kCongruentP = 211107843342337ULL;
 enum class Op : std::uint8_t { Add, Sub, Rsub, Mul };
 
 hazeError_t call_broadcast(Op op, void *const *dst, const void *const *src, const void *operand,
-                           uint64_t p, int in_range, const uint64_t *base, std::size_t len) {
+                           int in_range, const uint64_t *base, std::size_t len) {
     switch (op) {
     case Op::Add:
-        return hazeBroadcastAddMrp(dst, src, operand, p, in_range, base, len, nullptr);
+        return hazeBroadcastAddMrp(dst, src, operand, in_range, base, len, nullptr);
     case Op::Sub:
-        return hazeBroadcastSubMrp(dst, src, operand, p, in_range, base, len, nullptr);
+        return hazeBroadcastSubMrp(dst, src, operand, in_range, base, len, nullptr);
     case Op::Rsub:
-        return hazeBroadcastRsubMrp(dst, src, operand, p, in_range, base, len, nullptr);
+        return hazeBroadcastRsubMrp(dst, src, operand, in_range, base, len, nullptr);
     case Op::Mul:
-        return hazeBroadcastMulMrp(dst, src, operand, p, in_range, base, len, nullptr);
+        return hazeBroadcastMulMrp(dst, src, operand, in_range, base, len, nullptr);
     }
     return HAZE_ERROR_INVALID_VALUE;
+}
+
+// One-shot configuration over an arbitrary chain (bridge scaffold from moduli[0]).
+void setup_chain_config(const std::vector<uint64_t> &moduli) {
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    const hazeFheParams fhe = {
+        .ring_dim = kRingDim, .moduli = moduli.data(), .moduli_count = moduli.size()};
+    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
+    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
+    uint64_t scaffold = 0;
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, moduli[0], &scaffold) == HAZE_SUCCESS);
+}
+
+// H2D `vals` and record them under moduli[mod_idx] via a zero-add (the values
+// pass through verbatim); the broadcast recovers the operand's ring from that
+// recorded modulus. Returns {raw, bound}; caller frees both.
+std::pair<void *, void *> bind_operand(const std::vector<uint64_t> &vals, int mod_idx) {
+    void *d_raw = nullptr;
+    void *d_m = nullptr;
+    REQUIRE(hazeMalloc(&d_raw, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeMemcpy(d_raw, vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    REQUIRE(hazeAddScalar(d_m, d_raw, 0, mod_idx, nullptr) == HAZE_SUCCESS);
+    return {d_raw, d_m};
 }
 
 // Centered lift oracle: m for m <= (p-1)/2, else m - p, reduced mod q.
@@ -77,10 +101,11 @@ uint64_t op_ref(Op op, uint64_t a, uint64_t b, uint64_t q) {
     return 0;
 }
 
-// Run one broadcast over pseudorandom limbs and operand, flush, and require
-// exact equality against the lift+op oracle on every coefficient. The operand
-// limb for base[i] == p is used verbatim (no lift), matching the pass-through.
-void run_broadcast_golden(Op op, const std::vector<uint64_t> &base, uint64_t p,
+// Run one broadcast over pseudorandom limbs and an operand recorded under
+// moduli[p_idx] (= p), flush, and require exact equality against the lift+op
+// oracle on every coefficient. The operand limb for base[i] == p is used
+// verbatim (no lift), matching the pass-through.
+void run_broadcast_golden(Op op, const std::vector<uint64_t> &base, uint64_t p, int p_idx,
                           const std::vector<uint64_t> &operand_vals, int in_range, uint64_t seed) {
     std::vector<std::vector<uint64_t>> inputs(base.size());
     for (std::size_t i = 0; i < base.size(); ++i)
@@ -88,13 +113,10 @@ void run_broadcast_golden(Op op, const std::vector<uint64_t> &base, uint64_t p,
 
     const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
     const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
-    void *d_m = nullptr;
-    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
-    REQUIRE(hazeMemcpy(d_m, operand_vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
-            HAZE_SUCCESS);
+    const auto [d_raw, d_m] = bind_operand(operand_vals, p_idx);
 
     const std::vector<const void *> src_view = haze::test::to_const(d_src);
-    REQUIRE(call_broadcast(op, d_dst.data(), src_view.data(), d_m, p, in_range, base.data(),
+    REQUIRE(call_broadcast(op, d_dst.data(), src_view.data(), d_m, in_range, base.data(),
                            base.size()) == HAZE_SUCCESS);
     for (void *out : d_dst)
         REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
@@ -115,6 +137,7 @@ void run_broadcast_golden(Op op, const std::vector<uint64_t> &base, uint64_t p,
 
     haze::test::free_all_residues(d_src);
     haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_raw) == HAZE_SUCCESS);
     REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
 }
 
@@ -165,7 +188,7 @@ TEST_CASE("hazeBroadcastMulMrp: hazeIsHalfModulus mask applied to all limbs", "[
     const std::vector<const void *> src_view = haze::test::to_const(d_src);
 
     const int in_range = GENERATE(0, 1);
-    REQUIRE(hazeBroadcastMulMrp(d_dst.data(), src_view.data(), d_mask, kQ1, in_range, base.data(),
+    REQUIRE(hazeBroadcastMulMrp(d_dst.data(), src_view.data(), d_mask, in_range, base.data(),
                                 base.size(), nullptr) == HAZE_SUCCESS);
     for (void *out : d_dst)
         REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
@@ -190,11 +213,11 @@ TEST_CASE("hazeBroadcastMulMrp: hazeIsHalfModulus mask applied to all limbs", "[
 }
 
 TEST_CASE("hazeBroadcast: general values, small operand prime (p < q)", "[integration]") {
-    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    setup_chain_config({kQ0, kQ1, kSmallQ});
     const std::vector<uint64_t> base = {kQ0, kQ1};
     const std::vector<uint64_t> vals = boundary_operand(kSmallQ, 626262ULL);
     for (Op op : {Op::Add, Op::Sub, Op::Rsub, Op::Mul})
-        run_broadcast_golden(op, base, kSmallQ, vals, /*in_range=*/0,
+        run_broadcast_golden(op, base, kSmallQ, /*p_idx=*/2, vals, /*in_range=*/0,
                              /*seed=*/700000ULL + static_cast<uint64_t>(op));
 }
 
@@ -203,7 +226,7 @@ TEST_CASE("hazeBroadcast: general values, large operand prime (p > q)", "[integr
     const std::vector<uint64_t> base = {kQ0, kQ1};
     const std::vector<uint64_t> vals = boundary_operand(kQ2, 636363ULL);
     for (Op op : {Op::Add, Op::Sub, Op::Rsub, Op::Mul})
-        run_broadcast_golden(op, base, kQ2, vals, /*in_range=*/0,
+        run_broadcast_golden(op, base, kQ2, /*p_idx=*/2, vals, /*in_range=*/0,
                              /*seed=*/710000ULL + static_cast<uint64_t>(op));
 }
 
@@ -211,11 +234,11 @@ TEST_CASE("hazeBroadcast: zero unshift immediate (base prime divides half the op
           "[integration]") {
     // kSmallQ | (kCongruentP-1)/2 zeroes the kSmallQ limb's unshift immediate,
     // hitting the simulator's addps-imm-0 copy path inside the gadget.
-    haze::test::setup_integration_mrp3_config(kRingDim, kSmallQ);
+    setup_chain_config({kSmallQ, kQ0, kCongruentP});
     const std::vector<uint64_t> base = {kSmallQ, kQ0};
     const std::vector<uint64_t> vals = boundary_operand(kCongruentP, 646400ULL);
     for (Op op : {Op::Add, Op::Sub, Op::Rsub, Op::Mul})
-        run_broadcast_golden(op, base, kCongruentP, vals, /*in_range=*/0,
+        run_broadcast_golden(op, base, kCongruentP, /*p_idx=*/2, vals, /*in_range=*/0,
                              /*seed=*/740000ULL + static_cast<uint64_t>(op));
 }
 
@@ -223,7 +246,7 @@ TEST_CASE("hazeBroadcast: direct path with general in-range values", "[integrati
     // operand_in_range with non-binary coefficients: all values satisfy the
     // contract (<= (p-1)/2 and below every base prime), so the lift is elided
     // on the ordinary format and the results must match the lift oracle.
-    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    setup_chain_config({kQ0, kQ2, kSmallQ});
     const std::vector<uint64_t> base = {kQ0, kQ2};
     std::vector<uint64_t> vals =
         haze::test::make_residue(((kSmallQ - 1) / 2) + 1, 656600ULL, kRingDim);
@@ -231,7 +254,7 @@ TEST_CASE("hazeBroadcast: direct path with general in-range values", "[integrati
     vals[1] = 1;
     vals[2] = (kSmallQ - 1) / 2; // the contract's upper edge
     for (Op op : {Op::Add, Op::Sub, Op::Rsub, Op::Mul})
-        run_broadcast_golden(op, base, kSmallQ, vals, /*in_range=*/1,
+        run_broadcast_golden(op, base, kSmallQ, /*p_idx=*/2, vals, /*in_range=*/1,
                              /*seed=*/750000ULL + static_cast<uint64_t>(op));
 }
 
@@ -239,21 +262,22 @@ TEST_CASE("hazeBroadcast: operand modulus inside the base (pass-through limb)", 
     haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
     const std::vector<uint64_t> base = {kQ0, kQ1};
     const std::vector<uint64_t> vals = boundary_operand(kQ1, 646464ULL);
-    run_broadcast_golden(Op::Sub, base, kQ1, vals, /*in_range=*/0, /*seed=*/730000ULL);
+    run_broadcast_golden(Op::Sub, base, kQ1, /*p_idx=*/1, vals, /*in_range=*/0,
+                         /*seed=*/730000ULL);
 }
 
 TEST_CASE("hazeBroadcast: H2D overwrite clears a stale recorded operand modulus", "[integration]") {
     // An address that held a compute result (recorded under the aux prime)
-    // and is then H2D-overwritten is a fresh raw operand again; the
-    // consistency guard must accept the caller's modulus for the new bytes.
-    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    // and is then H2D-overwritten is a fresh raw operand again: the recovery
+    // rejects it until a modulus-carrying op records a ring for the new bytes.
+    setup_chain_config({kQ0, kQ2, kSmallQ});
     const std::vector<uint64_t> pred_in = haze::test::make_residue(kQ0, 767676ULL, kRingDim);
     void *d_t = nullptr;
     void *d_in = nullptr;
     REQUIRE(hazeMalloc(&d_t, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeMalloc(&d_in, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(d_in, pred_in.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
-    REQUIRE(hazeIsHalfModulus(d_t, d_in, 0, nullptr) == HAZE_SUCCESS); // recorded under kQ1
+    REQUIRE(hazeIsHalfModulus(d_t, d_in, 0, nullptr) == HAZE_SUCCESS); // recorded under kQ2
 
     const std::vector<uint64_t> mask = binary_mask(0x7E7EULL);
     REQUIRE(hazeMemcpy(d_t, mask.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
@@ -265,9 +289,14 @@ TEST_CASE("hazeBroadcast: H2D overwrite clears a stale recorded operand modulus"
     const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
     const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
     const std::vector<const void *> src_view = haze::test::to_const(d_src);
-    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_t, kSmallQ,
-                                /*operand_in_range=*/1, base.data(), base.size(),
-                                nullptr) == HAZE_SUCCESS);
+    // The stale kQ2 recording is gone: the raw bytes are rejected...
+    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_t, /*operand_in_range=*/1,
+                                base.data(), base.size(), nullptr) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    // ...until a zero-add records a ring for them (kSmallQ at index 2).
+    REQUIRE(hazeAddScalar(d_t, d_t, 0, 2, nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_t, /*operand_in_range=*/1,
+                                base.data(), base.size(), nullptr) == HAZE_SUCCESS);
     for (void *out : d_dst)
         REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
     REQUIRE(hazeFlush() == HAZE_SUCCESS);
@@ -287,7 +316,7 @@ TEST_CASE("hazeBroadcast: H2D overwrite clears a stale recorded operand modulus"
 }
 
 TEST_CASE("hazeBroadcast: in-place dst == src", "[integration]") {
-    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+    setup_chain_config({kQ0, kQ1, kSmallQ});
     const std::vector<uint64_t> base = {kQ0, kQ1};
     std::vector<std::vector<uint64_t>> inputs(base.size());
     for (std::size_t i = 0; i < base.size(); ++i)
@@ -295,14 +324,11 @@ TEST_CASE("hazeBroadcast: in-place dst == src", "[integration]") {
     const std::vector<uint64_t> mask = binary_mask(0xA5A5ULL);
 
     const std::vector<void *> d_x = haze::test::allocate_and_h2d_residues(inputs);
-    void *d_m = nullptr;
-    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
-    REQUIRE(hazeMemcpy(d_m, mask.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    const auto [d_raw, d_m] = bind_operand(mask, /*mod_idx=*/2); // kSmallQ
 
     const std::vector<const void *> src_view = haze::test::to_const(d_x);
-    REQUIRE(hazeBroadcastAddMrp(d_x.data(), src_view.data(), d_m, kSmallQ,
-                                /*operand_in_range=*/1, base.data(), base.size(),
-                                nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeBroadcastAddMrp(d_x.data(), src_view.data(), d_m, /*operand_in_range=*/1,
+                                base.data(), base.size(), nullptr) == HAZE_SUCCESS);
     for (void *out : d_x)
         REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
     REQUIRE(hazeFlush() == HAZE_SUCCESS);
@@ -316,6 +342,7 @@ TEST_CASE("hazeBroadcast: in-place dst == src", "[integration]") {
         }
     }
     haze::test::free_all_residues(d_x);
+    REQUIRE(hazeFree(d_raw) == HAZE_SUCCESS);
     REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
 }
 
@@ -339,17 +366,18 @@ TEST_CASE("hazeBroadcast rejects invalid arguments", "[unit]") {
     void *dst_polys[] = {d_a, d_b};
     const void *src_polys[] = {d_a, d_b};
 
-    REQUIRE(hazeBroadcastAddMrp(nullptr, src_polys, d_m, kQ2, 0, base, 2, nullptr) ==
+    REQUIRE(hazeBroadcastAddMrp(nullptr, src_polys, d_m, 0, base, 2, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeBroadcastAddMrp(dst_polys, nullptr, d_m, kQ2, 0, base, 2, nullptr) ==
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, nullptr, d_m, 0, base, 2, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, nullptr, kQ2, 0, base, 2, nullptr) ==
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, nullptr, 0, base, 2, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, kQ2, 0, nullptr, 2, nullptr) ==
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, 0, nullptr, 2, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, kQ2, 0, base, 0, nullptr) ==
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, 0, base, 0, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
-    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, 0, 0, base, 2, nullptr) ==
+    // d_m was never computed on: no recorded modulus, so the recovery rejects it.
+    REQUIRE(hazeBroadcastAddMrp(dst_polys, src_polys, d_m, 0, base, 2, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 
@@ -358,35 +386,27 @@ TEST_CASE("hazeBroadcast rejects invalid arguments", "[unit]") {
     REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeBroadcast rejects an operand modulus that disagrees with the recorded one",
-          "[integration]") {
-    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
+TEST_CASE("hazeBroadcast rejects an operand recorded under an even modulus", "[integration]") {
+    // The centered lift's h = (p-1)/2 needs an odd operand ring; an operand
+    // bound under an even chain entry is rejected at recovery.
+    setup_chain_config({kQ0, kQ1, 1ULL << 40});
 
-    // Compute a mask under the auto aux kQ1, then lie about its modulus.
-    const std::vector<uint64_t> pred_in = haze::test::make_residue(kQ0, 676767ULL, kRingDim);
-    void *d_pred_in = nullptr;
-    void *d_mask = nullptr;
-    REQUIRE(hazeMalloc(&d_pred_in, kBytes) == HAZE_SUCCESS);
-    REQUIRE(hazeMalloc(&d_mask, kBytes) == HAZE_SUCCESS);
-    REQUIRE(hazeMemcpy(d_pred_in, pred_in.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
-            HAZE_SUCCESS);
-    REQUIRE(hazeIsHalfModulus(d_mask, d_pred_in, 0, nullptr) == HAZE_SUCCESS);
-
-    const uint64_t base[] = {kQ0, kQ2};
+    const uint64_t base[] = {kQ0, kQ1};
     const std::vector<void *> d_src =
         haze::test::allocate_and_h2d_residues({haze::test::make_residue(kQ0, 1ULL, kRingDim),
-                                               haze::test::make_residue(kQ2, 2ULL, kRingDim)});
+                                               haze::test::make_residue(kQ1, 2ULL, kRingDim)});
     const std::vector<void *> d_dst = haze::test::allocate_dst_residues(2, kBytes);
     const std::vector<const void *> src_view = haze::test::to_const(d_src);
+    const auto [d_raw, d_m] = bind_operand(binary_mask(0x1B1BULL), /*mod_idx=*/2);
 
-    REQUIRE(hazeBroadcastMulMrp(d_dst.data(), src_view.data(), d_mask, kQ2, 0, base, 2, nullptr) ==
+    REQUIRE(hazeBroadcastMulMrp(d_dst.data(), src_view.data(), d_m, 0, base, 2, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 
     haze::test::free_all_residues(d_src);
     haze::test::free_all_residues(d_dst);
-    REQUIRE(hazeFree(d_pred_in) == HAZE_SUCCESS);
-    REQUIRE(hazeFree(d_mask) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_raw) == HAZE_SUCCESS);
+    REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
 }
 
 // ===========================================================================
@@ -411,13 +431,15 @@ std::size_t count_occurrences(const std::string &haystack, const std::string &ne
     return count;
 }
 
-// Record one hazeBroadcastAddMrp (operand under kQ1, base {kQ0, kQ2}) into a
+// Record one hazeBroadcastAddMrp (operand bound under moduli[p_idx] by a
+// zero-add — every trace below therefore carries one extra sr_addps) into a
 // uniquely named program dir and return the trace text.
 std::string record_broadcast_trace(const std::string &program_name, bool montgomery, int in_range,
-                                   uint64_t operand_modulus, const std::vector<uint64_t> &base) {
+                                   const std::vector<uint64_t> &moduli, int p_idx,
+                                   const std::vector<uint64_t> &base) {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
-    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
+    const hazeFheParams fhe = {
+        .ring_dim = kRingDim, .moduli = moduli.data(), .moduli_count = moduli.size()};
     const hazeReplayConfig replay = {.target = "FUNC_SIM",
                                      .program_name = program_name.c_str(),
                                      .program_version = "0.1",
@@ -427,27 +449,25 @@ std::string record_broadcast_trace(const std::string &program_name, bool montgom
                                      .reduced_noise = 1};
     REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
     uint64_t scaffold = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, moduli[0], &scaffold) == HAZE_SUCCESS);
 
     std::vector<std::vector<uint64_t>> inputs(base.size());
     for (std::size_t i = 0; i < base.size(); ++i)
         inputs[i] = haze::test::make_residue(base[i], 686868ULL + i, kRingDim);
     const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
     const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
-    void *d_m = nullptr;
-    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
-    const std::vector<uint64_t> mask = binary_mask(0x5A5AULL);
-    REQUIRE(hazeMemcpy(d_m, mask.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    const auto [d_raw, d_m] = bind_operand(binary_mask(0x5A5AULL), p_idx);
 
     const std::vector<const void *> src_view = haze::test::to_const(d_src);
-    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_m, operand_modulus, in_range,
-                                base.data(), base.size(), nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_m, in_range, base.data(),
+                                base.size(), nullptr) == HAZE_SUCCESS);
     for (void *out : d_dst)
         REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
     REQUIRE(hazeWriteProgram() == HAZE_SUCCESS);
 
     haze::test::free_all_residues(d_src);
     haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_raw) == HAZE_SUCCESS);
     REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
     return slurp(std::filesystem::path{program_name} / (program_name + ".fhetch"));
 }
@@ -460,8 +480,9 @@ TEST_CASE("hazeBroadcast record-time: per-limb lift emission", "[unit][hwfmt]") 
 
     SECTION("flag off, ordinary: 3-op gadget per limb + pointwise") {
         const std::string trace =
-            record_broadcast_trace("haze_bc_threeop", /*montgomery=*/false, 0, kQ1, base);
-        CHECK(count_occurrences(trace, "sr_addps ") == 4); // 2 shifts + 2 unshifts
+            record_broadcast_trace("haze_bc_threeop", /*montgomery=*/false, 0, {kQ0, kQ1, kQ2},
+                                   /*p_idx=*/1, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 5); // bind + 2 shifts + 2 unshifts
         CHECK(count_occurrences(trace, "sr_mulps ") == 2); // 2 rebases
         CHECK(count_occurrences(trace, "sr_addp ") == 2);  // pointwise
         REQUIRE(trace.find(", " + std::to_string(half_p) + ",") != std::string::npos);
@@ -471,47 +492,51 @@ TEST_CASE("hazeBroadcast record-time: per-limb lift emission", "[unit][hwfmt]") 
     }
     SECTION("flag off, montgomery: 4-op gadget per limb + pointwise") {
         const std::string trace =
-            record_broadcast_trace("haze_bc_fourop", /*montgomery=*/true, 0, kQ1, base);
-        CHECK(count_occurrences(trace, "sr_addps ") == 4);
+            record_broadcast_trace("haze_bc_fourop", /*montgomery=*/true, 0, {kQ0, kQ1, kQ2},
+                                   /*p_idx=*/1, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 5);
         CHECK(count_occurrences(trace, "sr_mulps ") == 4); // leading identities + rebases
         CHECK(count_occurrences(trace, "sr_addp ") == 2);
     }
     SECTION("flag on, ordinary: no lift at all") {
         const std::string trace =
-            record_broadcast_trace("haze_bc_direct", /*montgomery=*/false, 1, kQ1, base);
-        CHECK(count_occurrences(trace, "sr_addps ") == 0);
+            record_broadcast_trace("haze_bc_direct", /*montgomery=*/false, 1, {kQ0, kQ1, kQ2},
+                                   /*p_idx=*/1, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 1); // the bind only
         CHECK(count_occurrences(trace, "sr_mulps ") == 0);
         CHECK(count_occurrences(trace, "sr_addp ") == 2);
         REQUIRE(trace.find(std::to_string(half_p)) == std::string::npos);
     }
     SECTION("flag on, montgomery: the switch is the data-format conversion") {
-        const std::string trace =
-            record_broadcast_trace("haze_bc_direct_mont", /*montgomery=*/true, 1, kQ1, base);
-        CHECK(count_occurrences(trace, "sr_addps ") == 4);
+        const std::string trace = record_broadcast_trace("haze_bc_direct_mont", /*montgomery=*/true,
+                                                         1, {kQ0, kQ1, kQ2}, /*p_idx=*/1, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 5);
         CHECK(count_occurrences(trace, "sr_mulps ") == 4);
         CHECK(count_occurrences(trace, "sr_addp ") == 2);
     }
     SECTION("operand modulus in the base: pass-through limb lifts nothing") {
-        const std::string trace = record_broadcast_trace("haze_bc_passthrough",
-                                                         /*montgomery=*/false, 0, kQ2, base);
-        CHECK(count_occurrences(trace, "sr_addps ") == 2); // one gadget only (kQ0 limb)
+        const std::string trace = record_broadcast_trace(
+            "haze_bc_passthrough", /*montgomery=*/false, 0, {kQ0, kQ1, kQ2}, /*p_idx=*/2, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 3); // bind + one gadget (kQ0 limb)
         CHECK(count_occurrences(trace, "sr_mulps ") == 1);
         CHECK(count_occurrences(trace, "sr_addp ") == 2);
     }
     SECTION("pass-through limb under montgomery: same-ring use needs no format switch") {
-        const std::string trace = record_broadcast_trace("haze_bc_passthrough_mont",
-                                                         /*montgomery=*/true, 0, kQ2, base);
-        CHECK(count_occurrences(trace, "sr_addps ") == 2); // one FourOp gadget (kQ0 limb)
+        const std::string trace = record_broadcast_trace(
+            "haze_bc_passthrough_mont", /*montgomery=*/true, 0, {kQ0, kQ1, kQ2}, /*p_idx=*/2, base);
+        CHECK(count_occurrences(trace, "sr_addps ") == 3); // bind + one FourOp gadget
         CHECK(count_occurrences(trace, "sr_mulps ") == 2);
         CHECK(count_occurrences(trace, "sr_addp ") == 2);
     }
     SECTION("zero unshift immediate stays inside the gadget shape") {
-        const std::string trace = record_broadcast_trace("haze_bc_zeroimm", /*montgomery=*/false, 0,
-                                                         kCongruentP, {kSmallQ, kQ0});
-        CHECK(count_occurrences(trace, "sr_addps ") == 4);
+        const std::string trace =
+            record_broadcast_trace("haze_bc_zeroimm", /*montgomery=*/false, 0,
+                                   {kSmallQ, kQ0, kCongruentP}, /*p_idx=*/2, {kSmallQ, kQ0});
+        CHECK(count_occurrences(trace, "sr_addps ") == 5);
         CHECK(count_occurrences(trace, "sr_mulps ") == 2);
         CHECK(count_occurrences(trace, "sr_addp ") == 2);
-        REQUIRE(trace.find(", 0, m=") != std::string::npos); // kSmallQ | (kCongruentP-1)/2
+        // The bind and the zeroed unshift (kSmallQ | (kCongruentP-1)/2).
+        CHECK(count_occurrences(trace, ", 0, m=") == 2);
     }
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
@@ -530,7 +555,7 @@ bool transport_target_active() {
 // Record + flush one broadcast under the given toggles and return the
 // per-limb D2H results.
 std::vector<std::vector<uint64_t>>
-run_broadcast_transport(bool montgomery, int in_range, Op op, uint64_t p,
+run_broadcast_transport(bool montgomery, int in_range, Op op, int p_idx,
                         const std::vector<uint64_t> &base,
                         const std::vector<uint64_t> &operand_vals) {
     const uint64_t moduli[] = {kQ0, kQ1, kQ2};
@@ -548,13 +573,10 @@ run_broadcast_transport(bool montgomery, int in_range, Op op, uint64_t p,
         inputs[i] = haze::test::make_residue(base[i], 696969ULL + i, kRingDim);
     const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
     const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
-    void *d_m = nullptr;
-    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
-    REQUIRE(hazeMemcpy(d_m, operand_vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) ==
-            HAZE_SUCCESS);
+    const auto [d_raw, d_m] = bind_operand(operand_vals, p_idx);
 
     const std::vector<const void *> src_view = haze::test::to_const(d_src);
-    REQUIRE(call_broadcast(op, d_dst.data(), src_view.data(), d_m, p, in_range, base.data(),
+    REQUIRE(call_broadcast(op, d_dst.data(), src_view.data(), d_m, in_range, base.data(),
                            base.size()) == HAZE_SUCCESS);
     for (void *out : d_dst)
         REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
@@ -568,6 +590,7 @@ run_broadcast_transport(bool montgomery, int in_range, Op op, uint64_t p,
     }
     haze::test::free_all_residues(d_src);
     haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_raw) == HAZE_SUCCESS);
     REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
     return results;
 }
@@ -580,24 +603,24 @@ TEST_CASE("hazeBroadcast transport: A/B byte-exact vs ordinary mode", "[integrat
 
     struct Arm {
         Op op;
-        uint64_t p;
+        int p_idx;
         std::vector<uint64_t> base;
         std::vector<uint64_t> vals;
         int in_range;
     };
     const std::vector<Arm> arms = {
-        {Op::Mul, kQ1, {kQ0, kQ2}, binary_mask(0x3C3CULL), 0},
-        {Op::Mul, kQ1, {kQ0, kQ2}, binary_mask(0x3C3CULL), 1},
-        {Op::Sub, kQ2, {kQ0, kQ2}, boundary_operand(kQ2, 787878ULL), 0}, // pass-through limb
+        {Op::Mul, 1, {kQ0, kQ2}, binary_mask(0x3C3CULL), 0},           // p = kQ1
+        {Op::Mul, 1, {kQ0, kQ2}, binary_mask(0x3C3CULL), 1},           // p = kQ1
+        {Op::Sub, 2, {kQ0, kQ2}, boundary_operand(kQ2, 787878ULL), 0}, // pass-through kQ2
     };
     for (std::size_t a = 0; a < arms.size(); ++a) {
         const Arm &arm = arms[a];
         REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
         const auto ordinary = run_broadcast_transport(/*montgomery=*/false, arm.in_range, arm.op,
-                                                      arm.p, arm.base, arm.vals);
+                                                      arm.p_idx, arm.base, arm.vals);
         REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
         const auto encoded = run_broadcast_transport(/*montgomery=*/true, arm.in_range, arm.op,
-                                                     arm.p, arm.base, arm.vals);
+                                                     arm.p_idx, arm.base, arm.vals);
         INFO("arm " << a << " in_range " << arm.in_range);
         REQUIRE(ordinary == encoded);
     }
@@ -613,13 +636,7 @@ TEST_CASE("hazeBroadcast transport: non-synthesizable operand modulus fails loud
     // bridge must synthesize; a prime not ≡ 1 mod 2N fails at flush — cleanly,
     // never silently.
     constexpr uint64_t kBadP = 1000003ULL; // prime, not ≡ 1 mod 8192
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    const uint64_t moduli[] = {kQ0, kQ1, kQ2};
-    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
-    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
-    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
-    uint64_t scaffold = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
+    setup_chain_config({kQ0, kQ1, kBadP});
 
     const std::vector<uint64_t> base = {kQ0, kQ1};
     std::vector<std::vector<uint64_t>> inputs(base.size());
@@ -627,14 +644,12 @@ TEST_CASE("hazeBroadcast transport: non-synthesizable operand modulus fails loud
         inputs[i] = haze::test::make_residue(base[i], 797979ULL + i, kRingDim);
     const std::vector<void *> d_src = haze::test::allocate_and_h2d_residues(inputs);
     const std::vector<void *> d_dst = haze::test::allocate_dst_residues(base.size(), kBytes);
-    void *d_m = nullptr;
-    REQUIRE(hazeMalloc(&d_m, kBytes) == HAZE_SUCCESS);
     const std::vector<uint64_t> vals = haze::test::make_residue(kBadP, 808080ULL, kRingDim);
-    REQUIRE(hazeMemcpy(d_m, vals.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+    const auto [d_raw, d_m] = bind_operand(vals, /*mod_idx=*/2);
 
     const std::vector<const void *> src_view = haze::test::to_const(d_src);
-    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_m, kBadP, 0, base.data(),
-                                base.size(), nullptr) == HAZE_SUCCESS);
+    REQUIRE(hazeBroadcastAddMrp(d_dst.data(), src_view.data(), d_m, 0, base.data(), base.size(),
+                                nullptr) == HAZE_SUCCESS);
     for (void *out : d_dst)
         REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
     REQUIRE(hazeFlush() != HAZE_SUCCESS);
@@ -642,6 +657,7 @@ TEST_CASE("hazeBroadcast transport: non-synthesizable operand modulus fails loud
 
     haze::test::free_all_residues(d_src);
     haze::test::free_all_residues(d_dst);
+    REQUIRE(hazeFree(d_raw) == HAZE_SUCCESS);
     REQUIRE(hazeFree(d_m) == HAZE_SUCCESS);
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }


### PR DESCRIPTION
Stacked on #80 (base: `is-half-modulus`).

## Summary

Adds numpy-style broadcasting of one single-residue polynomial across all limbs of an MRP — the consumer API for `hazeIsHalfModulus` masks:

- `hazeBroadcast{Add,Sub,Rsub,Mul}Mrp(dst, src, operand, operand_modulus, operand_in_range, base, base_len, stream)` — `dst[i]_k = src[i]_k op lift(operand)_k mod base[i]` (Rsub reverses the subtraction).
- The lift is the minimal hardware-safe cross-ring move: one centered-switch gadget per limb (3 ops ordinary / 4 montgomery — the SwitchModulus recognizer's floor), plus 1 pointwise op per limb. Emitted by `emit_centered_switch`, hoisted from `is_half_modulus.cpp` into shared `src/core/centered_switch.{hpp,cpp}` (second production user). A base prime equal to `operand_modulus` passes the operand through verbatim (0 lift ops).
- `operand_in_range` (caller assertion, unvalidated: coefficients ≤ `(operand_modulus−1)/2` and below every base prime — binary masks qualify) elides the lift entirely on ordinary-format recordings (**L ops total**); under montgomery the switch remains, as it is the data-format conversion. Documented limitation: an ordinary-form recording that used the flag with `base_len > 1` must not be replayed under `--niobium_hw` (the driver re-encodes each input under one modulus only).
- Includes `fix(core)`: `tag_h2d_input_locked` now drops a stale recorded modulus on H2D rebind, so a reused address passes the operand-modulus consistency guard with its new bytes.

## Verification

- Exhaustive adversarial model of the emitted sequences under the simulator's exact fast-path semantics (all odd prime pairs < 200, all operand values, all four ops, both flag settings, ThreeOp/FourOp): zero mismatches; the flag's documented contract shown to be exactly necessary and sufficient.
- Driver-optimizer interactions verified against fhetch_driver source: switchmod recognition with a shared gadget input across L chains (use-count guards are on intermediates only), GVN ordering, identity folds on the zero-unshift-immediate case (`kSmallQ | (kCongruentP−1)/2`), and scalar_factor rules (never match — the sub's other operand is a ciphertext limb).
- Suites: local sim 154/154 + unit/e2e/isolation; full FUNC_SIM (photovoltaic) transport 160/160 (1.98M assertions), including three hwfmt A/B byte-equality arms (binary mask ×2 flag settings, pass-through with general values) and a loud-failure case for a non-synthesizable operand modulus.
- `scripts/clang-format.sh --check`, `clang-tidy --warnings-as-errors='*'`, and `scripts/local-pr-review.sh` (BASE=is-half-modulus) clean/dispositioned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)