### PR TITLE
feat(core): expose minted input group names

### DIFF
--- a/include/haze/haze.h
+++ b/include/haze/haze.h
@@ -105,6 +105,24 @@ HAZE_API hazeError_t hazeMemcpyMrp(void *const *dst, const void *const *src, siz
                                    hazeMemcpyKind kind, const uint64_t *base,
                                    size_t base_len) HAZE_NOEXCEPT;
 
+// Read-only query, never starting, finalizing or perturbing an epoch: writes into `out` (NUL-
+// terminated) the MRP input group name minted for the H2D upload that most recently wrote `ptr`'s
+// address — re-uploading the same address, by hazeMemcpyMrp or a plain hazeMemcpy, answers the
+// newer name (a plain hazeMemcpy(H2D) governs the address under its own, unnamed entry, so the
+// prior MRP name stops answering for it). A compute result stored at an uploaded address does
+// NOT drop the name: the address hasn't changed hands, and the entry remains a live input of the
+// program under construction. HAZE_ERROR_SOURCE_UNAVAILABLE if `ptr` names no live upload this
+// epoch: never uploaded, an output-only address, or the binding dropped by
+// hazeFree/hazeFreeMrp/hazeMemset on that address, or by an epoch finalize (hazeFlush /
+// hazeWriteProgram with something pending) or hazeDeviceReset — any error-path epoch clear
+// (a contained throw during tagging or finalize) drops every name the same way. A write_program
+// with nothing pending preserves the epoch, so a name recorded before it still answers after.
+// `out_len` must hold the name plus its NUL terminator (64 bytes always suffices); a buffer too
+// short returns HAZE_ERROR_INVALID_VALUE with `out` left untouched (no truncation). NULL
+// `ptr`/`out` or `out_len == 0` returns HAZE_ERROR_INVALID_VALUE; HAZE_ERROR_INTERNAL on an
+// internal failure (e.g. allocation failure copying the name).
+HAZE_API hazeError_t hazeInputGroupName(const void *ptr, char *out, size_t out_len) HAZE_NOEXCEPT;
+
 // hazeMallocMrp reserves `num_residues` device polynomials for one MRP group under a single
 // allocator lock and writes their addresses into `ptrs[0..num_residues)` (all non-null on
 // success); `num_residues` is the group's residue count (the `base_len` passed to the MRP

--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -20,9 +20,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <cstring>
 #include <expected>
 #include <haze/haze.h>
 #include <haze/haze_types.h>
+#include <string>
 #include <unistd.h>
 #include <vector>
 
@@ -172,6 +174,24 @@ extern "C" hazeError_t hazeMemcpyMrp(void *const *dst, const void *const *src, s
             haze::copy_device_to_device_mrp(dst, src, count, base, base_len));
 
     return set_error(HAZE_ERROR_INVALID_VALUE);
+}
+
+extern "C" hazeError_t hazeInputGroupName(const void *ptr, char *out, size_t out_len) noexcept {
+    if (ptr == nullptr)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    if (out == nullptr)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    if (out_len == 0)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    auto result = haze::input_group_name(haze::to_dev_addr(ptr));
+    if (!result)
+        return set_error(haze::to_public_error(result.error()));
+    // No truncation: a buffer too short to hold the name plus its NUL is rejected outright.
+    if (result->size() + 1 > out_len)
+        return set_error(HAZE_ERROR_INVALID_VALUE);
+    std::memcpy(out, result->data(), result->size());
+    out[result->size()] = '\0';
+    return HAZE_SUCCESS;
 }
 
 extern "C" hazeError_t hazeMemset(void *dev_ptr, int value, size_t count) noexcept {

--- a/src/core/epoch.cpp
+++ b/src/core/epoch.cpp
@@ -314,11 +314,13 @@ std::expected<void, HazeInternalError> EpochState::tag_h2d_input_locked(DevAddr 
         fhetch::tag_input(name, poly);
         // New H2D bytes overwrite the binding, drop any output tag and stale
         // modulus, and mark the addr as carrying bytes no prime was declared for
-        // (MRP-group claims stay).
+        // (MRP-group claims stay, but the query index's entry does not: this
+        // upload, not the earlier MRP one, now governs these bytes).
         poly_map_.insert_or_assign(addr, std::move(poly));
         pending_outputs_.erase(addr);
         addr_modulus_.erase(addr);
         undeclared_uploads_.insert(addr);
+        mrp_.forget_input_group(addr);
     } catch (...) {
         // put() and bind_name() both already committed; undo both before the epoch-wide
         // clear so addr itself is restored, not just left to a fresh epoch's bookkeeping.
@@ -444,6 +446,10 @@ EpochState::tag_h2d_mrp_input_locked(std::span<const DevAddr> addrs,
             addr_modulus_.insert_or_assign(addrs[i], moduli[i]);
             undeclared_uploads_.erase(addrs[i]);
         }
+        // Last statement of the commit: every fallible step above has already
+        // succeeded, so a throw here is rolled back by the catch below exactly like
+        // the state it sits beside, and a successful return commits it alongside them.
+        mrp_.record_input_group(addrs, name);
     } catch (...) {
         erase_puts(addrs.size());
         restore_shadows(addrs.size());
@@ -618,6 +624,22 @@ std::expected<void, HazeInternalError> EpochState::tag_output(DevAddr addr) noex
     }
 }
 
+std::expected<std::string, HazeInternalError> EpochState::input_group_name(DevAddr addr) noexcept {
+    HazeLockGuard lock(mutex_);
+    try {
+        const std::string *name = mrp_.input_group_name(addr);
+        if (name == nullptr) {
+            record_internal_error(HazeInternalError::SourceUnavailable,
+                                  "input_group_name: addr has no live input group binding");
+            return std::unexpected(HazeInternalError::SourceUnavailable);
+        }
+        return *name;
+    } catch (...) {
+        record_internal_error(HazeInternalError::BackendReplayFailed, "input_group_name threw");
+        return std::unexpected(HazeInternalError::BackendReplayFailed);
+    }
+}
+
 void EpochState::reset() noexcept {
     HazeLockGuard lock(mutex_);
     clear_state_locked();
@@ -654,6 +676,10 @@ std::expected<void, HazeInternalError> write_program() noexcept {
 
 std::expected<void, HazeInternalError> tag_output(DevAddr addr) noexcept {
     return epoch().tag_output(addr);
+}
+
+std::expected<std::string, HazeInternalError> input_group_name(DevAddr addr) noexcept {
+    return epoch().input_group_name(addr);
 }
 
 std::expected<void, HazeInternalError> flush() noexcept {

--- a/src/core/epoch.hpp
+++ b/src/core/epoch.hpp
@@ -73,6 +73,12 @@ class EpochState {
     // with nothing recorded (empty poly_map_) returns SourceUnavailable.
     std::expected<void, HazeInternalError> tag_output(DevAddr addr) noexcept HAZE_EXCLUDES(mutex_);
 
+    // Read-only query (backs hazeInputGroupName): the MRP input group name last minted for
+    // `addr`, or SourceUnavailable if none is live this epoch. Never starts or perturbs a
+    // recording.
+    std::expected<std::string, HazeInternalError> input_group_name(DevAddr addr) noexcept
+        HAZE_EXCLUDES(mutex_);
+
     void reset() noexcept HAZE_EXCLUDES(mutex_);
 
     // ---- Locked methods (caller holds mutex_) ----
@@ -250,6 +256,9 @@ std::expected<void, HazeInternalError> write_program() noexcept;
 
 // Backs hazeTagOutput (EpochState::tag_output).
 std::expected<void, HazeInternalError> tag_output(DevAddr addr) noexcept;
+
+// Backs hazeInputGroupName (EpochState::input_group_name).
+std::expected<std::string, HazeInternalError> input_group_name(DevAddr addr) noexcept;
 
 // Backs hazeFlush (EpochState::replay_and_populate).
 std::expected<void, HazeInternalError> flush() noexcept;

--- a/src/core/mrp_registry.cpp
+++ b/src/core/mrp_registry.cpp
@@ -53,6 +53,7 @@ void MrpGroupRegistry::invalidate(DevAddr addr) {
     }
     // A recycled allocation leading a new group gets a fresh name.
     out_names_.erase(addr);
+    in_names_.erase(addr);
 }
 
 std::string MrpGroupRegistry::group_name(DevAddr leading) {
@@ -65,6 +66,20 @@ std::string MrpGroupRegistry::group_name(DevAddr leading) {
 
 std::string MrpGroupRegistry::next_input_group_name() {
     return "haze_mrp_in_" + std::to_string(in_counter_++);
+}
+
+void MrpGroupRegistry::record_input_group(std::span<const DevAddr> addrs, const std::string &name) {
+    for (DevAddr addr : addrs)
+        in_names_.insert_or_assign(addr, name);
+}
+
+const std::string *MrpGroupRegistry::input_group_name(DevAddr addr) const {
+    auto it = in_names_.find(addr);
+    return it == in_names_.end() ? nullptr : &it->second;
+}
+
+void MrpGroupRegistry::forget_input_group(DevAddr addr) {
+    in_names_.erase(addr);
 }
 
 std::expected<bool, HazeInternalError>
@@ -186,6 +201,7 @@ void MrpGroupRegistry::clear() {
     pending_.clear();
     addr_to_groups_.clear();
     out_names_.clear();
+    in_names_.clear();
     in_counter_ = 0;
     out_counter_ = 0;
 }

--- a/src/core/mrp_registry.hpp
+++ b/src/core/mrp_registry.hpp
@@ -53,6 +53,19 @@ class MrpGroupRegistry {
     // .ids file binds.
     std::string next_input_group_name();
 
+    // Record `name` as the group last minted for every addr in `addrs` (latest-write-wins per
+    // addr); called once per upload, right after next_input_group_name() and bind_name() both
+    // succeed.
+    void record_input_group(std::span<const DevAddr> addrs, const std::string &name);
+
+    // Group name last recorded for `addr` by record_input_group(), or nullptr if none is live.
+    const std::string *input_group_name(DevAddr addr) const;
+
+    // Drop `addr`'s query-index entry without touching group membership: a later, differently
+    // shaped upload at the same address now governs it and the old input group name must stop
+    // answering for it.
+    void forget_input_group(DevAddr addr);
+
     // Record `addrs`/`moduli` as the current MRP group `name` (latest-write-wins), returning
     // true if it was already a tagged output so the caller re-tags its members.
     std::expected<bool, HazeInternalError> record_mrp_group(std::span<const DevAddr> addrs,
@@ -84,6 +97,10 @@ class MrpGroupRegistry {
     // Reverse index addr -> group names (at most one after any registration).
     std::unordered_map<DevAddr, std::unordered_set<std::string>> addr_to_groups_;
     std::unordered_map<DevAddr, std::string> out_names_;
+    // Query index only (addr -> last minted input group name); never consulted when
+    // tagging, so fresh-name-per-upload is unaffected. A prior naming-key use was removed in
+    // e34c662.
+    std::unordered_map<DevAddr, std::string> in_names_;
     uint64_t in_counter_ = 0;
     uint64_t out_counter_ = 0;
 };

--- a/test/test_input_entries.cpp
+++ b/test/test_input_entries.cpp
@@ -28,6 +28,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <haze/haze.h>
@@ -1030,4 +1031,248 @@ TEST_CASE("a failed MRP tag mid-way through undoes an already-spilled prefix", "
     REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
     std::filesystem::remove_all(dir);
     std::filesystem::remove_all(spill_root);
+}
+
+TEST_CASE("hazeInputGroupName answers the minted name for every residue of an MRP upload",
+          "[integration]") {
+    const std::vector<uint64_t> base = {kQ0, kQ1, kQ2};
+    const std::string program_name = "haze_input_group_name_basic";
+    const std::filesystem::path dir{program_name};
+    std::filesystem::remove_all(dir);
+    configure(program_name, base);
+    const auto src = haze::test::allocate_and_h2d_residues(residues_for(base, 0x1000ULL), base);
+
+    char buf[64];
+    for (void *p : src) {
+        REQUIRE(hazeInputGroupName(p, buf, sizeof buf) == HAZE_SUCCESS);
+        REQUIRE(std::string(buf) == "haze_mrp_in_0");
+    }
+
+    const auto dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    REQUIRE(hazeAddMrp(dst.data(), haze::test::to_const(src).data(),
+                       haze::test::to_const(src).data(), base.data(), base.size(),
+                       nullptr) == HAZE_SUCCESS);
+    for (void *out : dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeWriteProgram() == HAZE_SUCCESS);
+
+    const auto entries = read_manifest(dir, program_name);
+    REQUIRE(entries.size() == 1);
+    REQUIRE(entries.front().name == "haze_mrp_in_0");
+
+    haze::test::free_all_residues(src);
+    haze::test::free_all_residues(dst);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("hazeInputGroupName follows a re-upload to the newer group name", "[integration]") {
+    // Mirrors "recorded inputs: re-uploading the same addresses records both uploads":
+    // each upload builds fresh fhetch polynomials, so the query must track the newer
+    // name, not the leading addr's original one.
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    const std::string program_name = "haze_input_group_name_reupload";
+    const std::filesystem::path dir{program_name};
+    std::filesystem::remove_all(dir);
+    configure(program_name, base);
+
+    const auto src = haze::test::allocate_and_h2d_residues(residues_for(base, 0x1100ULL), base);
+    char buf[64];
+    for (void *p : src) {
+        REQUIRE(hazeInputGroupName(p, buf, sizeof buf) == HAZE_SUCCESS);
+        REQUIRE(std::string(buf) == "haze_mrp_in_0");
+    }
+    const auto dst1 = haze::test::allocate_dst_residues(base.size(), kBytes);
+    REQUIRE(hazeAddMrp(dst1.data(), haze::test::to_const(src).data(),
+                       haze::test::to_const(src).data(), base.data(), base.size(),
+                       nullptr) == HAZE_SUCCESS);
+
+    const auto second = residues_for(base, 0x1200ULL);
+    std::vector<const void *> hosts(base.size(), nullptr);
+    for (std::size_t i = 0; i < base.size(); ++i)
+        hosts[i] = second[i].data();
+    REQUIRE(hazeMemcpyMrp(src.data(), hosts.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE, base.data(),
+                          base.size()) == HAZE_SUCCESS);
+    for (void *p : src) {
+        REQUIRE(hazeInputGroupName(p, buf, sizeof buf) == HAZE_SUCCESS);
+        REQUIRE(std::string(buf) == "haze_mrp_in_1");
+    }
+
+    const auto dst2 = haze::test::allocate_dst_residues(base.size(), kBytes);
+    REQUIRE(hazeAddMrp(dst2.data(), haze::test::to_const(src).data(),
+                       haze::test::to_const(src).data(), base.data(), base.size(),
+                       nullptr) == HAZE_SUCCESS);
+    for (void *out : dst1)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    for (void *out : dst2)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    REQUIRE(hazeWriteProgram() == HAZE_SUCCESS);
+
+    const auto entries = read_manifest(dir, program_name);
+    REQUIRE(count_prefixed(entries, "haze_mrp_in_") == 2);
+
+    haze::test::free_all_residues(src);
+    haze::test::free_all_residues(dst1);
+    haze::test::free_all_residues(dst2);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("hazeInputGroupName answers SOURCE_UNAVAILABLE once the address is freed or memset",
+          "[integration]") {
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    configure("haze_input_group_name_freed", base);
+    const auto src = haze::test::allocate_and_h2d_residues(residues_for(base, 0x1300ULL), base);
+    char buf[64];
+    REQUIRE(hazeInputGroupName(src[0], buf, sizeof buf) == HAZE_SUCCESS);
+
+    REQUIRE(hazeMemset(src[0], 0, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeInputGroupName(src[0], buf, sizeof buf) == HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+    // The other residue's binding is untouched by src[0]'s memset.
+    REQUIRE(hazeInputGroupName(src[1], buf, sizeof buf) == HAZE_SUCCESS);
+
+    REQUIRE(hazeFree(src[1]) == HAZE_SUCCESS);
+    REQUIRE(hazeInputGroupName(src[1], buf, sizeof buf) == HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+
+    REQUIRE(hazeFree(src[0]) == HAZE_SUCCESS);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeInputGroupName answers SOURCE_UNAVAILABLE after a real finalize", "[integration]") {
+    const std::vector<uint64_t> base = {kQ0, kQ1, kQ2};
+    const std::string program_name = "haze_input_group_name_finalize";
+    const std::filesystem::path dir{program_name};
+    std::filesystem::remove_all(dir);
+    configure(program_name, base);
+    const auto src = haze::test::allocate_and_h2d_residues(residues_for(base, 0x1400ULL), base);
+    char buf[64];
+    REQUIRE(hazeInputGroupName(src[0], buf, sizeof buf) == HAZE_SUCCESS);
+
+    const auto dst = haze::test::allocate_dst_residues(base.size(), kBytes);
+    REQUIRE(hazeAddMrp(dst.data(), haze::test::to_const(src).data(),
+                       haze::test::to_const(src).data(), base.data(), base.size(),
+                       nullptr) == HAZE_SUCCESS);
+    for (void *out : dst)
+        REQUIRE(hazeTagOutput(out) == HAZE_SUCCESS);
+    // A real finalize: something was tagged, so clear_state_locked wipes the epoch.
+    REQUIRE(hazeWriteProgram() == HAZE_SUCCESS);
+
+    REQUIRE(hazeInputGroupName(src[0], buf, sizeof buf) == HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+
+    haze::test::free_all_residues(src);
+    haze::test::free_all_residues(dst);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+    std::filesystem::remove_all(dir);
+}
+
+TEST_CASE("hazeInputGroupName still answers after a true no-op write_program", "[integration]") {
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    configure("haze_input_group_name_noop_finalize", base);
+    const auto src = haze::test::allocate_and_h2d_residues(residues_for(base, 0x1500ULL), base);
+    char buf[64];
+    REQUIRE(hazeInputGroupName(src[0], buf, sizeof buf) == HAZE_SUCCESS);
+    REQUIRE(std::string(buf) == "haze_mrp_in_0");
+
+    // Nothing tagged: finalize_locked's true-no-op path leaves recording and
+    // bindings intact, so the epoch this name belongs to survives.
+    REQUIRE(hazeWriteProgram() == HAZE_SUCCESS);
+
+    REQUIRE(hazeInputGroupName(src[0], buf, sizeof buf) == HAZE_SUCCESS);
+    REQUIRE(std::string(buf) == "haze_mrp_in_0");
+
+    haze::test::free_all_residues(src);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeInputGroupName drops the name once a plain hazeMemcpy(H2D) re-writes "
+          "an MRP-uploaded address",
+          "[integration]") {
+    // The address is now governed by a fresh, unnamed haze_in_<n> entry, not the earlier
+    // MRP group: the query index must stop answering the stale name for it.
+    const std::vector<uint64_t> base = {kQ0, kQ1};
+    configure("haze_input_group_name_plain_h2d_forgets", base);
+    const auto src = haze::test::allocate_and_h2d_residues(residues_for(base, 0x1700ULL), base);
+    char buf[64];
+    REQUIRE(hazeInputGroupName(src[0], buf, sizeof buf) == HAZE_SUCCESS);
+    REQUIRE(hazeInputGroupName(src[1], buf, sizeof buf) == HAZE_SUCCESS);
+
+    const auto plain = residues_for({kQ0}, 0x1800ULL).front();
+    REQUIRE(hazeMemcpy(src[0], plain.data(), kBytes, HAZE_MEMCPY_HOST_TO_DEVICE) == HAZE_SUCCESS);
+
+    REQUIRE(hazeInputGroupName(src[0], buf, sizeof buf) == HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+    // The untouched sibling residue still answers the original MRP group name.
+    REQUIRE(hazeInputGroupName(src[1], buf, sizeof buf) == HAZE_SUCCESS);
+    REQUIRE(std::string(buf) == "haze_mrp_in_0");
+
+    haze::test::free_all_residues(src);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeInputGroupName never answers for an output-only address", "[integration]") {
+    // A compute result's destination address was never uploaded, so it never entered
+    // the query index in the first place - distinct from forget_input_group, which
+    // only fires for an address that WAS an upload.
+    const std::vector<uint64_t> base = {kQ0};
+    configure("haze_input_group_name_output_only", base);
+    const auto src = haze::test::allocate_and_h2d_residues(residues_for(base, 0x1900ULL));
+    void *dst = nullptr;
+    REQUIRE(hazeMalloc(&dst, kBytes) == HAZE_SUCCESS);
+    REQUIRE(hazeAdd(dst, src[0], src[0], 0, nullptr) == HAZE_SUCCESS);
+
+    char buf[64];
+    REQUIRE(hazeInputGroupName(dst, buf, sizeof buf) == HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+
+    haze::test::free_all_residues(src);
+    REQUIRE(hazeFree(dst) == HAZE_SUCCESS);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeInputGroupName refuses a buffer too short, leaving it untouched", "[integration]") {
+    // "haze_mrp_in_0" is 13 chars; the exact fit is 14 bytes (name + NUL). A
+    // size()+1 > out_len check alone would let out_len == 13 through and write
+    // one byte past a 13-byte buffer, so this pins the boundary on both sides.
+    const std::vector<uint64_t> base = {kQ0};
+    configure("haze_input_group_name_short_buffer", base);
+    const auto src = haze::test::allocate_and_h2d_residues(residues_for(base, 0x1600ULL), base);
+
+    char buf[16];
+    std::memset(buf, 0x7E, sizeof buf); // sentinel: must survive a rejected call untouched
+
+    REQUIRE(hazeInputGroupName(src[0], buf, 3) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    for (char c : buf)
+        REQUIRE(c == 0x7E);
+
+    // One byte short of the exact fit: still refused, still untouched.
+    REQUIRE(hazeInputGroupName(src[0], buf, 13) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    for (char c : buf)
+        REQUIRE(c == 0x7E);
+
+    // The exact fit succeeds and writes exactly name.size() + 1 bytes.
+    REQUIRE(hazeInputGroupName(src[0], buf, 14) == HAZE_SUCCESS);
+    REQUIRE(std::string(buf) == "haze_mrp_in_0");
+    REQUIRE(buf[13] == '\0');
+    REQUIRE(buf[14] == 0x7E);
+    REQUIRE(buf[15] == 0x7E);
+
+    haze::test::free_all_residues(src);
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}
+
+TEST_CASE("hazeInputGroupName rejects NULL/zero arguments", "[integration]") {
+    char buf[64];
+    void *const ptr = reinterpret_cast<void *>(0x1000);
+
+    REQUIRE(hazeInputGroupName(nullptr, buf, sizeof buf) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    REQUIRE(hazeInputGroupName(ptr, nullptr, sizeof buf) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
+    REQUIRE(hazeInputGroupName(ptr, buf, 0) == HAZE_ERROR_INVALID_VALUE);
+    hazeGetLastError();
 }

--- a/test/test_mrp_registry.cpp
+++ b/test/test_mrp_registry.cpp
@@ -57,6 +57,49 @@ TEST_CASE("registry: every input group name is fresh", "[unit]") {
     REQUIRE(reg.next_input_group_name() == "haze_mrp_in_0");
 }
 
+TEST_CASE("registry: record_input_group binds every addr of an upload to its name", "[unit]") {
+    MrpGroupRegistry reg;
+    const auto a = addrs({1, 2, 3});
+    reg.record_input_group(a, "haze_mrp_in_0");
+    for (DevAddr d : a) {
+        const auto *name = reg.input_group_name(d);
+        REQUIRE(name != nullptr);
+        REQUIRE(*name == "haze_mrp_in_0");
+    }
+    REQUIRE(reg.input_group_name(addr(4)) == nullptr);
+}
+
+TEST_CASE("registry: re-recording the same addrs is last-write-wins", "[unit]") {
+    MrpGroupRegistry reg;
+    const auto a = addrs({1, 2, 3});
+    reg.record_input_group(a, "haze_mrp_in_0");
+    reg.record_input_group(a, "haze_mrp_in_1");
+    for (DevAddr d : a) {
+        const auto *name = reg.input_group_name(d);
+        REQUIRE(name != nullptr);
+        REQUIRE(*name == "haze_mrp_in_1");
+    }
+}
+
+TEST_CASE("registry: invalidate drops only the touched addr's input group name", "[unit]") {
+    MrpGroupRegistry reg;
+    const auto a = addrs({1, 2, 3});
+    reg.record_input_group(a, "haze_mrp_in_0");
+    reg.invalidate(addr(2));
+    REQUIRE(reg.input_group_name(addr(2)) == nullptr);
+    REQUIRE(*reg.input_group_name(addr(1)) == "haze_mrp_in_0");
+    REQUIRE(*reg.input_group_name(addr(3)) == "haze_mrp_in_0");
+}
+
+TEST_CASE("registry: clear drops every input group name", "[unit]") {
+    MrpGroupRegistry reg;
+    const auto a = addrs({1, 2, 3});
+    reg.record_input_group(a, "haze_mrp_in_0");
+    reg.clear();
+    for (DevAddr d : a)
+        REQUIRE(reg.input_group_name(d) == nullptr);
+}
+
 TEST_CASE("registry: addr/moduli length mismatch is rejected", "[unit]") {
     MrpGroupRegistry reg;
     const auto a = addrs({1, 2});


### PR DESCRIPTION
Add a per-addr query index over minted MRP input group names, recorded at the tag commit point, erased on invalidate and clear. 

Add a read-only hazeInputGroupName C API for harnesses that need the name to build replay substitution plans by identity instead of content search. 

A plain hazeMemcpy(H2D) over a previously MRP-uploaded address also forgets that entry, since a fresh, unnamed upload now governs the bytes.