### PR TITLE
fix(api): harden hazeInputGroupName buffer check

### DIFF
--- a/src/api/memory.cpp
+++ b/src/api/memory.cpp
@@ -187,7 +187,8 @@ extern "C" hazeError_t hazeInputGroupName(const void *ptr, char *out, size_t out
     if (!result)
         return set_error(haze::to_public_error(result.error()));
     // No truncation: a buffer too short to hold the name plus its NUL is rejected outright.
-    if (result->size() + 1 > out_len)
+    // >= keeps the same bound as size()+1 > out_len without the wrap at SIZE_MAX.
+    if (result->size() >= out_len)
         return set_error(HAZE_ERROR_INVALID_VALUE);
     std::memcpy(out, result->data(), result->size());
     out[result->size()] = '\0';

--- a/test/test_input_entries.cpp
+++ b/test/test_input_entries.cpp
@@ -1276,3 +1276,15 @@ TEST_CASE("hazeInputGroupName rejects NULL/zero arguments", "[integration]") {
     REQUIRE(hazeInputGroupName(ptr, buf, 0) == HAZE_ERROR_INVALID_VALUE);
     hazeGetLastError();
 }
+
+TEST_CASE("hazeInputGroupName answers SOURCE_UNAVAILABLE for an unregistered pointer",
+          "[integration]") {
+    configure("input_group_name_unregistered", {kQ0});
+    // Non-null, well-formed arguments, but the address was never uploaded this epoch: the
+    // query index misses, exactly as for a freed or finalized address.
+    char buf[64];
+    void *const never_uploaded = reinterpret_cast<void *>(0x1000);
+    REQUIRE(hazeInputGroupName(never_uploaded, buf, sizeof buf) == HAZE_ERROR_SOURCE_UNAVAILABLE);
+    hazeGetLastError();
+    REQUIRE(hazeDeviceReset() == HAZE_SUCCESS);
+}


### PR DESCRIPTION
Use size() >= out_len so the fit check cannot wrap at SIZE_MAX, and pin the unregistered-pointer contract (SOURCE_UNAVAILABLE) with a test.