### PR TITLE
[release-train niobium-fhetch-113] bump niobium-fhetch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,7 +22,7 @@
       "locked": {
         "lastModified": 1784580339,
         "ref": "refs/heads/main",
-        "rev": "f7f6c8a021456bbae9059b096288b30d92d4d01d",
+        "rev": "32567c9001d49b49086ba6b02308ce4c3524ef39",
         "revCount": 185,
         "submodules": true,
         "type": "git",


### PR DESCRIPTION
✅ Deps merged; submodule pointer(s) on default branch. **Ready to merge.**

<!-- release-train id=niobium-fhetch-113 repo=niobium-haze deps=niobium-fhetch -->