### PR TITLE
feat(config): generate program-wide aux prime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,7 @@ add_library(haze_objs OBJECT
   # Shared leaf utilities.
   src/common/errors.cpp
   src/common/log.cpp
+  src/common/mod_arith.cpp
 )
 
 target_include_directories(haze_objs

--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -149,6 +149,11 @@ HAZE_API hazeError_t hazeFlush(void) HAZE_NOEXCEPT;
  * nothing is installed on failure, so a corrected struct may be retried.
  * Re-calling reinstalls the configuration; changing the ring dimension while
  * allocations are live returns HAZE_ERROR_CONFIGERR (free them or reset first).
+ * Every ciphertext modulus must be a prime (deterministically checked;
+ * HAZE_ERROR_CONFIGERR otherwise) and unique, and at most 63 may be supplied:
+ * the device generates one dedicated aux prime for hazeIsHalfModulus (the
+ * smallest prime >= 2^30 with p ≡ 1 mod 2*ring_dim not colliding with the
+ * supplied moduli) and appends it as the last chain entry.
  *
  * hazeReplayConfig::target selects the niobium-compiler replay target:
  *   1. "local" (the default): libnbfhetch loads the .fhetch trace into its
@@ -216,9 +221,9 @@ HAZE_API hazeError_t hazeMulScalar(void *dst, const void *src, uint64_t scalar, 
                                    hazeStream_t stream) HAZE_NOEXCEPT;
 
 // hazeIsHalfModulus records the per-coefficient predicate dst_i = (src_i > q/2) ? 1 : 0,
-// where q = moduli[mod_idx] (must be odd); dst is recorded under the auto-selected aux:
-// the lowest-indexed configured modulus != mod_idx that passes a deterministic primality
-// check — composite chain entries are skipped, HAZE_ERROR_INVALID_VALUE when none exists.
+// where q = moduli[mod_idx] (must be odd); dst is recorded under the program-wide aux
+// prime the device generated at hazeConfigureDevice (the last chain entry). mod_idx
+// naming the aux slot itself returns HAZE_ERROR_INVALID_VALUE.
 HAZE_API hazeError_t hazeIsHalfModulus(void *dst, const void *src, int mod_idx,
                                        hazeStream_t stream) HAZE_NOEXCEPT;
 
@@ -271,9 +276,8 @@ HAZE_API hazeError_t hazeMulScalarMrp(void *const *dst, const void *const *src,
                                       size_t base_len, hazeStream_t stream) HAZE_NOEXCEPT;
 
 // hazeIsHalfModulusMrp records the per-limb predicate dst[i]_k = (src[i]_k > base[i]/2) ? 1 : 0
-// (base moduli must be odd); every dst[i] is recorded under one shared auto-selected aux:
-// the lowest-indexed configured modulus not in base that passes a deterministic primality
-// check — composite chain entries are skipped, HAZE_ERROR_INVALID_VALUE when none exists.
+// (base moduli must be odd); every dst[i] is recorded under the program-wide generated aux
+// prime. A base containing the aux returns HAZE_ERROR_INVALID_VALUE.
 HAZE_API hazeError_t hazeIsHalfModulusMrp(void *const *dst, const void *const *src,
                                           const uint64_t *base, size_t base_len,
                                           hazeStream_t stream) HAZE_NOEXCEPT;

--- a/src/common/errors.cpp
+++ b/src/common/errors.cpp
@@ -27,6 +27,7 @@ hazeError_t to_public_error(HazeInternalError err) noexcept {
     case HazeInternalError::NotConfigured:
     case HazeInternalError::ConfigLocked:
     case HazeInternalError::DuplicateModulus:
+    case HazeInternalError::CompositeModulus:
         return HAZE_ERROR_CONFIGERR;
     case HazeInternalError::UnknownAddress:
         return HAZE_ERROR_UNKNOWN_ADDRESS;
@@ -71,6 +72,8 @@ const char *internal_error_name(HazeInternalError err) noexcept {
         return "configuration locked (already configured / in use); conflicting re-set rejected";
     case HazeInternalError::DuplicateModulus:
         return "duplicate ciphertext modulus; each configured modulus must be distinct";
+    case HazeInternalError::CompositeModulus:
+        return "composite ciphertext modulus; each configured modulus must be prime";
     case HazeInternalError::UnknownAddress:
         return "unknown address";
     case HazeInternalError::NoData:

--- a/src/common/errors.hpp
+++ b/src/common/errors.hpp
@@ -35,6 +35,7 @@ enum class HazeInternalError : std::uint8_t {
     NotConfigured,              // ring_dim / modulus not set when required
     ConfigLocked,               // configuration frozen; conflicting re-set rejected
     DuplicateModulus,           // FheParams::build(): two ciphertext moduli are equal
+    CompositeModulus,           // FheParams::build(): a ciphertext modulus is not prime
     UnknownAddress,             // DevAddr not in the allocator's table
     NoData,                     // address allocated but no H2D / compute output present
     PolySizeMismatch,           // size != configured polynomial size (ring_dim * 8)

--- a/src/common/mod_arith.cpp
+++ b/src/common/mod_arith.cpp
@@ -48,7 +48,7 @@ bool is_prime_u64(uint64_t n) noexcept {
     uint64_t d = n - 1;
     unsigned s = 0;
     while (d % 2 == 0) {
-        d /= 2;
+        d >>= 1U;
         ++s;
     }
     for (uint64_t b : kBases) {

--- a/src/common/mod_arith.cpp
+++ b/src/common/mod_arith.cpp
@@ -1,0 +1,72 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+
+#include "common/mod_arith.hpp"
+
+#include <cstdint>
+
+namespace haze {
+
+uint64_t mulmod_u64(uint64_t a, uint64_t b, uint64_t m) noexcept {
+    return static_cast<uint64_t>((static_cast<__uint128_t>(a) * b) % m);
+}
+
+uint64_t powmod_u64(uint64_t base, uint64_t exp, uint64_t m) noexcept {
+    uint64_t result = 1;
+    base %= m;
+    while (exp > 0) {
+        if ((exp & 1U) != 0)
+            result = mulmod_u64(result, base, m);
+        base = mulmod_u64(base, base, m);
+        exp >>= 1U;
+    }
+    return result;
+}
+
+uint64_t modinv_prime(uint64_t a, uint64_t p) noexcept {
+    return powmod_u64(a, p - 2, p);
+}
+
+bool is_prime_u64(uint64_t n) noexcept {
+    constexpr uint64_t kBases[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37};
+    if (n < 2)
+        return false;
+    for (uint64_t b : kBases) {
+        if (n % b == 0)
+            return n == b;
+    }
+    uint64_t d = n - 1;
+    unsigned s = 0;
+    while (d % 2 == 0) {
+        d /= 2;
+        ++s;
+    }
+    for (uint64_t b : kBases) {
+        uint64_t x = powmod_u64(b, d, n);
+        if (x == 1 || x == n - 1)
+            continue;
+        bool composite = true;
+        for (unsigned i = 1; i < s; ++i) {
+            x = mulmod_u64(x, x, n);
+            if (x == n - 1) {
+                composite = false;
+                break;
+            }
+        }
+        if (composite)
+            return false;
+    }
+    return true;
+}
+
+} // namespace haze

--- a/src/common/mod_arith.hpp
+++ b/src/common/mod_arith.hpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2026, All rights reserved by Niobium Microsystems.
+// The contents of this file and all related materials provided herein (the
+// "Product") may not be used except pursuant to a separate written
+// agreement signed by a duly authorized officer of Niobium Microsystems,
+// Inc. (a "License Agreement").
+// Without limiting the foregoing, you may not, at any time or for any
+// reason, directly or indirectly, in whole or in part: (i) copy, modify,
+// or create derivative works of the Product; (ii) rent, lease, lend, sell,
+// sublicense, assign, distribute, publish, transfer, or otherwise make
+// available the Product; (iii) reverse engineer, disassemble, decompile,
+// decode, or adapt the Product; or (iv) remove any proprietary notices
+// from the Product.
+#pragma once
+
+#include <cstdint>
+
+namespace haze {
+
+// Host-side scalar modular arithmetic (record-time immediates only, never a
+// polynomial hot path).
+
+// a * b mod m via 128-bit product.
+uint64_t mulmod_u64(uint64_t a, uint64_t b, uint64_t m) noexcept;
+
+uint64_t powmod_u64(uint64_t base, uint64_t exp, uint64_t m) noexcept;
+
+// Fermat inverse a^(p-2) mod p; requires p prime and a not divisible by p.
+uint64_t modinv_prime(uint64_t a, uint64_t p) noexcept;
+
+// Deterministic Miller-Rabin for 64-bit n (the 12-base set is exact below 3.3e24).
+bool is_prime_u64(uint64_t n) noexcept;
+
+} // namespace haze

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -13,6 +13,7 @@
 #include "core/config.hpp"
 
 #include "common/errors.hpp"
+#include "common/mod_arith.hpp"
 #include "core/device.hpp"
 
 #include <cstddef>
@@ -23,6 +24,31 @@
 namespace haze {
 
 namespace {
+
+// Floor for the generated aux prime: the replay bridge's OpenFHE template
+// synthesis rejects tiny trace moduli (LastPrime overflow below ~2^30).
+constexpr uint64_t kAuxPrimeFloor = uint64_t{1} << 30U;
+
+// Smallest prime >= kAuxPrimeFloor with p ≡ 1 (mod 2*ring_dim) — NTT-friendly
+// for the hardware twiddle tables and readback synthesis — that is not one of
+// the user's moduli. Deterministic given (ring_dim, moduli).
+uint64_t generate_aux_prime(uint64_t ring_dim, const uint64_t *moduli, size_t count) noexcept {
+    const uint64_t step = 2 * ring_dim;
+    uint64_t candidate = (((kAuxPrimeFloor + step - 1) / step) * step) + 1;
+    for (;; candidate += step) {
+        if (!is_prime_u64(candidate))
+            continue;
+        bool collides = false;
+        for (size_t i = 0; i < count; ++i) {
+            if (moduli[i] == candidate) {
+                collides = true;
+                break;
+            }
+        }
+        if (!collides)
+            return candidate;
+    }
+}
 
 // Power of two within the device envelope; the upper bound also keeps
 // n * sizeof(uint64_t) from wrapping.
@@ -43,7 +69,8 @@ std::expected<FheParams, HazeInternalError> FheParams::create(const hazeFheParam
     // Per-argument: ring_dim in the device envelope; modulus count within it.
     if (!is_supported_ring_dim(raw.ring_dim))
         return std::unexpected(HazeInternalError::InvalidArgument);
-    if (raw.moduli_count > static_cast<size_t>(kMaxCiphertextModuli))
+    // Reserve the last chain slot for the generated aux prime.
+    if (raw.moduli_count > static_cast<size_t>(kMaxCiphertextModuli) - 1)
         return std::unexpected(HazeInternalError::InvalidArgument);
 
     FheParams p;
@@ -52,6 +79,11 @@ std::expected<FheParams, HazeInternalError> FheParams::create(const hazeFheParam
         const uint64_t qi = raw.moduli[i];
         if (qi == 0) // per-argument: moduli non-zero
             return std::unexpected(HazeInternalError::InvalidArgument);
+        if (!is_prime_u64(qi)) { // per-argument: moduli prime
+            record_internal_error(HazeInternalError::CompositeModulus,
+                                  "FheParams::create: modulus not prime");
+            return std::unexpected(HazeInternalError::CompositeModulus);
+        }
         for (size_t j = 0; j < i; ++j) // whole-config: moduli unique
             if (raw.moduli[j] == qi) {
                 record_internal_error(HazeInternalError::DuplicateModulus,
@@ -60,7 +92,13 @@ std::expected<FheParams, HazeInternalError> FheParams::create(const hazeFheParam
             }
         p.moduli_[i] = qi;
     }
-    p.moduli_count_ = static_cast<int>(raw.moduli_count);
+    // One program-wide aux prime for hazeIsHalfModulus, generated here and
+    // appended as the last chain entry; compute calls never derive it.
+    if (raw.moduli_count > 0) {
+        p.aux_modulus_ = generate_aux_prime(raw.ring_dim, raw.moduli, raw.moduli_count);
+        p.moduli_[raw.moduli_count] = p.aux_modulus_;
+    }
+    p.moduli_count_ = static_cast<int>(raw.moduli_count) + (raw.moduli_count > 0 ? 1 : 0);
     p.twiddle_generators_.assign(raw.twiddle_generators,
                                  raw.twiddle_generators + raw.twiddle_count);
     return p;

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -32,10 +32,15 @@ constexpr uint64_t kAuxPrimeFloor = uint64_t{1} << 30U;
 // Smallest prime >= kAuxPrimeFloor with p ≡ 1 (mod 2*ring_dim) — NTT-friendly
 // for the hardware twiddle tables and readback synthesis — that is not one of
 // the user's moduli. Deterministic given (ring_dim, moduli).
+// 0 on exhaustion — unreachable for the validated ring_dim envelope (roughly
+// one in ln(2^30) ≈ 21 candidates in the progression is prime), but a bounded
+// loop turns a hypothetical generator bug into a clean configure error
+// instead of a stall.
 uint64_t generate_aux_prime(uint64_t ring_dim, const uint64_t *moduli, size_t count) noexcept {
+    constexpr uint64_t kMaxCandidates = 100000;
     const uint64_t step = 2 * ring_dim;
     uint64_t candidate = (((kAuxPrimeFloor + step - 1) / step) * step) + 1;
-    for (;; candidate += step) {
+    for (uint64_t tries = 0; tries < kMaxCandidates; ++tries, candidate += step) {
         if (!is_prime_u64(candidate))
             continue;
         bool collides = false;
@@ -48,6 +53,7 @@ uint64_t generate_aux_prime(uint64_t ring_dim, const uint64_t *moduli, size_t co
         if (!collides)
             return candidate;
     }
+    return 0;
 }
 
 // Power of two within the device envelope; the upper bound also keeps
@@ -96,6 +102,12 @@ std::expected<FheParams, HazeInternalError> FheParams::create(const hazeFheParam
     // appended as the last chain entry; compute calls never derive it.
     if (raw.moduli_count > 0) {
         p.aux_modulus_ = generate_aux_prime(raw.ring_dim, raw.moduli, raw.moduli_count);
+        if (p.aux_modulus_ == 0) {
+            record_internal_error(HazeInternalError::InvalidArgument,
+                                  "FheParams::create: aux prime generation exhausted");
+            return std::unexpected(HazeInternalError::InvalidArgument);
+        }
+        // In bounds: the count cap above reserves this final slot for the aux.
         p.moduli_[raw.moduli_count] = p.aux_modulus_;
     }
     p.moduli_count_ = static_cast<int>(raw.moduli_count) + (raw.moduli_count > 0 ? 1 : 0);

--- a/src/core/config.hpp
+++ b/src/core/config.hpp
@@ -40,9 +40,11 @@ class FheParams {
   public:
     // Validate the caller's struct and deep-copy it into an immutable FheParams.
     // Enforces per-argument invariants (ring_dim in the device envelope; moduli
-    // non-zero and within the modulus envelope), the whole-config invariant
+    // non-zero, prime, and within the modulus envelope), the whole-config invariant
     // (moduli unique), and struct well-formedness (a NULL array with a non-zero
-    // count is InvalidArgument). Nothing partial escapes — on any failure it
+    // count is InvalidArgument). When any moduli are supplied, a dedicated aux
+    // prime for hazeIsHalfModulus is generated and appended as the last chain
+    // entry (see aux_modulus()). Nothing partial escapes — on any failure it
     // returns the error and no object.
     static std::expected<FheParams, HazeInternalError> create(const hazeFheParams &raw) noexcept;
 
@@ -55,10 +57,14 @@ class FheParams {
             return 0;
         return moduli_[static_cast<size_t>(idx)];
     }
+    // The program-wide hazeIsHalfModulus aux prime, generated at create() and
+    // appended as the last chain entry (0 = no moduli configured).
+    uint64_t aux_modulus() const noexcept { return aux_modulus_; }
 
   private:
     uint64_t ring_dim_ = 0;
     std::array<uint64_t, static_cast<size_t>(kMaxCiphertextModuli)> moduli_{};
+    uint64_t aux_modulus_ = 0;
     int moduli_count_ = 0;
     std::vector<uint64_t> twiddle_generators_; // stored for the trace; no reader yet
 };

--- a/src/core/is_half_modulus.cpp
+++ b/src/core/is_half_modulus.cpp
@@ -19,10 +19,10 @@
 
 #include "common/errors.hpp"
 #include "common/handle.hpp"
+#include "common/mod_arith.hpp"
 #include "core/allocator.hpp"
 #include "core/centered_switch.hpp"
 #include "core/config.hpp"
-#include "core/device.hpp"
 #include "core/epoch.hpp"
 #include "core/mrp_polymap.hpp"
 
@@ -39,63 +39,6 @@ namespace haze {
 namespace fhetch = niobium::fhetch;
 
 namespace {
-
-// a * b mod m via 128-bit product.
-uint64_t mulmod_u64(uint64_t a, uint64_t b, uint64_t m) noexcept {
-    return static_cast<uint64_t>((static_cast<__uint128_t>(a) * b) % m);
-}
-
-uint64_t powmod_u64(uint64_t base, uint64_t exp, uint64_t m) noexcept {
-    uint64_t result = 1;
-    base %= m;
-    while (exp > 0) {
-        if ((exp & 1U) != 0)
-            result = mulmod_u64(result, base, m);
-        base = mulmod_u64(base, base, m);
-        exp >>= 1U;
-    }
-    return result;
-}
-
-// Fermat inverse a^(p-2) mod p; requires p prime and a not divisible by p.
-uint64_t modinv_prime(uint64_t a, uint64_t p) noexcept {
-    return powmod_u64(a, p - 2, p);
-}
-
-// Deterministic Miller-Rabin for 64-bit n (the 12-base set is exact below 3.3e24).
-// Guards the aux selection: a composite aux would make the Fermat inverse silently
-// wrong.
-bool is_prime_u64(uint64_t n) noexcept {
-    constexpr uint64_t kBases[] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37};
-    if (n < 2)
-        return false;
-    for (uint64_t b : kBases) {
-        if (n % b == 0)
-            return n == b;
-    }
-    uint64_t d = n - 1;
-    unsigned s = 0;
-    while (d % 2 == 0) {
-        d /= 2;
-        ++s;
-    }
-    for (uint64_t b : kBases) {
-        uint64_t x = powmod_u64(b, d, n);
-        if (x == 1 || x == n - 1)
-            continue;
-        bool composite = true;
-        for (unsigned i = 1; i < s; ++i) {
-            x = mulmod_u64(x, x, n);
-            if (x == n - 1) {
-                composite = false;
-                break;
-            }
-        }
-        if (composite)
-            return false;
-    }
-    return true;
-}
 
 // b = [x > h], h = (q-1)/2: g1 = c(x-h) == x-h (signed), g2 = c(x) == x - q*b,
 // so ((g1 - g2 + h) mod p) * q^-1 == b exactly, for any prime p != q.
@@ -143,30 +86,13 @@ std::expected<void, HazeInternalError> is_half_modulus(DevAddr dst, DevAddr src,
                               "hazeIsHalfModulus: modulus must be odd");
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
-    // Aux prime: lowest configured index != mod_idx holding a prime; composite
-    // entries are skipped (the Fermat inverse below is only an inverse mod a
-    // prime — a composite aux would yield silently wrong results).
-    uint64_t p = 0;
-    for (int j = 0; j < kMaxCiphertextModuli; ++j) {
-        if (j == mod_idx)
-            continue;
-        const uint64_t candidate = fhe_params().modulus(j);
-        if (candidate == 0)
-            break; // configured moduli are contiguous from index 0
-        if (is_prime_u64(candidate)) {
-            p = candidate;
-            break;
-        }
-    }
-    if (p == 0) {
+    // The program-wide aux prime generated at configure time (last chain
+    // entry); distinct primes, so q and p are coprime by construction. The
+    // aux slot itself is not a data modulus.
+    const uint64_t p = fhe_params().aux_modulus();
+    if (q == p) {
         record_internal_error(HazeInternalError::InvalidArgument,
-                              "hazeIsHalfModulus: no prime configured modulus for the aux");
-        return std::unexpected(HazeInternalError::InvalidArgument);
-    }
-    if (std::gcd(q, p) != 1) {
-        // q^-1 mod p must exist; p is prime, so this only rejects p | q.
-        record_internal_error(HazeInternalError::InvalidArgument,
-                              "hazeIsHalfModulus: modulus and aux modulus not coprime");
+                              "hazeIsHalfModulus: mod_idx names the aux modulus");
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
     auto x = epoch().lookup_or_create_locked(src);
@@ -182,35 +108,20 @@ std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, con
                                                            std::size_t base_len) noexcept {
     if (auto v = validate_moduli_base(base, base_len); !v)
         return v;
-    // Shared aux prime: lowest configured index whose value is prime and not in
-    // base; composite entries are skipped (a composite aux would make the
-    // Fermat inverse silently wrong).
-    uint64_t aux_modulus = 0;
-    for (int j = 0; j < kMaxCiphertextModuli; ++j) {
-        const uint64_t candidate = fhe_params().modulus(j);
-        if (candidate == 0)
-            break; // configured moduli are contiguous from index 0
-        if (!is_prime_u64(candidate))
-            continue;
-        bool in_base = false;
-        for (std::size_t i = 0; i < base_len; ++i) {
-            if (base[i] == candidate) {
-                in_base = true;
-                break;
-            }
-        }
-        if (!in_base) {
-            aux_modulus = candidate;
-            break;
-        }
-    }
+    // The program-wide aux prime generated at configure time (last chain
+    // entry); one aux serves every limb.
+    const uint64_t aux_modulus = fhe_params().aux_modulus();
     if (aux_modulus == 0) {
         record_internal_error(HazeInternalError::InvalidArgument,
-                              "hazeIsHalfModulusMrp: no prime configured modulus outside base for "
-                              "the aux");
+                              "hazeIsHalfModulusMrp: no moduli configured");
         return std::unexpected(HazeInternalError::InvalidArgument);
     }
     for (std::size_t i = 0; i < base_len; ++i) {
+        if (base[i] == aux_modulus) {
+            record_internal_error(HazeInternalError::InvalidArgument,
+                                  "hazeIsHalfModulusMrp: base contains the aux modulus");
+            return std::unexpected(HazeInternalError::InvalidArgument);
+        }
         if (base[i] % 2 == 0) {
             // h = (q_i-1)/2 centering needs odd limb moduli.
             record_internal_error(HazeInternalError::InvalidArgument,

--- a/src/core/is_half_modulus.cpp
+++ b/src/core/is_half_modulus.cpp
@@ -128,7 +128,9 @@ std::expected<void, HazeInternalError> is_half_modulus_mrp(void *const *dst, con
                                   "hazeIsHalfModulusMrp: base modulus must be odd");
             return std::unexpected(HazeInternalError::InvalidArgument);
         }
-        // q_i^-1 mod aux must exist; aux is prime, so this only rejects aux | q_i.
+        // q_i^-1 mod aux must exist. Unlike the SRP path (whose q comes from
+        // the primality-validated chain), MRP bases are caller-defined raw
+        // values; aux is prime, so this only rejects aux | q_i.
         if (std::gcd(base[i], aux_modulus) != 1) {
             record_internal_error(HazeInternalError::InvalidArgument,
                                   "hazeIsHalfModulusMrp: aux modulus not coprime to base prime");

--- a/test/test_broadcast.cpp
+++ b/test/test_broadcast.cpp
@@ -168,7 +168,7 @@ std::vector<uint64_t> boundary_operand(uint64_t p, uint64_t seed) {
 TEST_CASE("hazeBroadcastMulMrp: hazeIsHalfModulus mask applied to all limbs", "[integration]") {
     haze::test::setup_integration_mrp3_config(kRingDim, kQ0); // {kQ0, kQ1, kQ2}
 
-    // Mask: SRP predicate of a value under kQ0; recorded under the auto aux kQ1.
+    // Mask: SRP predicate of a value under kQ0; recorded under the generated aux.
     const std::vector<uint64_t> pred_in = haze::test::make_residue(kQ0, 424242ULL, kRingDim);
     void *d_pred_in = nullptr;
     void *d_mask = nullptr;
@@ -277,7 +277,7 @@ TEST_CASE("hazeBroadcast: H2D overwrite clears a stale recorded operand modulus"
     REQUIRE(hazeMalloc(&d_t, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeMalloc(&d_in, kBytes) == HAZE_SUCCESS);
     REQUIRE(hazeMemcpy(d_in, pred_in.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
-    REQUIRE(hazeIsHalfModulus(d_t, d_in, 0, nullptr) == HAZE_SUCCESS); // recorded under kQ2
+    REQUIRE(hazeIsHalfModulus(d_t, d_in, 0, nullptr) == HAZE_SUCCESS); // recorded under the aux
 
     const std::vector<uint64_t> mask = binary_mask(0x7E7EULL);
     REQUIRE(hazeMemcpy(d_t, mask.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
@@ -389,7 +389,7 @@ TEST_CASE("hazeBroadcast rejects invalid arguments", "[unit]") {
 TEST_CASE("hazeBroadcast rejects an operand recorded under an even modulus", "[integration]") {
     // The centered lift's h = (p-1)/2 needs an odd operand ring; an operand
     // bound under an even chain entry is rejected at recovery.
-    setup_chain_config({kQ0, kQ1, 1ULL << 40});
+    setup_chain_config({kQ0, kQ1, 2}); // 2: the one even prime the config accepts
 
     const uint64_t base[] = {kQ0, kQ1};
     const std::vector<void *> d_src =

--- a/test/test_invariant_regressions.cpp
+++ b/test/test_invariant_regressions.cpp
@@ -549,17 +549,22 @@ TEST_CASE("ciphertext-modulus count is bounded by the device envelope", "[unit]"
     hazeDeviceProp prop{};
     REQUIRE(hazeGetDeviceProperties(&prop, 0) == HAZE_SUCCESS);
     const auto max = static_cast<std::size_t>(prop.maxCiphertextModuli);
-    std::vector<uint64_t> moduli(max + 1);
-    for (std::size_t i = 0; i < moduli.size(); ++i)
-        moduli[i] = kQ0 + (2 * i);
+    // Distinct primes (the config enforces primality); the device appends its
+    // generated aux as the last chain entry, so callers may supply max - 1.
+    const std::vector<uint64_t> moduli = {
+        3,   5,   7,   11,  13,  17,  19,  23,  29,  31,  37,  41,  43,  47,  53,  59,
+        61,  67,  71,  73,  79,  83,  89,  97,  101, 103, 107, 109, 113, 127, 131, 137,
+        139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227,
+        229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313};
+    REQUIRE(moduli.size() >= max);
 
-    // Exactly `max` distinct primes configure cleanly...
-    const hazeFheParams full = {.ring_dim = kRingDim, .moduli = moduli.data(), .moduli_count = max};
+    // Exactly `max - 1` supplied primes configure cleanly (aux slot reserved)...
+    const hazeFheParams full = {
+        .ring_dim = kRingDim, .moduli = moduli.data(), .moduli_count = max - 1};
     REQUIRE(hazeConfigureDevice(&full, nullptr) == HAZE_SUCCESS);
-    // ...and one past the envelope is rejected (previously an unbounded vector
-    // grew; now it guards a fixed array).
-    const hazeFheParams over = {
-        .ring_dim = kRingDim, .moduli = moduli.data(), .moduli_count = max + 1};
+    // ...and one more is rejected (previously an unbounded vector grew; now it
+    // guards a fixed array with the last slot reserved for the generated aux).
+    const hazeFheParams over = {.ring_dim = kRingDim, .moduli = moduli.data(), .moduli_count = max};
     REQUIRE(hazeConfigureDevice(&over, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);

--- a/test/test_is_half_modulus.cpp
+++ b/test/test_is_half_modulus.cpp
@@ -31,31 +31,20 @@ constexpr std::size_t kBytes = kRingDim * sizeof(uint64_t);
 constexpr uint64_t kQ0 = 576460752303415297ULL;
 constexpr uint64_t kQ1 = 576460752303439873ULL;
 constexpr uint64_t kQ2 = 576460752303702017ULL;
-// Small NTT-friendly prime (~2^30, ≡ 1 mod 8192); the practical floor — the
-// replay bridge's template synthesis throws for tiny primes like 65537.
+// The device-generated aux prime for ring_dim 4096: the smallest prime >= 2^30
+// (the replay bridge floor) with p ≡ 1 mod 8192. Configuring it as a data
+// modulus makes the generator skip to the next candidate (1073815553).
 constexpr uint64_t kSmallQ = 1073750017ULL;
 // 59-bit NTT-friendly prime with q ≡ 1 (mod kSmallQ): against aux p = kSmallQ
 // it drives qinv == 1, p | h, and the zero-immediate gadget branches at once.
 constexpr uint64_t kCongruentQ = 288241371603542017ULL;
-// 2*kQ0 + 1: composite (3*5*7*13 divide it) — the "safe-prime-looking" aux a
-// caller might configure; the aux selection must skip it (a composite aux
-// makes the Fermat inverse silently wrong).
+// 2*kQ0 + 1: composite (3*5*7*13 divide it) — the "safe-prime-looking" modulus
+// a caller might configure; hazeConfigureDevice must reject it (a composite
+// chain entry would make Fermat inverses silently wrong).
 constexpr uint64_t kCompositeAux = (2 * kQ0) + 1;
-constexpr uint64_t kEvenModulus = 1ULL << 40;
 
 uint64_t is_half_ref(uint64_t x, uint64_t q) {
     return (x > (q - 1) / 2) ? 1U : 0U;
-}
-
-// Two-prime configuration; the aux prime for mod_idx=0 is q1 (lowest index != 0).
-void setup_two_prime_config(uint64_t q0, uint64_t q1) {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    const uint64_t moduli[] = {q0, q1};
-    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
-    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
-    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
-    uint64_t scaffold = 0; // built then overwritten from the trace; not used for results
-    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, q0, &scaffold) == HAZE_SUCCESS);
 }
 
 // Pseudorandom residues mod q with the threshold boundary cases pinned into the
@@ -102,69 +91,42 @@ void run_golden_case(uint64_t q, int mod_idx, uint64_t seed) {
 // Golden values ([integration]: runs under test-sim and test-transport).
 // ===========================================================================
 
-TEST_CASE("hazeIsHalfModulus: golden values, aux prime above q", "[integration]") {
+TEST_CASE("hazeIsHalfModulus: golden values, generated aux below q", "[integration]") {
     haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
-    run_golden_case(kQ0, /*mod_idx=*/0, /*seed=*/424242ULL); // p = kQ1 > q
+    // aux = kSmallQ (generated, ~2^30): p < q and h >= p for every data prime.
+    run_golden_case(kQ0, /*mod_idx=*/0, /*seed=*/424242ULL);
+    run_golden_case(kQ1, /*mod_idx=*/1, /*seed=*/911223ULL);
+    run_golden_case(kQ2, /*mod_idx=*/2, /*seed=*/171717ULL);
 }
 
-TEST_CASE("hazeIsHalfModulus: golden values, aux prime below q", "[integration]") {
-    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
-    run_golden_case(kQ1, /*mod_idx=*/1, /*seed=*/911223ULL); // p = kQ0 < q
-    run_golden_case(kQ2, /*mod_idx=*/2, /*seed=*/171717ULL); // p = kQ0 < q
-}
-
-TEST_CASE("hazeIsHalfModulus: golden values, small q against 59-bit aux prime", "[integration]") {
-    setup_two_prime_config(kSmallQ, kQ0);
-    run_golden_case(kSmallQ, /*mod_idx=*/0, /*seed=*/555555ULL); // p = kQ0 >> q
-}
-
-TEST_CASE("hazeIsHalfModulus: golden values, small aux prime (h >= p)", "[integration]") {
-    setup_two_prime_config(kQ0, kSmallQ);
-    run_golden_case(kQ0, /*mod_idx=*/0, /*seed=*/777777ULL); // p = kSmallQ, h >> p
+TEST_CASE("hazeIsHalfModulus: golden values, generated aux above q (collision skip)",
+          "[integration]") {
+    // kSmallQ as a data modulus collides with the generator's first candidate,
+    // so the aux becomes the next qualifying prime (1073815553) — above q.
+    haze::test::setup_integration_compute_config(kRingDim, kSmallQ);
+    run_golden_case(kSmallQ, /*mod_idx=*/0, /*seed=*/555555ULL);
 }
 
 TEST_CASE("hazeIsHalfModulus: golden values, q ≡ 1 mod p (qinv == 1, p | h)", "[integration]") {
-    setup_two_prime_config(kCongruentQ, kSmallQ);
+    // kSmallQ | (kCongruentQ-1)/2, and the generated aux for this chain is
+    // exactly kSmallQ — driving qinv == 1 and the zero-immediate branches.
+    haze::test::setup_integration_compute_config(kRingDim, kCongruentQ);
     run_golden_case(kCongruentQ, /*mod_idx=*/0, /*seed=*/999999ULL);
 }
 
-TEST_CASE("hazeIsHalfModulus: aux selection skips a composite chain entry", "[integration]") {
-    // {kQ0, 2*kQ0+1 (composite), kQ1}: the aux for mod_idx=0 must skip index 1
-    // and land on kQ1; picking the composite would return garbage for every
-    // x > q/2 (Fermat inverse of a composite is not an inverse).
+TEST_CASE("hazeConfigureDevice rejects a composite modulus", "[unit]") {
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     const uint64_t moduli[] = {kQ0, kCompositeAux, kQ1};
     const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
-    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
-    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
-    uint64_t scaffold = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
-    run_golden_case(kQ0, /*mod_idx=*/0, /*seed=*/121212ULL); // aux = kQ1
-}
-
-TEST_CASE("hazeIsHalfModulus rejects a chain with no prime aux candidate", "[unit]") {
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    const uint64_t moduli[] = {kQ0, kCompositeAux};
-    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
-    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
-
-    void *d_src = nullptr;
-    void *d_dst = nullptr;
-    REQUIRE(hazeMalloc(&d_src, kBytes) == HAZE_SUCCESS);
-    REQUIRE(hazeMalloc(&d_dst, kBytes) == HAZE_SUCCESS);
-    std::vector<uint64_t> a(kRingDim, 1);
-    REQUIRE(hazeMemcpy(d_src, a.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
-
-    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_ERROR_CONFIGERR);
     hazeGetLastError();
-
-    REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
-    REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
 }
 
 TEST_CASE("hazeIsHalfModulus rejects an even modulus", "[unit]") {
+    // 2 is the only prime the config accepts that the odd-centering guard
+    // must still reject.
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    const uint64_t moduli[] = {kEvenModulus, kQ0};
+    const uint64_t moduli[] = {2, kQ0};
     const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 2};
     REQUIRE(hazeConfigureDevice(&fhe, nullptr) == HAZE_SUCCESS);
 
@@ -175,11 +137,10 @@ TEST_CASE("hazeIsHalfModulus rejects an even modulus", "[unit]") {
     std::vector<uint64_t> a(kRingDim, 1);
     REQUIRE(hazeMemcpy(d_src, a.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
 
-    // mod_idx 0 names the even modulus: rejected. An even value is also never
-    // selectable as aux (it fails the primality check).
+    // mod_idx 0 names the even prime: rejected by the odd-centering guard.
     REQUIRE(hazeIsHalfModulus(d_dst, d_src, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
-    const uint64_t base[] = {kEvenModulus};
+    const uint64_t base[] = {2};
     void *dst_polys[] = {d_dst};
     const void *src_polys[] = {d_src};
     REQUIRE(hazeIsHalfModulusMrp(dst_polys, src_polys, base, 1, nullptr) ==
@@ -289,7 +250,13 @@ TEST_CASE("hazeIsHalfModulus with invalid modulus index returns error", "[unit]"
     REQUIRE(hazeFree(d_dst) == HAZE_SUCCESS);
 }
 
-TEST_CASE("hazeIsHalfModulus without a second configured modulus returns error", "[unit]") {
+TEST_CASE("hazeIsHalfModulus: a single data modulus works via the generated aux", "[integration]") {
+    haze::test::setup_integration_compute_config(kRingDim, kQ0);
+    run_golden_case(kQ0, /*mod_idx=*/0, /*seed=*/343434ULL);
+}
+
+TEST_CASE("hazeIsHalfModulus rejects mod_idx naming the aux slot", "[unit]") {
+    // {kQ0} configures as {kQ0, aux}; the aux entry is not a data modulus.
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     const uint64_t moduli[] = {kQ0};
     const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 1};
@@ -302,8 +269,7 @@ TEST_CASE("hazeIsHalfModulus without a second configured modulus returns error",
     std::vector<uint64_t> a(kRingDim, 1);
     REQUIRE(hazeMemcpy(d_src, a.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
 
-    // mod_idx 0 is valid; the failure is the missing aux modulus.
-    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 0, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    REQUIRE(hazeIsHalfModulus(d_dst, d_src, 1, nullptr) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 
     REQUIRE(hazeFree(d_src) == HAZE_SUCCESS);
@@ -382,12 +348,12 @@ std::filesystem::path record_ihm_program(const std::string &program_name, bool m
     return std::filesystem::path{program_name};
 }
 
-// Immediates of the lowering for q = kQ0, p = kQ1 (aux = lowest index != 0):
+// Immediates of the lowering for q = kQ0 against the generated aux kSmallQ:
 // h (subps + gadget shifts), -h mod p (gadget unshifts, exactly twice),
 // h mod p (the +h re-add), qinv (the final scale).
 void check_ihm_trace_shape(const std::string &trace, bool four_op) {
     const uint64_t q = kQ0;
-    const uint64_t p = kQ1;
+    const uint64_t p = kSmallQ;
     const uint64_t h = (q - 1) / 2;
     const uint64_t neg_half = p - (h % p);
     const uint64_t qinv = niobium::mod_arith::modinv_prime(q % p, p);
@@ -558,7 +524,7 @@ void check_ihm_mrp_results(const std::vector<uint64_t> &base, uint64_t seed,
 
 } // namespace
 
-TEST_CASE("hazeIsHalfModulusMrp: per-limb golden values, shared configured aux", "[integration]") {
+TEST_CASE("hazeIsHalfModulusMrp: per-limb golden values, shared generated aux", "[integration]") {
     const std::vector<uint64_t> base =
         haze::test::setup_integration_mrp3_config(kRingDim, kQ0); // {kQ0, kQ1, kQ2}
     const std::vector<uint64_t> limb_base = {base[0], base[1]};
@@ -575,7 +541,6 @@ TEST_CASE("hazeIsHalfModulusMrp: per-limb golden values, shared configured aux",
         haze::test::free_all_residues(d_tmp);
     }
 
-    // Auto-selected aux = base[2] (kQ2), the lowest configured index not in the base.
     check_ihm_mrp_results(limb_base, /*seed=*/818181ULL,
                           run_ihm_mrp(limb_base, /*seed=*/818181ULL));
 }
@@ -606,37 +571,20 @@ TEST_CASE("hazeIsHalfModulusMrp: in-place dst == src", "[integration]") {
     haze::test::free_all_residues(d_x);
 }
 
-TEST_CASE("hazeIsHalfModulusMrp: small auto-selected aux (h >= p per limb)", "[integration]") {
-    // Config {kSmallQ, kQ1, kQ2} with base {kQ1, kQ2}: the auto-selected aux is
-    // kSmallQ (lowest configured index not in the base), exercising h >= p
-    // immediate reduction on every limb.
-    haze::test::setup_integration_mrp3_config(kRingDim, kSmallQ);
+TEST_CASE("hazeIsHalfModulusMrp: generated aux (h >= p per limb)", "[integration]") {
+    // The generated ~2^30 aux serves 59-bit limbs with h >= p immediate
+    // reduction on every limb.
+    haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
     const std::vector<uint64_t> limb_base = {kQ1, kQ2};
     check_ihm_mrp_results(limb_base, /*seed=*/828282ULL,
                           run_ihm_mrp(limb_base, /*seed=*/828282ULL));
 }
 
-TEST_CASE("hazeIsHalfModulusMrp: aux selection skips a composite chain entry", "[integration]") {
-    // {kQ0, 2*kQ0+1 (composite), kQ2} with base {kQ0}: aux must skip the
-    // composite and select kQ2.
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    const uint64_t moduli[] = {kQ0, kCompositeAux, kQ2};
-    const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
-    const hazeReplayConfig replay = {.target = haze::test::target_from_env(), .reduced_noise = 1};
-    REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
-    uint64_t scaffold = 0;
-    REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
-    const std::vector<uint64_t> limb_base = {kQ0};
-    check_ihm_mrp_results(limb_base, /*seed=*/131313ULL,
-                          run_ihm_mrp(limb_base, /*seed=*/131313ULL));
-}
-
 TEST_CASE("hazeIsHalfModulusMrp: base prime outside the configured chain", "[integration]") {
     // Base primes are caller-defined raw values (registered through the trace's
-    // modulus table); only the aux comes from the configuration. Config
-    // {kQ0, kQ1, kQ2} with base {kSmallQ, kQ1} auto-selects aux = kQ0.
+    // modulus table); the generated aux serves them all the same.
     haze::test::setup_integration_mrp3_config(kRingDim, kQ0);
-    const std::vector<uint64_t> limb_base = {kSmallQ, kQ1};
+    const std::vector<uint64_t> limb_base = {kCongruentQ, kQ1};
     check_ihm_mrp_results(limb_base, /*seed=*/868686ULL,
                           run_ihm_mrp(limb_base, /*seed=*/868686ULL));
 }
@@ -661,11 +609,11 @@ TEST_CASE("hazeIsHalfModulusMrp rejects invalid arguments", "[unit]") {
             HAZE_ERROR_INVALID_VALUE);
     REQUIRE(hazeIsHalfModulusMrp(dst_polys, src_polys, base, 0, nullptr) ==
             HAZE_ERROR_INVALID_VALUE);
-    // Base covering every configured modulus leaves no aux prime to select.
-    const uint64_t full_base[] = {kQ0, kQ1, kQ2};
-    void *dst3[] = {d_a, d_b, d_a};
-    const void *src3[] = {d_a, d_b, d_a};
-    REQUIRE(hazeIsHalfModulusMrp(dst3, src3, full_base, 3, nullptr) == HAZE_ERROR_INVALID_VALUE);
+    // A base containing the generated aux prime is rejected (p must differ
+    // from every limb modulus).
+    const uint64_t aux_base[] = {kQ0, kSmallQ};
+    REQUIRE(hazeIsHalfModulusMrp(dst_polys, src_polys, aux_base, 2, nullptr) ==
+            HAZE_ERROR_INVALID_VALUE);
     // Bad src residues surface from the source-resolution path (same lookup as
     // build_mrp_locked): allocated-but-unwritten reports SOURCE_UNAVAILABLE,
     // null reports UNKNOWN_ADDRESS. d_a is written before the null case so

--- a/test/test_is_half_modulus.cpp
+++ b/test/test_is_half_modulus.cpp
@@ -571,6 +571,15 @@ TEST_CASE("hazeIsHalfModulusMrp: in-place dst == src", "[integration]") {
     haze::test::free_all_residues(d_x);
 }
 
+TEST_CASE("hazeIsHalfModulusMrp: base spanning the whole data chain", "[integration]") {
+    // The scenario the configured-aux design could not serve: a predicate over
+    // every data modulus at once. The generated aux lives outside the supplied
+    // chain, so a full-chain base always has an extraction ring.
+    const std::vector<uint64_t> base =
+        haze::test::setup_integration_mrp3_config(kRingDim, kQ0); // {kQ0, kQ1, kQ2}
+    check_ihm_mrp_results(base, /*seed=*/878787ULL, run_ihm_mrp(base, /*seed=*/878787ULL));
+}
+
 TEST_CASE("hazeIsHalfModulusMrp: generated aux (h >= p per limb)", "[integration]") {
     // The generated ~2^30 aux serves 59-bit limbs with h >= p immediate
     // reduction on every limb.

--- a/test/test_is_half_modulus.cpp
+++ b/test/test_is_half_modulus.cpp
@@ -647,8 +647,11 @@ TEST_CASE("hazeIsHalfModulusMrp transport: A/B byte-exact vs ordinary mode",
     if (!transport_target_active())
         SKIP("data format requires a transport target (run under make test-transport)");
 
-    const std::vector<uint64_t> limb_base = {kQ0, kQ1};
-    auto run_once = [&](bool montgomery, bool bit_reversal) {
+    // Two arms: a partial base and one spanning the whole data chain (the case
+    // only the generated aux can serve).
+    const std::vector<std::vector<uint64_t>> bases = {{kQ0, kQ1}, {kQ0, kQ1, kQ2}};
+    auto run_once = [&](const std::vector<uint64_t> &limb_base, bool montgomery,
+                        bool bit_reversal) {
         const uint64_t moduli[] = {kQ0, kQ1, kQ2};
         const hazeFheParams fhe = {.ring_dim = kRingDim, .moduli = moduli, .moduli_count = 3};
         const hazeReplayConfig replay = {.target = haze::test::target_from_env(),
@@ -658,15 +661,18 @@ TEST_CASE("hazeIsHalfModulusMrp transport: A/B byte-exact vs ordinary mode",
         REQUIRE(hazeConfigureDevice(&fhe, &replay) == HAZE_SUCCESS);
         uint64_t scaffold = 0;
         REQUIRE(hazeReplayBridgeInitCryptoContext(kRingDim, kQ0, &scaffold) == HAZE_SUCCESS);
-        return run_ihm_mrp(limb_base, /*seed=*/838383ULL); // auto aux = kQ2
+        return run_ihm_mrp(limb_base, /*seed=*/838383ULL);
     };
 
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    const auto ordinary = run_once(/*montgomery=*/false, /*bit_reversal=*/false);
-    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
-    const auto encoded = run_once(/*montgomery=*/true, /*bit_reversal=*/true);
-    REQUIRE(ordinary == encoded);
-    check_ihm_mrp_results(limb_base, /*seed=*/838383ULL, encoded);
+    for (const std::vector<uint64_t> &limb_base : bases) {
+        REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+        const auto ordinary = run_once(limb_base, /*montgomery=*/false, /*bit_reversal=*/false);
+        REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+        const auto encoded = run_once(limb_base, /*montgomery=*/true, /*bit_reversal=*/true);
+        INFO("base_len " << limb_base.size());
+        REQUIRE(ordinary == encoded);
+        check_ihm_mrp_results(limb_base, /*seed=*/838383ULL, encoded);
+    }
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
 }
 


### PR DESCRIPTION
## Summary

Moves the hazeIsHalfModulus aux-prime story entirely into `hazeConfigureDevice`, per design review:

- **All configured moduli must be prime** — enforced with a deterministic 12-base Miller–Rabin (`CompositeModulus` → `HAZE_ERROR_CONFIGERR`). This closes the composite-chain silent-corruption hole at its root (the `p = 2q+1` incident): a composite modulus can no longer enter the system at all, so no per-call skipping or checking is needed.
- **One program-wide aux prime, generated by the device**: the smallest prime ≥ 2³⁰ (the replay bridge floor) with `p ≡ 1 mod 2·ring_dim` (NTT-friendly for hardware twiddle tables and readback synthesis) that doesn't collide with the supplied moduli, appended as the **last chain entry**. For `ring_dim = 4096` this is `1073750017` unless the user configured that value, in which case the generator steps to the next candidate. Deterministic given (ring_dim, moduli) — traces stay reproducible. Users supply only data moduli (at most 63; the last slot is reserved).
- `hazeIsHalfModulus`/`-Mrp` read the single frozen aux — zero per-call selection or primality work. A single data modulus now suffices (`{q}` configures as `{q, aux}`), and misuse is rejected cleanly: `mod_idx` naming the aux slot, or an MRP base containing the aux, returns `HAZE_ERROR_INVALID_VALUE`.
- The scalar modular-arithmetic helpers (`mulmod/powmod/modinv_prime/is_prime_u64`) are promoted to `src/common/mod_arith` (second production user: the config).

Correctness is invariant to which prime the aux is — the machine-checked Lean theorems require only `p ≠ q`, `p` prime, `q` odd — so all existing golden coverage carries over; tests are reworked for the new contract (config-level composite rejection, collision-skip case, aux-slot rejection, single-modulus success, `q ≡ 1 mod p` corner preserved via the generated aux).